### PR TITLE
Add support for ground generators in the graphs

### DIFF
--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -19,7 +19,7 @@ from typing import List, Union, Optional, Iterator, Dict
 
 import numpy as np
 
-from .gates import Gate, gate_types, ZPhase, XPhase, CZ, CX, CNOT, HAD, SWAP, CCZ, Tofolli
+from .gates import Gate, gate_types, ZPhase, XPhase, CZ, CX, CNOT, HAD, SWAP, CCZ, Tofolli, Measurement
 
 from ..graph.base import BaseGraph
 
@@ -39,28 +39,28 @@ class Circuit(object):
     The methods in this class that convert a specification of a circuit into an instance of this class,
     generally do not check whether the specification is well-defined. If a bad input is given,
     the behaviour is undefined."""
-    def __init__(self, qubit_amount: int, name: str = '') -> None:
+    def __init__(self, qubit_amount: int, name: str = '', bit_amount: Optional[int] = None) -> None:
         self.qubits: int        = qubit_amount
+        self.bits: int = 0 if bit_amount is None else bit_amount
         self.gates:  List[Gate] = []
         self.name:   str        = name
-
 
     ### BASIC FUNCTIONALITY
 
 
     def __str__(self) -> str:
-        return "Circuit({!s} qubits, {!s} gates)".format(self.qubits,len(self.gates))
+        return "Circuit({!s} qubits, {!s} bits, {!s} gates)".format(self.qubits,self.bits,len(self.gates))
 
     def __repr__(self) -> str:
         return str(self)
 
     def copy(self) -> 'Circuit':
-        c = Circuit(self.qubits, self.name)
+        c = Circuit(self.qubits, self.name, self.bits)
         c.gates = [g.copy() for g in self.gates]
         return c
 
     def adjoint(self) -> 'Circuit':
-        c = Circuit(self.qubits, self.name + 'Adjoint')
+        c = Circuit(self.qubits, self.name + 'Adjoint', self.bits)
         for g in reversed(self.gates):
             c.gates.append(g.to_adjoint())
         return c
@@ -81,6 +81,10 @@ class Circuit(object):
             up_to_swaps: if set to True, only checks equality up to a permutation of the qubits.
 
         """
+        if self.bits or other.bits:
+            # TODO once full_gnd_reduce is merged
+            raise NotImplementedError("The equality verification does not support hybrid circuits.")
+
         from ..simplify import full_reduce
         c = self.adjoint()
         c.add_circuit(other)
@@ -128,11 +132,12 @@ class Circuit(object):
         for g in gates.split(" "):
             self.add_gate(g, qubit)
 
-    def add_circuit(self, circ: 'Circuit', mask: Optional[List[int]]=None) -> None:
+    def add_circuit(self, circ: 'Circuit', mask: Optional[List[int]]=None, bit_mask: Optional[List[int]]=None) -> None:
         """Adds the gate of another circuit to this one. If ``mask`` is not given,
         then they must have the same amount of qubits and they are mapped one-to-one.
         If mask is given then it must be a list specifying to which qubits the qubits
-        in the given circuit correspond.
+        in the given circuit correspond. Similarly, if ``bit_mask`` is not given,
+        then they must have the same amount of bits.
 
         Example::
 
@@ -148,13 +153,23 @@ class Circuit(object):
             c1 += c2
 
         """
-        if not mask:
-            if self.qubits != circ.qubits: raise TypeError("Amount of qubits do not match")
+        if mask is None and bit_mask is None:
+            if self.qubits != circ.qubits:
+                raise TypeError("Amount of qubits do not match")
+            if self.bits != circ.bits:
+                raise TypeError("Amount of bits do not match")
             self.gates.extend([g.copy() for g in circ.gates])
             return
-        elif len(mask) != circ.qubits: raise TypeError("Mask size does not match qubits")
+        if mask is None:
+            mask = list(range(self.qubits))
+        if bit_mask is None:
+            bit_mask = list(range(self.bits))
+        if len(mask) != circ.qubits:
+            raise TypeError("Mask size does not match qubits")
+        if len(bit_mask) != circ.bits:
+            raise TypeError("Bit mask size does not match bits")
         for gate in circ.gates:
-            g = gate.reposition(mask)
+            g = gate.reposition(mask, bit_mask)
             self.add_gate(g)
 
     def tensor(self, other: CircuitLike) -> 'Circuit':
@@ -169,7 +184,8 @@ class Circuit(object):
         c = Circuit(self.qubits + other.qubits)
         c.gates = [g.copy() for g in self.gates]
         mask = [i+self.qubits for i in range(other.qubits)]
