### PR TITLE
Add lookahead extraction

### DIFF
--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -444,7 +444,6 @@ class Circuit(object):
             else:
                 other += 1
         d = dict()
-        d["name"] = self.name
         d["qubits"] = self.qubits
         d["gates"] = total
         d["tcount"] = tcount

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -1362,7 +1362,7 @@ def get_optimize_value(c: Circuit, optimize_for_depth: bool, expand_to_basic: bo
             if isinstance(gate, (CNOT, CZ)):
                 d += 1
         return d
-    return Circuit.depth_of_circ(c.qubits, c.gates)
+    return c.depth()
 
 
 def cnots_to_xor_list(cnots: list[CNOT], size: int) -> list[set[int]]:

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -1164,24 +1164,27 @@ class RootPicker:
         """
         Pick the roots that correspond to the best k leaves added
 
-        The type needs Optional to match the type in `lookahead_extract_base`
+        The type needs Optional to match the type in `lookahead_extract_base`, which allows nodes to be removed from
+        the list early.
         """
         if len(self.nodes) == 0:
             return []
         s = set()
         for p in self.best:
             s.add(p[2])
-        nodes = []
+        nodes: List[Optional[LookaheadNode]] = []
         for i in s:
-            if self.nodes[i] is None:
+            entry = self.nodes[i]
+            if entry is None:
                 # Does not happen, needed for type checking
                 raise AssertionError("RootPicker removed a root that was still needed")
-            n = self.nodes[i][0]
-            if self.nodes[i][1] is not None:
-                n.c = self.nodes[i][1] + n.c
-                if n.d != -1:
-                    n.d = self.nodes[i][2] + n.d
-            nodes.append(n)
+            else:
+                n = entry[0]
+                if entry[1] is not None:
+                    n.c = entry[1] + n.c
+                    if n.d != -1:
+                        n.d = entry[2] + n.d
+                nodes.append(n)
         return nodes
 
 

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -1299,7 +1299,7 @@ def lookahead_fast(g: BaseGraph[VT, ET], optimize_for_depth: bool = False, up_to
     """
     A lookahead extraction with relatively fast results. For details see :func:`lookahead_extract_base`
     """
-    c = lookahead_extract_base(g, 4 * g.qubit_count(), 8, 0, 4, -1, [0, 2], optimize_for_depth, False, up_to_perm)
+    c = lookahead_extract_base(g, 4 * g.qubit_count(), 8, 5, 4, -1, [0, 1], optimize_for_depth, False, up_to_perm)
     if c is None:
         raise AssertionError("Lookahead extraction with no hard limit returned None")
     return c
@@ -1309,10 +1309,16 @@ def lookahead_extract(g: BaseGraph[VT, ET], optimize_for_depth: bool = False, up
     """
         A lookahead extraction with recommended parameters. For details see :func:`lookahead_extract_base`
     """
-    c = lookahead_extract_base(g, 3 * g.qubit_count(), 7, int(g.qubit_count() / 2), 4, -1,
-                               [0, 1, 3], optimize_for_depth, True, up_to_perm)
+    qubits = g.qubit_count()
+    c = lookahead_extract_base(g.clone(), 4 * qubits, 8, 0, 4, -1, [0, 1], optimize_for_depth, True, up_to_perm)
     if c is None:
         raise AssertionError("Lookahead extraction with no hard limit returned None")
+    d = get_optimize_value(c, optimize_for_depth, True)
+    c1 = lookahead_extract_base(g, 4 * qubits, 8, 5, 4, d, [0, 3], optimize_for_depth, False, up_to_perm)
+    if c1 is not None:
+        d1 = get_optimize_value(c1, optimize_for_depth, True)
+        if d1 < d:
+            c = c1
     return c
 
 
@@ -1333,13 +1339,13 @@ def lookahead_full(g: BaseGraph[VT, ET], optimize_for_depth: bool = False, up_to
         if d1 < d:
             c = c1
             d = d1
-    c1 = lookahead_extract_base(g.clone(), 4 * qubits, 8, 0, 4, d, [0, 2], optimize_for_depth, False, up_to_perm)
+    c1 = lookahead_extract_base(g.clone(), 4 * qubits, 8, 5, 4, d, [0, 2], optimize_for_depth, False, up_to_perm)
     if c1 is not None:
         d1 = get_optimize_value(c1, optimize_for_depth, True)
         if d1 < d:
             c = c1
             d = d1
-    c1 = lookahead_extract_base(g, 4 * qubits, 8, 0, 4, d, [0, 3], optimize_for_depth, False, up_to_perm)
+    c1 = lookahead_extract_base(g, 4 * qubits, 8, 5, 4, d, [0, 3], optimize_for_depth, False, up_to_perm)
     if c1 is not None:
         d1 = get_optimize_value(c1, optimize_for_depth, True)
         if d1 < d:

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -173,6 +173,14 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns a new graph equal to the adjoint of this graph."""
         return self.copy(adjoint=True)
 
+    def clone(self) -> 'BaseGraph':
+        """
+        This method should return an identical copy of the graph, without any relabeling
+
+        Used in lookahead extraction.
+        """
+        return self.copy()
+
     def map_qubits(self, qubit_map:Mapping[int,Tuple[float,float]]) -> None:
         for v in self.vertices():
             q = self.qubit(v)

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -41,6 +41,28 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
 
         self._vdata: Dict[int,Any]                      = dict()
         
+    def clone(self):
+        cpy = GraphS()
+        for v, d in self.graph.items():
+            cpy.graph[v] = d.copy()
+        cpy._vindex = self._vindex
+        cpy.nedges = self.nedges
+        cpy.ty = self.ty.copy()
+        cpy._phase = self._phase.copy()
+        cpy._qindex = self._qindex.copy()
+        cpy._maxq = self._maxq
+        cpy._rindex = self._rindex.copy()
+        cpy._maxr = self._maxr
+        cpy._vdata = self._vdata.copy()
+        cpy.scalar = self.scalar.copy()
+        cpy.inputs = self.inputs.copy()
+        cpy.outputs = self.outputs.copy()
+        cpy.track_phases = self.track_phases
+        cpy.phase_index = self.phase_index.copy()
+        cpy.phase_master = self.phase_master
+        cpy.phase_mult = self.phase_mult.copy()
+        cpy.max_phase_index = self.max_phase_index
+        return cpy
 
     def vindex(self): return self._vindex
     def depth(self): 

--- a/pyzx/linalg.py
+++ b/pyzx/linalg.py
@@ -338,12 +338,15 @@ class Mat2(object):
             vectors.append(v)
         return vectors
 
-    def to_cnots(self, optimize:bool=False) -> List[CNOT]:
+    def to_cnots(self, optimize: bool = False, use_log_blocksize: bool = False) -> List[CNOT]:
         """Returns a list of CNOTs that implements the matrix as a reversible circuit of qubits."""
         cn: Optional[CNOTMaker]
         if not optimize:
             cn = CNOTMaker()
-            self.copy().gauss(full_reduce=True,x=cn, blocksize=5)
+            blocksize = 5
+            if use_log_blocksize:
+                blocksize = int(math.log2(self.rows()))
+            self.copy().gauss(full_reduce=True,x=cn, blocksize=blocksize)
         else:
             best = 1000000
             best_cn = None


### PR DESCRIPTION
The lookahead extraction has a main function called `lookahead_extract_base` and 3 predefined functions that offer good parametrizations for the base one: `lookahead_fast`, `lookahead_extract`, `lookahead_full`. 

Changes to the existing code include splitting the existing extraction into smaller pieces and reusing them where needed, a function for identical copies for `GraphS`, and a function in `Circuit` that computes the depth of a circuit.

An additional change that I found very useful in testing, but is not needed in the extraction, is a function in `Circuit` that returns a dictionary of the different parameters for a circuit. It is similar to `Circuit.stats()`, but the dictionary allows for different values to be compared between circuits, while the string output only allowed printing.