### PR TITLE
Various small fixes

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -56,7 +56,7 @@ class CircuitComparer:
         t = time.time()
         self.extracts = True
         try:
-            c2 = zx.extract.streaming_extract(g,quiet=True)
+            c2 = zx.extract.extract_circuit(g,quiet=True)
             self.time_extr = time.time() - t
         except Exception:
             self.extracts = False

--- a/pyzx/editor.py
+++ b/pyzx/editor.py
@@ -204,7 +204,7 @@ class ZXEditorWidget(widgets.DOMWidget):
 			self.scalar_view.value = "Scalar: " + s
 		if not self.show_matrix: return
 		try:
-			self.graph.auto_detect_inputs()
+			self.graph.auto_detect_io()
 		except TypeError:
 			self.matrix_view.value = "Couldn't parse inputs or outputs"
 			return

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -107,8 +107,8 @@ def column_optimal_swap(m: Mat2) -> Dict[int,int]:
     return target
 
 def _find_targets(
-        conn: Dict[int,Set[int]], 
-        connr: Dict[int,Set[int]], 
+        conn: Dict[int,Set[int]],
+        connr: Dict[int,Set[int]],
         target:Dict[int,int]={}
         ) -> Optional[Dict[int,int]]:
     """Helper function for :func:`column_optimal_swap`.
@@ -117,10 +117,10 @@ def _find_targets(
     target = target.copy()
     r = len(conn)
     c = len(connr)
-    
+
     claimedcols = set(target.keys())
     claimedrows = set(target.values())
-    
+
     while True:
         min_index = -1
         min_options = set(range(1000))
@@ -499,9 +499,9 @@ def clean_frontier(g: BaseGraph[VT, ET], c: Circuit, frontier: List[VT],
         q = qubit_map[v]
         b = [w for w in g.neighbors(v) if w in outputs][0]
         e = g.edge(v, b)
-        if g.edge_type(e) == 2:  # Hadamard edge
+        if g.edge_type(e) == EdgeType.HADAMARD:
             c.add_gate("HAD", q)
-            g.set_edge_type(e, 1)
+            g.set_edge_type(e, EdgeType.SIMPLE)
         if phases[v]:
             c.add_gate("ZPhase", q, phases[v])
             g.set_phase(v, 0)
@@ -558,11 +558,11 @@ def neighbors_of_frontier(g: BaseGraph[VT, ET], frontier: List[VT]) -> Set[VT]:
             b = [w for w in d if w in inputs][0]
             q = qs[b]
             r = rs[b]
-            w = g.add_vertex(1, q, r + 1)
+            w = g.add_vertex(VertexType.Z, q, r + 1)
             e = g.edge(v, b)
             et = g.edge_type(e)
             g.remove_edge(e)
-            g.add_edge(g.edge(v, w), 2)
+            g.add_edge(g.edge(v, w), EdgeType.HADAMARD)
             g.add_edge(g.edge(w, b), toggle_edge(et))
             d.remove(b)
             d.append(w)
@@ -617,7 +617,7 @@ def extract_circuit(
         if g.vertex_degree(v) == 1 and v not in inputs and v not in outputs:
             n = list(g.neighbors(v))[0]
             gadgets[n] = v
-    
+
     qubit_map: Dict[VT,int] = dict()
     frontier = []
     for i, o in enumerate(outputs):
@@ -626,7 +626,7 @@ def extract_circuit(
             continue
         frontier.append(v)
         qubit_map[v] = i
-        
+
     czs_saved = 0
     q: Union[float, int]
     
@@ -783,7 +783,7 @@ def graph_to_swaps(g: BaseGraph[VT, ET], no_swaps: bool = False) -> Circuit:
         if inp not in inputs: 
             raise TypeError("Algorithm failed: Graph is not fully reduced")
             return c
-        if g.edge_type(g.edge(v,inp)) == 2:
+        if g.edge_type(g.edge(v,inp)) == EdgeType.HADAMARD:
             c.prepend_gate(HAD(q))
             g.set_edge_type(g.edge(v,inp),EdgeType.SIMPLE)
         q2 = inputs.index(inp)
@@ -792,7 +792,6 @@ def graph_to_swaps(g: BaseGraph[VT, ET], no_swaps: bool = False) -> Circuit:
     if not no_swaps and leftover_swaps:
         for t1, t2 in permutation_as_swaps(swap_map):
             c.prepend_gate(SWAP(t1, t2))
-    #c.gates = list(reversed(c.gates))
     return c
 
 

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -130,6 +130,10 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             del self.graph[v]
             del self.ty[v]
             del self._phase[v]
+            if v in self._inputs:
+                self._inputs = tuple(u for u in self._inputs if u != v)
+            if v in self._outputs:
+                self._outputs = tuple(u for u in self._outputs if u != v)
             try: del self._qindex[v]
             except: pass
             try: del self._rindex[v]
@@ -241,7 +245,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     def set_phase(self, vertex, phase):
         self._phase[vertex] = Fraction(phase) % 2
     def add_to_phase(self, vertex, phase):
-        self._phase[vertex] = (self._phase.get(vertex,Fraction(1)) + phase) % 2
+        self._phase[vertex] = (self._phase.get(vertex,Fraction(1)) + Fraction(phase)) % 2
 
     def qubit(self, vertex):
         return self._qindex.get(vertex,-1)

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -79,6 +79,10 @@ def json_to_graph(js: str, backend:Optional[str]=None) -> BaseGraph:
         else:
             g.set_type(v,VertexType.Z)
             g.set_phase(v,Fraction(0,1))
+        for key, value in attr['annotation'].items():
+            if key == 'coord':
+                continue
+            g.set_vdata(v, key, value)
         
         #g.set_vdata(v, 'x', c[0])
         #g.set_vdata(v, 'y', c[1])
@@ -99,6 +103,10 @@ def json_to_graph(js: str, backend:Optional[str]=None) -> BaseGraph:
         if "output" in ann and ann["output"]: outputs.append(v)
         #g.set_vdata(v, 'x', c[0])
         #g.set_vdata(v, 'y', c[1])
+        for key, value in attr['annotation'].items():
+            if key in ('boundary','coord','input','output'):
+                continue
+            g.set_vdata(v, key, value)
 
     g.set_inputs(tuple(inputs))
     g.set_outputs(tuple(outputs))
@@ -168,6 +176,10 @@ def graph_to_json(g: BaseGraph[VT,ET], include_scalar: bool=True) -> str:
         if t == VertexType.BOUNDARY:
             wire_vs[name] = {"annotation":{"boundary":True,"coord":coord,
                                            "input":(v in inputs), "output":(v in outputs)}}
+            for key in g.vdata_keys(v):
+                if key in wire_vs[name]["annotation"]:
+                    continue
+                wire_vs[name]["annotation"][key] = g.vdata(v, key)
         else:
             node_vs[name] = {"annotation": {"coord":coord},"data":{}}
             if t==VertexType.Z:
@@ -181,6 +193,10 @@ def graph_to_json(g: BaseGraph[VT,ET], include_scalar: bool=True) -> str:
             phase = _phase_to_quanto_value(g.phase(v))
             if phase: node_vs[name]["data"]["value"] = phase
             if not node_vs[name]["data"]: del node_vs[name]["data"]
+            for key in g.vdata_keys(v):
+                if key in node_vs[name]["annotation"]:
+                    continue
+                node_vs[name]["annotation"][key] = g.vdata(v, key)
 
     i = 0
     for e in g.edges():


### PR DESCRIPTION
This is a compilation of (mostly) one-line fixes:

- Replace some remaining ints by `VertexType.*` and `EdgeType.*`.
- Replace deprecated uses of `streaming_extract` and `auto_detect_inputs`.
- Pop the vertex from the i/o tuples when removing it.
- Ensure the phases are always of the right type.
- Don't forget the vdata fields when storing/loading from a json.