### PR TITLE
Support representing symbolic graphs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -32,6 +32,3 @@ ignore_missing_imports = True
 
 [mypy-IPython.*]
 ignore_missing_imports = True
-
-[mypy-sympy.*]
-ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,3 +32,6 @@ ignore_missing_imports = True
 
 [mypy-IPython.*]
 ignore_missing_imports = True
+
+[mypy-sympy.*]
+ignore_missing_imports = True

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -191,7 +191,7 @@ class Circuit(object):
     def to_basic_gates(self) -> 'Circuit':
         """Returns a new circuit with every gate expanded in terms of X/Z phases, Hadamards
         and the 2-qubit gates CNOT, CZ, CX."""
-        c = Circuit(self.qubits, name=self.name)
+        c = Circuit(self.qubits, name=self.name, bit_amount=self.bits)
         for g in self.gates:
             c.gates.extend(g.to_basic_gates())
         return c

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -20,6 +20,7 @@ from typing import Tuple, Dict, Set, Any
 from .base import BaseGraph
 
 from ..utils import VertexType, EdgeType, FractionLike, FloatInt
+from sympy import Expr
 
 class GraphS(BaseGraph[int,Tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
@@ -245,10 +246,16 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     def phases(self):
         return self._phase
     def set_phase(self, vertex, phase):
-        self._phase[vertex] = Fraction(phase) % 2
+        if isinstance(phase, Expr):
+            self._phase[vertex] = phase
+        else:
+            self._phase[vertex] = Fraction(phase) % 2
     def add_to_phase(self, vertex, phase):
-        self._phase[vertex] = (self._phase.get(vertex,Fraction(1)) + Fraction(phase)) % 2
-
+        old_phase = self._phase.get(vertex, Fraction(1))
+        if isinstance(phase, Expr) or isinstance(self._phase[vertex], Expr):
+            self._phase[vertex] = old_phase + phase
+        else:
+            self._phase[vertex] = (old_phase + Fraction(phase)) % 2
     def qubit(self, vertex):
         return self._qindex.get(vertex,-1)
     def qubits(self):

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -20,7 +20,6 @@ from typing import Tuple, Dict, Set, Any
 from .base import BaseGraph
 
 from ..utils import VertexType, EdgeType, FractionLike, FloatInt
-from sympy import Expr
 
 class GraphS(BaseGraph[int,Tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
@@ -246,16 +245,16 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     def phases(self):
         return self._phase
     def set_phase(self, vertex, phase):
-        if isinstance(phase, Expr):
-            self._phase[vertex] = phase
-        else:
+        try:
             self._phase[vertex] = Fraction(phase) % 2
+        except Exception:
+            self._phase[vertex] = phase
     def add_to_phase(self, vertex, phase):
         old_phase = self._phase.get(vertex, Fraction(1))
-        if isinstance(phase, Expr) or isinstance(self._phase[vertex], Expr):
-            self._phase[vertex] = old_phase + phase
-        else:
+        try:
             self._phase[vertex] = (old_phase + Fraction(phase)) % 2
+        except Exception:
+            self._phase[vertex] = old_phase + phase
     def qubit(self, vertex):
         return self._qindex.get(vertex,-1)
     def qubits(self):

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -18,9 +18,6 @@ import os
 from fractions import Fraction
 from typing import Union, Optional, List, Dict
 from typing_extensions import Literal, Final
-from sympy import Expr, Symbol
-from sympy.printing.pretty.pretty import PrettyPrinter
-from sympy.printing.pretty.stringpict import prettyForm
 
 
 FloatInt = Union[float,int]
@@ -56,47 +53,13 @@ def toggle_edge(ty: EdgeType.Type) -> EdgeType.Type:
     return EdgeType.HADAMARD if ty == EdgeType.SIMPLE else EdgeType.SIMPLE
 
 
-superscript_map = {
-    k: v for k, v in
-    zip('0123456789ABDEGHIJKLMNOPRTUW⋅()+-',
-        '⁰¹²³⁴⁵⁶⁷⁸⁹ᴬᴮᴰᴱᴳᴴᴵᴶᴷᴸᴹᴺᴼᴾᴿᵀᵁᵂ˙⁽⁾⁺⁻')}
-
-
-class NewPrettyPrinter(PrettyPrinter):
-    def _print_Pow(self, power):
-        s = super()._print_Pow(power)
-        if str(s).count('\n') > 0:
-            if str(s).count('\n') == 1:
-                b, e = power.as_base_exp()
-                e_str = symbolize(e)
-                if all(chr in superscript_map for chr in e_str):
-                    e = ''.join([superscript_map[chr] for chr in e_str])
-                    b_str = symbolize(b)
-                    if not isinstance(b, Symbol):
-                        b_str = '(' + b_str + ')'
-                    return prettyForm(f'{b_str}{e}')
-            return prettyForm(str(power).replace('**', '^'))
-        return s
-
-
-def symbolize(expr):
-    """Reformat a symbolic expression to a string. """
-    pp = NewPrettyPrinter({})
-    s = pp.doprint(expr)
-    if '\n' in s:
-        return str(expr)
-    s = s.replace('⋅', '')
-    return s
-
-
 def phase_to_s(a: FractionLike, t:VertexType.Type=VertexType.Z):
     if (a == 0 and t != VertexType.H_BOX): return ''
     if (a == 1 and t == VertexType.H_BOX): return ''
-
-    if isinstance(a, Expr):
-        return symbolize(a)
-    if not isinstance(a, Fraction):
+    try:
         a = Fraction(a)
+    except Exception:
+        return str(a)
 
     if a == 0: return '0'
     simstr = ''


### PR DESCRIPTION
This is based on the work of Matthew Sutcliffe. For now this only allows the creation and drawing of symbolic graphs. ~~By using sympy's pretty print features, this `symbolize` function should be more robust.~~ Now the code just converts the symbolic expression to string, which should still look fine.


```python
import pyzx as zx
from sympy import symbols

circ = zx.Circuit(3)
syms = symbols('α β γ')
for i, sym in enumerate(syms):
    circ.add_gate('XPhase', i, -(i + 1) * sym ** (i + 2) + 1)
zx.draw(circ.to_graph())
```

<img width="147" alt="image" src="https://user-images.githubusercontent.com/13847804/187887968-fea95d6f-1813-4627-9ee0-7901f03925f5.png">


