### PR TITLE
Bialgebra rule fix

### DIFF
--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -91,7 +91,8 @@ def match_bialg_parallel(g, matchf=None, num=-1):
         v1t = types[v1]
         v0p = phases[v0]
         v1p = phases[v1]
-        if ((v0t == VertexType.Z and v1t == VertexType.X) or (v0t == VertexType.X and v1t == VertexType.Z)):
+        if (v0p == 0 and v1p == 0 and
+        ((v0t == VertexType.Z and v1t == VertexType.X) or (v0t == VertexType.X and v1t == VertexType.Z))):
             v0n = [n for n in g.neighbours(v0) if not n == v1]
             v1n = [n for n in g.neighbours(v1) if not n == v0]
             if (

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -61,19 +61,7 @@ def apply_rule(g, rewrite, m, check_isolated_vertices=True):
 
 def match_bialg(g):
     """Does the same as :func:`match_bialg_parallel` but with ``num=1``."""
-    types = g.types()
-    for e in g.edges():
-        v0, v1 = g.edge_st(e)
-        v0t = types[v0]
-        v1t = types[v1]
-        if (v0t == VertexType.Z and v1t == VertexType.X) or (v0t == VertexType.X and v1t == VertexType.Z):
-            v0n = [n for n in g.neighbours(v0) if not n == v1]
-            v1n = [n for n in g.neighbours(v1) if not n == v0]
-            if (
-                all([types[n] == v1t for n in v0n]) and
-                all([types[n] == v0t for n in v1n])):
-                return [[v0,v1,v0n,v1n]]
-    return []
+    return match_bialg_parallel(g, num=1)
 
 
 #TODO: make it be hadamard edge aware

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -80,6 +80,7 @@ def match_bialg_parallel(g, matchf=None, num=-1):
     """
     if matchf != None: candidates = set([e for e in g.edges() if matchf(e)])
     else: candidates = g.edge_set()
+    phases = g.phases()
     types = g.types()
     
     i = 0
@@ -88,12 +89,14 @@ def match_bialg_parallel(g, matchf=None, num=-1):
         v0, v1 = g.edge_st(candidates.pop())
         v0t = types[v0]
         v1t = types[v1]
+        v0p = phases[v0]
+        v1p = phases[v1]
         if ((v0t == VertexType.Z and v1t == VertexType.X) or (v0t == VertexType.X and v1t == VertexType.Z)):
             v0n = [n for n in g.neighbours(v0) if not n == v1]
             v1n = [n for n in g.neighbours(v1) if not n == v0]
             if (
-                all([types[n] == v1t for n in v0n]) and
-                all([types[n] == v0t for n in v1n])):
+                all([types[n] == v1t and phases[n] == 0 for n in v0n]) and
+                all([types[n] == v0t and phases[n] == 0 for n in v1n])):
                 i += 1
                 for v in v0n:
                     for c in g.incident_edges(v): candidates.discard(c)


### PR DESCRIPTION
Currently the bialgebra rule is matched without checking node phases.
This PR fixes both `match_bialg` and `match_bialg` by making `match_bialg` invoke 
`match_bialg_parallel` with `num=1`.

![bialgebra_rule_issue](https://user-images.githubusercontent.com/13847804/80115225-12414c00-85b7-11ea-9334-01d0e6d88eb4.png)

Credit to @sg495 for providing an illustration as to why the optimisation fails with non-zero phases.