### PR TITLE
Add missing sub-modules to the installer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
         "pyzx",
         "pyzx.circuit",
         "pyzx.graph",
-        "pyzx.routting",
+        "pyzx.routing",
         "pyzx.scripts"
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,11 @@ setup(
     url="https://github.com/Quantomatic/pyzx.git",
     description="Python library for quantum circuit rewriting and optimisation using the ZX-calculus",
     packages=[
-        "pyzx"
+        "pyzx",
+        "pyzx.circuit",
+        "pyzx.graph",
+        "pyzx.routting",
+        "pyzx.scripts"
     ],
     install_requires=[
         "numpy >= 1.14",


### PR DESCRIPTION
After installing `pyzx` via `pip` my `jupyter` notebook couldn't find the sub-modules.
This PR should fix that.