### PR TITLE
load qasm bug fix

### DIFF
--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -20,7 +20,7 @@ import math
 from fractions import Fraction
 
 from . import Circuit
-from .gates import qasm_gate_table
+from .gates import qasm_gate_table, ZPhase, XPhase
 
 class QASMParser(object):
     """Class for parsing QASM source files into circuit descriptions."""


### PR DESCRIPTION
Requires ZPhase and XPhase to load Circuit from QASM file. Otherwise, throws:
`NameError: name 'ZPhase' is not defined`

If you are open to PRs in general there are some others I can submit in future.