-        c.gates.extend([g.reposition(mask) for g in other.gates])
+        bit_mask = [i+self.bits for i in range(other.bits)]
+        c.gates.extend([g.reposition(mask, bit_mask) for g in other.gates])
         return c
 
     def to_basic_gates(self) -> 'Circuit':
@@ -259,7 +275,7 @@ class Circuit(object):
 
     def to_emoji(self) -> str:
         """Converts circuit into a representation that can be copy-pasted
-    	into the ZX-calculus Discord server."""
+        into the ZX-calculus Discord server."""
         from .emojiparser import circuit_to_emoji
         return circuit_to_emoji(self)
 
@@ -412,6 +428,8 @@ class Circuit(object):
         {} 2-qubit gates ({} CNOT, {} other) and
         {} Hadamard gates.""".format(d["name"], d["qubits"], d["gates"],
                 d["tcount"], d["clifford"], d["twoqubit"], d["cnot"], d["twoqubit"] - d["cnot"], d["had"])
+        if d["measurement"] > 0:
+            s += "\nThere are {} measurement gates".format(d["measurement"])
         if d["other"] > 0:
             s += "\nThere are {} gates of a different type".format(d["other"])
         if depth:
@@ -427,6 +445,7 @@ class Circuit(object):
         twoqubit = 0
         hadamard = 0
         clifford = 0
+        measurement = 0
         other = 0
         cnot = 0
         for g in self.gates:
@@ -441,6 +460,8 @@ class Circuit(object):
                 twoqubit += 1
                 clifford += 1
                 if isinstance(g, CNOT): cnot += 1
+            elif isinstance(g, Measurement):
+                measurement += 1
             else:
                 other += 1
         d : Dict[str, Union[str,int]] = dict()
@@ -452,6 +473,7 @@ class Circuit(object):
         d["twoqubit"] = twoqubit
         d["cnot"] = cnot
         d["had"] = hadamard
+        d["measurement"] = measurement
         d["other"] = other
         d["depth"] = 0
         d["depth_cz"] = 0

--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -259,7 +259,8 @@ def draw_d3(
     labels:bool=False, 
     scale:Optional[FloatInt]=None, 
     auto_hbox:Optional[bool]=None,
-    show_scalar:bool=False
+    show_scalar:bool=False,
+    vdata: List[str]=[]
     ) -> Any:
 
     if settings.mode not in ("notebook", "browser"): 
