### PR TITLE
Add more symbolic functionality

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -563,10 +563,17 @@ class CRZ(Gate):
         self.phase = phase
 
     def to_basic_gates(self):
-        return [ZPhase(self.target,Fraction(self.phase/2)),
-                CNOT(self.control,self.target),
-                ZPhase(self.target,Fraction(-self.phase/2)%2),
-                CNOT(self.control,self.target)]
+        phase1 = self.phase / 2
+        phase2 = -self.phase / 2
+        try:
+            phase1 = Fraction(phase1) % 2
+            phase2 = Fraction(phase2) % 2
+        except Exception:
+            pass
+        return [ZPhase(self.target, phase1),
+                CNOT(self.control, self.target),
+                ZPhase(self.target, phase2),
+                CNOT(self.control, self.target)]
 
 
     def to_graph(self, g, q_mapper, c_mapper):

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -452,7 +452,7 @@ def match_pivot_boundary(
                     wrong_match = True
             if len(boundaries) != 1 or wrong_match: # n is not on the boundary,
                 continue             # has too many boundaries or has neighbors of wrong type
-            if phases[n] and phases[n].denominator == 2:
+            if phases[n] and hasattr(phases[n], 'denominator') and phases[n].denominator == 2:
                 w = n
                 bound = boundaries[0]
             if not w:
@@ -709,7 +709,7 @@ def match_phase_gadgets(g: BaseGraph[VT,ET]) -> List[MatchGadgetType[VT]]:
     outputs = g.outputs()
     # First we find all the phase-gadgets, and the list of vertices they act on
     for v in g.vertices():
-        if phases[v] != 0 and phases[v].denominator > 2 and len(list(g.neighbors(v)))==1:
+        if phases[v] != 0 and hasattr(phases[v], 'denominator') and phases[v].denominator > 2 and len(list(g.neighbors(v)))==1:
             n = list(g.neighbors(v))[0]
             if phases[n] not in (0,1): continue # Not a real phase gadget (happens for scalar diagrams)
             if n in gadgets: continue # Not a real phase gadget (happens for scalar diagrams)


### PR DESCRIPTION
From my experimentation this enables `full_reduce` on symbolic diagrams. Here is an example on a DisCoCat diagram:

<img width="596" alt="image" src="https://user-images.githubusercontent.com/13847804/188112995-bb76a0e6-590e-4f28-9ff7-6fe1945aee77.png">
<img width="549" alt="image" src="https://user-images.githubusercontent.com/13847804/188113162-2d0c3852-45f8-49f4-be24-0958de2bd4bb.png">

