### PR TITLE
Fix `to_graph()`

### DIFF
--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -191,7 +191,7 @@ class Circuit(object):
     def to_basic_gates(self) -> 'Circuit':
         """Returns a new circuit with every gate expanded in terms of X/Z phases, Hadamards
         and the 2-qubit gates CNOT, CZ, CX."""
-        c = Circuit(self.qubits, name=self.name)
+        c = Circuit(self.qubits, name=self.name, bit_amount=self.bits)
         for g in self.gates:
             c.gates.extend(g.to_basic_gates())
         return c


### PR DESCRIPTION
This used to not work, now it does.

```python
import pyzx as zx
circ = zx.Circuit(qubit_amount=3, bit_amount=3)
print(circ)
print(circ.to_basic_gates())
```

```
Circuit(3 qubits, 3 bits, 0 gates)
Circuit(3 qubits, 0 bits, 0 gates)
```