@@ -295,7 +296,11 @@ def draw_d3(
               'x': (g.row(v)-minrow + 1) * scale,
               'y': (g.qubit(v)-minqub + 2) * scale,
               't': g.type(v),
-              'phase': phase_to_s(g.phase(v), g.type(v)) }
+              'phase': phase_to_s(g.phase(v), g.type(v)),
+              'ground': g.is_ground(v),
+              'vdata': [(key, g.vdata(v, key))
+                  for key in vdata if g.vdata(v, key, None) is not None],
+              }
              for v in g.vertices()]
     links = [{'source': str(g.edge_s(e)),
               'target': str(g.edge_t(e)),

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from fractions import Fraction
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Set, Any
 
 from .base import BaseGraph
 
@@ -38,6 +38,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         self._maxq: FloatInt                            = -1
         self._rindex: Dict[int, FloatInt]               = dict()
         self._maxr: FloatInt                            = -1
+        self._grounds: Set[int] = set()
 
         self._vdata: Dict[int,Any]                      = dict()
         self._inputs: Tuple[int, ...]                   = tuple()
@@ -140,6 +141,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             except: pass
             try: del self.phase_index[v]
             except: pass
+            self._grounds.discard(v)
             self._vdata.pop(v,None)
         self._vindex = max(self.vertices(),default=0) + 1
 
@@ -262,6 +264,16 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     def set_row(self, vertex, r):
         if r > self._maxr: self._maxr = r
         self._rindex[vertex] = r
+
+    def is_ground(self, vertex):
+        return vertex in self._grounds
+    def grounds(self):
+        return self._grounds
+    def set_ground(self, vertex, flag=True):
+        if flag:
+            self._grounds.add(vertex)
+        else:
+            self._grounds.discard(vertex)
 
     def vdata_keys(self, vertex):
         return self._vdata.get(vertex, {}).keys()

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -76,6 +76,8 @@ def json_to_graph(js: str, backend:Optional[str]=None) -> BaseGraph:
                 g.set_phase(v,_quanto_value_to_phase(d['value']))
             else:
                 g.set_phase(v,Fraction(0,1))
+            if d.get('ground', False):
+                g.set_ground(v)
         else:
             g.set_type(v,VertexType.Z)
             g.set_phase(v,Fraction(0,1))
@@ -192,6 +194,8 @@ def graph_to_json(g: BaseGraph[VT,ET], include_scalar: bool=True) -> str:
             else: raise Exception("Unkown vertex type "+ str(t))
             phase = _phase_to_quanto_value(g.phase(v))
             if phase: node_vs[name]["data"]["value"] = phase
+            if g.is_ground(v):
+                node_vs[name]["data"]["ground"] = True
             if not node_vs[name]["data"]: del node_vs[name]["data"]
             for key in g.vdata_keys(v):
                 if key in node_vs[name]["annotation"]:

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -104,6 +104,8 @@ def match_bialg_parallel(
     m = []
     while (num == -1 or i < num) and len(candidates) > 0:
         v0, v1 = g.edge_st(candidates.pop())
+        if g.is_ground(v0) or g.is_ground(v1):
+            continue
         v0t = types[v0]
         v1t = types[v1]
         v0p = phases[v0]
@@ -195,7 +197,13 @@ def spider(g: BaseGraph[VT,ET], matches: List[MatchSpiderType[VT]]) -> RewriteOu
         else:
             v0, v1 = m[0], m[1]
 
-        g.add_to_phase(v0, g.phase(v1))
+        ground = g.is_ground(v0) or g.is_ground(v1)
+
+        if ground:
+            g.set_phase(v0, 0)
+            g.set_ground(v0)
+        else:
+            g.add_to_phase(v0, g.phase(v1))
 
         if g.track_phases:
             g.fuse_phases(v0,v1)
@@ -223,21 +231,24 @@ def unspider(g: BaseGraph[VT,ET], m: List[Any], qubit:FloatInt=-1, row:FloatInt=
     Returns the index of the new node. Optional parameters ``qubit`` and ``row`` can be used
     to position the new node. If they are omitted, they are set as the same as the old node.
     """
-    v = g.add_vertex(ty=g.type(m[0]))
-    g.set_qubit(v, qubit if qubit != -1 else g.qubit(m[0]))
-    g.set_row(v, row if row != -1 else g.row(m[0]))
+    u = m[0]
+    v = g.add_vertex(ty=g.type(u))
+    u_is_ground = g.is_ground(u)
+    g.set_qubit(v, qubit if qubit != -1 else g.qubit(u))
+    g.set_row(v, row if row != -1 else g.row(u))
 
-    g.add_edge(g.edge(m[0], v))
+    g.add_edge(g.edge(u, v))
     for n in m[1]:
-        e = g.edge(m[0],n)
+        e = g.edge(u,n)
         g.add_edge(g.edge(v,n), edgetype=g.edge_type(e))
         g.remove_edge(e)
     if len(m) >= 3:
         g.add_to_phase(v, m[2])
-        g.add_to_phase(m[0], Fraction(0) - m[2])
+        if not u_is_ground:
+            g.add_to_phase(u, Fraction(0) - m[2])
     else:
-        g.set_phase(v, g.phase(m[0]))
-        g.set_phase(m[0], 0)
+        g.set_phase(v, g.phase(u))
+        g.set_phase(u, 0)
     return v
 
 MatchPivotType = Tuple[VT,VT,List[VT],List[VT]]
@@ -282,6 +293,8 @@ def match_pivot_parallel(
         v0a = phases[v0]
         v1a = phases[v1]
         if not ((v0a in (0,1)) and (v1a in (0,1))): continue
+        if g.is_ground(v0) or g.is_ground(v1):
+            continue
 
         invalid_edge = False
 
@@ -352,6 +365,9 @@ def match_pivot_gadget(
             else: continue
         elif v1a in (0,1): continue
         # Now v0 has a Pauli phase and v1 has a non-Pauli phase
+
+        if g.is_ground(v0):
+            continue
         
         v0n = list(g.neighbors(v0))
         v1n = list(g.neighbors(v1))
@@ -408,7 +424,8 @@ def match_pivot_boundary(
     inputs = g.inputs()
     while (num == -1 or i < num) and len(candidates) > 0:
         v = candidates.pop()
-        if types[v] != VertexType.Z or phases[v] not in (0,1): continue
+        if types[v] != VertexType.Z or phases[v] not in (0,1) or g.is_ground(v):
+            continue
 
         good_vert = True
         w = None
@@ -421,6 +438,9 @@ def match_pivot_boundary(
                 good_vert = False
                 break
             if n in consumed_vertices:
+                good_vert = False
+                break
+            if g.is_ground(n) in consumed_vertices:
                 good_vert = False
                 break
             boundaries = []
@@ -490,8 +510,10 @@ def pivot(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -> RewriteOutp
               [g.edge(s,t) for s in n[0] for t in n[2]])
         k0, k1, k2 = len(n[0]), len(n[1]), len(n[2])
         g.scalar.add_power(k0*k2 + k1*k2 + k0*k1)
-        
-        for v in n[2]: g.add_to_phase(v, 1)
+
+        for v in n[2]:
+            if not g.is_ground(v):
+                g.add_to_phase(v, 1)
 
         if g.phase(m[0]) and g.phase(m[1]): g.scalar.add_phase(Fraction(1))
         if not m[2] and not m[3]: 
@@ -503,8 +525,13 @@ def pivot(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -> RewriteOutp
         for i in range(2):
             # if m[i] has a phase, it will get copied on to the neighbors of m[1-i]:
             a = g.phase(m[i]) # type: ignore
-            for v in n[1-i]: g.add_to_phase(v, a)
-            for v in n[2]: g.add_to_phase(v, a)
+            if a:
+                for v in n[1-i]:
+                    if not g.is_ground(v):
+                        g.add_to_phase(v, a)
+                for v in n[2]:
+                    if not g.is_ground(v):
+                        g.add_to_phase(v, a)
 
             if not m[i+2]:
                 # if there is no boundary, the other vertex is destroyed
@@ -566,6 +593,9 @@ def match_lcomp_parallel(
         if vt != VertexType.Z: continue
         if not (va == Fraction(1,2) or va == Fraction(3,2)): continue
 
+        if g.is_ground(v):
+            continue
+
         if check_edge_types and not (
             all(g.edge_type(e) == EdgeType.HADAMARD for e in g.incident_edges(v))
             ): continue
@@ -592,7 +622,8 @@ def lcomp(g: BaseGraph[VT,ET], matches: List[MatchLcompType[VT]]) -> RewriteOutp
         n = len(m[1])
         g.scalar.add_power((n-2)*(n-1)//2)
         for i in range(n):
-            g.add_to_phase(m[1][i], -a)
+            if not g.is_ground(m[1][i]):
+                g.add_to_phase(m[1][i], -a)
             for j in range(i+1, n):
                 e = g.edge(m[1][i],m[1][j])
                 he = etab.get(e, [0,0])[1]
@@ -631,10 +662,15 @@ def match_ids_parallel(
 
     while (num == -1 or i < num) and len(candidates) > 0:
         v = candidates.pop()
-        if phases[v] != 0 or not vertex_is_zx(types[v]): continue
+        if phases[v] != 0 or not vertex_is_zx(types[v]) or g.is_ground(v):
+            continue
         neigh = g.neighbors(v)
         if len(neigh) != 2: continue
         v0, v1 = neigh
+        if (g.is_ground(v0) and types[v1] == VertexType.BOUNDARY or
+                g.is_ground(v1) and types[v0] == VertexType.BOUNDARY):
+            # Do not put ground spiders on the boundary
+            continue
         candidates.discard(v0)
         candidates.discard(v1)
         if g.edge_type(g.edge(v,v0)) != g.edge_type(g.edge(v,v1)): #exactly one of them is a hadamard edge
@@ -799,8 +835,10 @@ def match_copy(
     ) -> List[MatchCopyType[VT]]:
     """Finds spiders with a 0 or pi phase that have a single neighbor,
     and copies them through. Assumes that all the spiders are green and maximally fused."""
-    if vertexf is not None: candidates = set([v for v in g.vertices() if vertexf(v)])
-    else: candidates = g.vertex_set()
+    if vertexf is not None:
+        candidates = set([v for v in g.vertices() if vertexf(v)])
+    else:
+        candidates = g.vertex_set()
     phases = g.phases()
     types = g.types()
     m = []

--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -86,6 +86,8 @@ def tensorfy(g: 'BaseGraph[VT,ET]', preserve_scalar:bool=True) -> np.ndarray:
     """Takes in a Graph and outputs a multidimensional numpy array
     representing the linear map the ZX-diagram implements.
     Beware that quantum circuits take exponential memory to represent."""
+    if g.is_hybrid():
+        raise ValueError("Hybrid graphs are not supported.")
     rows = g.rows()
     phases = g.phases()
     types = g.types()

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -71,6 +71,12 @@ def phase_to_s(a: FractionLike, t:VertexType.Type=VertexType.Z):
     # unicode 0x03c0 = pi
     return simstr + ns + '\u03c0' + ds
 
+def phase_is_clifford(phase: FractionLike):
+    return phase in [Fraction(i, 2) for i in range(4)]
+
+def phase_is_pauli(phase: FractionLike):
+    return phase in (0, 1)
+
 tikz_classes = {
     'boundary': 'none',
     'Z': 'Z dot',

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -24,7 +24,8 @@ if __name__ == '__main__':
     sys.path.append('..')
     sys.path.append('.')
 
-from pyzx.graph import Graph, EdgeType, VertexType
+from pyzx.graph import Graph
+from pyzx.utils import EdgeType, VertexType
 from pyzx.generate import identity
 
 import numpy as np
@@ -68,10 +69,15 @@ class TestGraphBasicMethods(unittest.TestCase):
     def test_set_attributes(self):
         g = Graph()
         v = g.add_vertex()
+        self.assertEqual(g.phase(v),0)
         g.set_phase(v,1)
         self.assertEqual(g.phase(v),1)
-        g.set_type(v,2)
-        self.assertEqual(g.type(v),2)
+        self.assertEqual(g.type(v),VertexType.BOUNDARY)
+        g.set_type(v,VertexType.X)
+        self.assertEqual(g.type(v),VertexType.X)
+        self.assertFalse(g.is_ground(v))
+        g.set_ground(v)
+        self.assertTrue(g.is_ground(v))
         g.set_row(v,3)
         self.assertEqual(g.row(v),3)
         g.set_qubit(v,2)


### PR DESCRIPTION
Hi, this is a proposal for adding support for the ground generator (⏚) of the ZX⏚ calculus, to be able to represent partial traces and classical operations. I used this as a basis to implement the optimization routines in my hybrid optimization paper ([arXiv:2109.06071](https://arxiv.org/abs/2109.06071)) which I'll submit in a subsequent PR.

## Implementation

Instead of adding a separate kind of node, the spiders have a new boolean flag signaling if they have a single connected ⏚ (all diagrams can be normalized to this form). This is added directly to `BaseGraph` akin to the API for `row` and `qubit`. It defines the methods [`is_ground`, `set_ground`] for specific vertices and [`grounds`, `is_hybrid`] for the whole graph. They are implemented on `GraphS`.

The rewriting rules in `rules` had to be modified to check for the flag, as they should consider ⏚-spiders as non-Clifford for the rewriting steps regardless of their phase.

The `drawing` module now draws the ground symbols on the nodes, and is able to optionally show vdata fields.

![image](https://user-images.githubusercontent.com/3458997/133260918-5893d890-a147-4868-9c7f-bc1e02899bd8.png)

There is a simple extension of the `cliffordT` circuit generator, `cliffordTmeas`, which can insert measurement gates that ignore their classical result and just collapse the qubit state.

Finally, the `Circuit`s now support bit registers, with their own id separate from the qubits to better match the circuit description languages. These are all transformed into _qubits_ when transformed into a graph, as there is no difference between them in the diagrams. The `Gate.to_graph` methods where reworked a bit to clean them up and to support bit registers.

## Backwards compatibility

The only change in the API is that the `BaseGraph` class now has some ground-related abstract methods, which need to be implemented on new instances.

Algorithms implemented for pure circuit do not need to be changed, although it may be a good idea to check for `g.is_hybrid()` and raise an exception if it is not supported.

The benchmarks do not show any significant difference in performance on the existing tests.

## Alternatives

This could have been implemented as vdata labels on the vertices, but it would not standardize the way of representing grounds and may lead to algorithms mistakenly ignoring them (for example, unknowingly using `compare_tensors` on two hybrid graphs).
Our way let's us include an explicit `Graph.is_hybrid` method.

Another option would be to use a graph wrapper inheriting from `BaseGraph`. It'd be similar to this solution but making an algorithm that works both in pure-quantum and hybrid graphs would be more tedious and inefficient.

## Things not in this PR

- Optimization routines from the paper. I left them out to reduce the noise on an eventual design change.
I have them implemented in a separate submodule, which I'll submit once this PR is merged.

- Classicalization routines. The paper describes an algorithm for detecting wires which carry classical data.
This is implemented using a graph wrapper that adds this information to the edges, so it too would be too noisy for this PR.

- Qasm circuit parsing. The current implementation of the parser is not updated for OPENQASM 3,
so I think it will be better to rewrite it all at once. (`Circuit` *does* support bit registers).

- Interacting with gadget phase teleportation. The ground nodes can be interpreted as gadgets with an absorbing element '⏚' as it's phase. It shouldn't be too hard to add this later, but it was not the main goal of the change.

- Support for ⏚s in the js editor.

- `compare_tensor`, but with CPTP maps.

- Documentation. I'll add it along with the optimization routines.