### PR TITLE
Add github action with mypy and unittest

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,35 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install mypy
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: mypy
+      run: |
+        mypy pyzx/
+    - name: Test with unittest
+      run: |
+        sh runtests.sh


### PR DESCRIPTION
Enables some CI jobs using Github Actions, as discussed in #32.
Based on Github's model for [python packages](https://github.com/actions/starter-workflows/blob/master/ci/python-package.yml).

It runs mypy and the unit tests on python 3.6, 3.7, and 3.8
It does not run a linter (flake8 in the example) since it would fail on most files.