### PR TITLE
Issue#90 add support for ry gate to qasm spec

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -429,6 +429,34 @@ class XPhase(Gate):
         gates.append(HAD(self.target))
         return gates
 
+class YPhase(Gate):
+    name = 'YPhase'
+    printphase: ClassVar[bool] = True
+    qasm_name = 'ry'
+    def __init__(self, target: int, phase: FractionLike=0) -> None:
+        self.target = target
+        self.phase = phase
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, YPhase): return False
+        if self.index != other.index: return False
+        if self.target == other.target and self.phase == other.phase:
+            return True
+        return False
+
+    def __str__(self) -> str:
+        return 'QRot["exp(-i%Y)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
+
+    def to_basic_gates(self):
+        return [ZPhase(self.target, Fraction(1,2)), XPhase(self.target, self.phase), ZPhase(self.target, -Fraction(1,2))]
+
+    def to_graph(self, g, q_mapper, c_mapper):
+        for gate in self.to_basic_gates():
+            gate.to_graph(g, q_mapper, c_mapper)
+
+    def tcount(self):
+        return 1 if self.phase.denominator > 2 else 0
+
 class NOT(XPhase):
     name = 'NOT'
     quippername = 'not'
@@ -930,6 +958,7 @@ gate_types: Dict[str,Type[Gate]] = {
     "XPhase": XPhase,
     "NOT": NOT,
     "ZPhase": ZPhase,
+    "YPhase": YPhase,
     "Z": Z,
     "S": S,
     "T": T,

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -20,7 +20,8 @@ from fractions import Fraction
 from typing import List, Dict, Tuple, Optional
 
 from . import Circuit
-from .gates import Gate, qasm_gate_table, ZPhase, XPhase, CRZ
+from .gates import Gate, qasm_gate_table, ZPhase, XPhase, CRZ, YPhase
+
 
 class QASMParser(object):
     """Class for parsing QASM source files into circuit descriptions."""
@@ -155,7 +156,7 @@ class QASMParser(object):
                 else: g = qasm_gate_table[name](argset[0]) # type: ignore # - Gate subclasses with different numbers of parameters
                 gates.append(g)
                 continue
-            if name.startswith("rx") or name.startswith("rz") or name.startswith("u1") or name.startswith('crz'):
+            if name.startswith(("rx", "ry", "rz", "u1", "crz")):
                 i = name.find('(')
                 j = name.find(')')
                 if i == -1 or j == -1: raise TypeError("Invalid specification {}".format(name))
@@ -172,7 +173,9 @@ class QASMParser(object):
                 phase = self.parse_phase_arg(valp)
                 if name.startswith('rx'): g = XPhase(argset[0],phase=phase)
                 elif name.startswith('crz'): g = CRZ(argset[0],argset[1],phase=phase)
-                else: g = ZPhase(argset[0],phase=phase)
+                elif name.startswith('rz'): g = ZPhase(argset[0],phase=phase)
+                elif name.startswith("ry"): g = YPhase(argset[0],phase=phase)
+                else: raise TypeError("Invalid specification {}".format(name))
                 gates.append(g)
                 continue
             if name.startswith('u2') or name.startswith('u3'): # see https://arxiv.org/pdf/1707.03429.pdf

--- a/tests/ry.qasm
+++ b/tests/ry.qasm
@@ -1,0 +1,4 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg qubits[1];
+ry(0.25*pi) qubits[0];

--- a/tests/test_ry.py
+++ b/tests/test_ry.py
@@ -1,0 +1,43 @@
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import random
+import sys
+if __name__ == '__main__':
+    sys.path.append('..')
+    sys.path.append('.')
+
+try:
+    import numpy as np
+    from pyzx.tensor import tensorfy, compare_tensors, tensor_to_matrix
+except ImportError:
+    np = None
+
+from pyzx.circuit import Circuit
+from fractions import Fraction
+SEED = 1337
+
+@unittest.skipUnless(np, "numpy needs to be installed for this to run")
+class TestCircuit(unittest.TestCase):
+    def setUp(self):
+        c = Circuit(1)
+        c.add_gate("YPhase", 0, Fraction(1, 4))
+        self.c = c
+    def test_to_qasm_and_back(self):
+        s = self.c.to_qasm()
+        c1 = Circuit.from_qasm(s)
+        self.assertEqual(self.c.qubits, c1.qubits)
+        self.assertListEqual(self.c.gates,c1.gates)
+
+    def test_load_qasm_from_file(self):
+        c1 = Circuit.from_qasm_file("ry.qasm")
+        self.assertEqual(c1.qubits, self.c.qubits)
+        self.assertListEqual(c1.gates,self.c.gates)
+
+    def test_ry_preserves_graph_semantics(self):
+        g = self.c.to_graph()
+        t = tensor_to_matrix(tensorfy(g, False), 1, 1)
+        expected_t = np.asarray([[np.cos(np.pi/8), np.sin(np.pi/8)], [-np.sin(np.pi/8), np.cos(np.pi/8)]])
+        self.assertTrue(compare_tensors(t, expected_t, False))


### PR DESCRIPTION
#90 
- Add support for YPhase (ry) gate by composing ZPhase and XPhase
- Update qasm parser to properly parse ry gate rather than throw error 