### PR TITLE
Fix import error in routing.parity_maps

### DIFF
--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -20,7 +20,7 @@ import sys
 if __name__ == '__main__':
     sys.path.append('..')
 from pyzx.generate import cnots as generate_cnots
-from pyzx.circuit import Circuit, gate_types
+from pyzx.circuit import Circuit, gates
 from pyzx.linalg import Mat2
 
 import numpy as np
@@ -64,7 +64,7 @@ class CNOT_tracker(Circuit):
             circuit.add_gate("ZPhase", 2, phase=Fraction(3,4)) # Adds a ZPhase gate on qubit 2 with phase 3/4
         """
         if isinstance(gate, str):
-            gate_class = gate_types[gate]
+            gate_class = gates.gate_types[gate]
             gate = gate_class(*args, **kwargs)
         self.gates.insert(0, gate)
 


### PR DESCRIPTION
Running `python -m pyzx` threw an ImportError:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "[..]/pyzx/pyzx/__main__.py", line 35, in <module>
    from .scripts import cnot_mapper
  File "[..]/pyzx/pyzx/scripts/cnot_mapper.py", line 37, in <module>
    from ..routing.parity_maps import CNOT_tracker
  File "[..]/pyzx/pyzx/routing/parity_maps.py", line 23, in <module>
    from pyzx.circuit import Circuit, gate_types
ImportError: cannot import name 'gate_types' from 'pyzx.circuit' ([..]/pyzx/pyzx/circuit/__init__.py)
```

It seems the definition for `gates_types` is nested inside the submodule `gates`.
This PR fixes the error.