### PR TITLE
fix issue with parsing <float>*pi type expressions

### DIFF
--- a/pyzx/circuit.py
+++ b/pyzx/circuit.py
@@ -756,8 +756,8 @@ class QASMParser(object):
                     phase = float(val)/math.pi
                 except ValueError:
                     if not val.find('pi'): raise TypeError("Invalid specification {}".format(name))
-                    val.replace('pi', '')
-                    val.replace('*','')
+                    val = val.replace('pi', '')
+                    val = val.replace('*','')
                     try: phase = float(val)
                     except: raise TypeError("Invalid specification {}".format(name))
                 phase = Fraction(phase).limit_denominator(100000000)

--- a/pyzx/circuit.py
+++ b/pyzx/circuit.py
@@ -755,7 +755,7 @@ class QASMParser(object):
                 try:
                     phase = float(val)/math.pi
                 except ValueError:
-                    if not val.find('pi'): raise TypeError("Invalid specification {}".format(name))
+                    if val.find('pi') == -1: raise TypeError("Invalid specification {}".format(name))
                     val = val.replace('pi', '')
                     val = val.replace('*','')
                     try: phase = float(val)


### PR DESCRIPTION
This fixes parsing qasm expressions like `rz(0.75*pi)` that currently fails with 


```
ValueError: could not convert string to float: '0.75*pi'
```