### PR TITLE
Ignore failing test case when numpy is not installed

### DIFF
--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -194,6 +194,7 @@ class TestGraphCircuitMethods(unittest.TestCase):
         g.compose(g)
         self.assertEqual((len(g.inputs),len(g.outputs)),(2,2))
 
+    @unittest.skipUnless(np, "numpy needs to be installed for this to run")
     def test_compose_unitary(self):
         g = self.graph
         g.set_edge_type(g.edge(self.v,self.o1),2)


### PR DESCRIPTION
The function `compare_tensors` is not imported in `test_graph.py` if numpy is not installed.

A test case that depends on it did not have the `skipUnless` decorator, and was causing a `NameError` when running the test suite without having numpy. There are other tests that already use this guard.