### PR TITLE
extract: Remove circuit_extract and greedy_cut_extract from __all__

### DIFF
--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -17,7 +17,7 @@
 
 from __future__ import print_function
 
-__all__ = ['circuit_extract', 'clifford_extract', 'greedy_cut_extract', 'streaming_extract']
+__all__ = ['clifford_extract', 'streaming_extract']
 
 from fractions import Fraction
 import itertools


### PR DESCRIPTION
If the removed functions are still kept in `__all__`, the `import *` statements fail, i.e.:

```
tests/long_test.py:27: in <module>
    from pyzx.extract import *
E   AttributeError: module 'pyzx.extract' has no attribute 'greedy_cut_extract'
```