### PR TITLE
Add some documentation for the phase polynomial routing

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -108,6 +108,20 @@ Below is listed the content of ``optimize.py``.
    :undoc-members:
 
 
+.. _routing:
+
+List of routing functions
+------------------------------
+
+Below is listed the content of ``routing.py``.
+
+.. module:: routing
+
+.. automodule:: pyzx.routing
+   :members:
+   :undoc-members:
+   :member-order: bysource
+
 .. _tensor:
 
 Functions for dealing with tensors

--- a/doc/simplify.rst
+++ b/doc/simplify.rst
@@ -60,3 +60,32 @@ Besides the advanced simplification strategies based on the ZX-calculus, PyZX al
 A more advanced optimization technique involves splitting up the circuit into `phase polynomial <https://arxiv.org/abs/1303.2042>`_ subcircuits, optimizing each of these, and then resynthesising the circuit, which can be done using :func:`~pyzx.optimize.phase_block_optimize`.
 
 The :func:`~pyzx.optimize.basic_optimization` and :func:`~pyzx.optimize.phase_block_optimize` functions are also combined into a single function :func:`~pyzx.optimize.full_optimize`.
+
+Architecture-aware circuit routing
+----------------------------------
+
+The :func:`~pyzx.extract.extract_circuit` function does not take into account
+the architecture of the quantum computer that the circuit will be run on. When
+targeting a specific architecture it is often beneficial to resynthesize the
+circuit to that architecture by following the qubit connectivity when deciding
+which multi-qubit gates to use.
+
+First, we need to define the specific architecture we want to target. The
+function :func:`~pyzx.routing.create_architecture` can create a number of
+pre-defined :class:`~pyzx.routing.Architecture` objects.::
+
+	import pyzx.routing.architecture
+	
+	# Create a 9-qubit square grid architecture
+	grid_arch = architecture.create_architecture(architecture.SQUARE, 9)
+	
+	# Create a IBM qx5 architecture
+	ibm_arch = architecture.create_architecture(architecture.IBM_QX5)
+
+PyZX provides a function for routing phase-polynomial circuits. These circuits
+composed of CNOT, CX and ZPhase gates, which can be directly translated to phase
+gadgets in ZX. The module :mod:`~pyzx.generate` provides a function for creating
+such circuits to an architecture.::
+
+	c_pp = zx.generate.phase_poly(n_qubits=16, n_phase_layers=10, cnots_per_layer=10)
+	routed_circuit = zx.routing.route_phase_poly(c_pp, ibm_arch)

--- a/pyzx/routing/__init__.py
+++ b/pyzx/routing/__init__.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -13,3 +13,40 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""
+This module implements :class:`Architecture` aware routing methods for :class:`Circuit` s.
+"""
+
+__all__ = [
+    # Architecture objects
+    "architectures",
+    "create_architecture",
+    "Architecture",
+
+    # Qubit parity map trackers
+    "Parity",
+    "CNOT_tracker",
+
+    # Cnot mapping
+    "ElimMode",
+    "CostMetric",
+    "FitnessFunction",
+    "gauss",
+    "permuted_gauss",
+    "sequential_gauss",
+    "steiner_gauss",
+    "rec_steiner_gauss",
+
+    # Phase polynomial routing
+    "RoutingMethod",
+    "RootHeuristic",
+    "SplitHeuristic",
+    "route_phase_poly",
+]
+
+from .architecture import Architecture, architectures, create_architecture
+from .cnot_mapper import ElimMode, CostMetric, FitnessFunction, gauss, permuted_gauss, sequential_gauss
+from .parity_maps import Parity, CNOT_tracker
+from .steiner import steiner_gauss, rec_steiner_gauss
+from .phase_poly import RoutingMethod, RootHeuristic, SplitHeuristic, route_phase_poly

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -311,7 +311,7 @@ def permuted_gauss(
 
 
 def sequential_gauss(
-    matrices: list[Mat2],
+    matrices: List[Mat2],
     mode: Optional[ElimMode] = None,
     architecture: Optional[Architecture] = None,
     fitness_func: Optional[FitnessFunction] = None,

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -20,38 +20,52 @@ from multiprocessing.pool import Pool
 from typing import Any, List, Optional, Tuple
 import numpy as np
 
-class GeneticAlgorithm():
 
-    def __init__(self, population_size: int, crossover_prob: float, mutation_prob: float, fitness_func, maximize: bool=False):
+class GeneticAlgorithm:
+    def __init__(
+        self,
+        population_size: int,
+        crossover_prob: float,
+        mutation_prob: float,
+        fitness_func,
+        maximize: bool = False,
+    ):
         self.population_size = population_size
         self.negative_population_size = int(np.sqrt(population_size))
         self.crossover_prob = crossover_prob
         self.mutation_prob = mutation_prob
         self.fitness_func = fitness_func
-        self._sort = lambda l: l.sort(key=lambda x:x[1], reverse=maximize)
+        self._sort = lambda l: l.sort(key=lambda x: x[1], reverse=maximize)
         self.maximize = maximize
         self.n_qubits = 0
         self.population: List[Tuple[List[int], Any]] = []
 
     def _select(self):
-        fitness_scores = [f for c,f in self.population]
+        fitness_scores = [f for c, f in self.population]
         total_fitness = sum(fitness_scores)
         if self.maximize:
-            selection_chance = [f/total_fitness for f in fitness_scores]
+            selection_chance = [f / total_fitness for f in fitness_scores]
         else:
             max_fitness = max(fitness_scores) + 1
             adjusted_scores = [max_fitness - f for f in fitness_scores]
             adjusted_total = sum(adjusted_scores)
-            selection_chance = [ f/adjusted_total for f in adjusted_scores]
-        return np.random.choice(self.population_size, size=2, replace=False, p=selection_chance)
+            selection_chance = [f / adjusted_total for f in adjusted_scores]
+        return np.random.choice(
+            self.population_size, size=2, replace=False, p=selection_chance
+        )
 
     def _create_population(self, n):
         population = [np.random.permutation(n) for _ in range(self.population_size)]
-        self.population = [(list(chromosome), self.fitness_func(chromosome)) for chromosome in population]
+        self.population = [
+            (list(chromosome), self.fitness_func(chromosome))
+            for chromosome in population
+        ]
         self._sort(self.population)
-        self.negative_population = self.population[-self.negative_population_size:]
+        self.negative_population = self.population[-self.negative_population_size :]
 
-    def find_optimum(self, n_qubits, n_generations, initial_order=None, n_child=None, continued=False):
+    def find_optimum(
+        self, n_qubits, n_generations, initial_order=None, n_child=None, continued=False
+    ):
         self.n_qubits = n_qubits
         partial_solution = False
         if not continued or not self.population:
@@ -74,17 +88,28 @@ class GeneticAlgorithm():
 
     def _add_children(self, children):
         n_child = len(children)
-        self.population.extend([(child, self.fitness_func(child)) for child in children])
+        self.population.extend(
+            [(child, self.fitness_func(child)) for child in children]
+        )
         self._sort(self.population)
         self.negative_population.extend(self.population[-n_child:])
-        self.negative_population = [self.negative_population[i] for i in np.random.choice(self.negative_population_size + n_child, size=self.negative_population_size, replace=False)]
-        self.population = self.population[:self.population_size]
+        self.negative_population = [
+            self.negative_population[i]
+            for i in np.random.choice(
+                self.negative_population_size + n_child,
+                size=self.negative_population_size,
+                replace=False,
+            )
+        ]
+        self.population = self.population[: self.population_size]
 
     def _update_population(self, n_child: int):
         children = []
         # Create a child from weak parents to avoid local optima
         p1, p2 = np.random.choice(self.negative_population_size, size=2, replace=False)
-        child = self._crossover(self.negative_population[p1][0], self.negative_population[p2][0])
+        child = self._crossover(
+            self.negative_population[p1][0], self.negative_population[p2][0]
+        )
         children.append(child)
         for _ in range(n_child):
             if np.random.random() < self.crossover_prob:
@@ -96,16 +121,16 @@ class GeneticAlgorithm():
         self._add_children(children)
 
     def _crossover(self, parent1, parent2):
-        crossover_start = np.random.choice(int(self.n_qubits/2))
-        crossover_length = np.random.choice(self.n_qubits-crossover_start)
+        crossover_start = np.random.choice(int(self.n_qubits / 2))
+        crossover_length = np.random.choice(self.n_qubits - crossover_start)
         crossover_end = crossover_start + crossover_length
-        child = -1*np.ones_like(parent1)
-        child[crossover_start:crossover_end] = parent1[crossover_start: crossover_end]
+        child = -1 * np.ones_like(parent1)
+        child[crossover_start:crossover_end] = parent1[crossover_start:crossover_end]
         child_idx = 0
         for parent_gen in parent2:
-            if child_idx == crossover_start: # skip over the parent1 part in child
+            if child_idx == crossover_start:  # skip over the parent1 part in child
                 child_idx = crossover_end
-            if parent_gen not in child: # only add new genes
+            if parent_gen not in child:  # only add new genes
                 child[child_idx] = parent_gen
                 child_idx += 1
         return child
@@ -117,10 +142,32 @@ class GeneticAlgorithm():
         parent[gen2] = _
         return parent
 
-class ParticleSwarmOptimization():
+class ParticleSwarmOptimization:
+    """
+    Optimizer based on the particle swarm optimization algorithm.
+    """
 
-    def __init__(self, swarm_size: int, fitness_func, step_func, s_best_crossover: float, p_best_crossover: float, mutation: float, maximize: bool=False, n_threads :Optional[int]=None):
-        #self.fitness_func = fitness_func
+    def __init__(
+        self,
+        swarm_size: int,
+        step_func, # type 'StepFunction'
+        s_best_crossover: float,
+        p_best_crossover: float,
+        mutation: float,
+        maximize: bool = False,
+        n_threads: Optional[int] = None,
+    ):
+        """
+        Setup the optimizer
+
+        :param swarm_size: Swarm size for the swarm optimization.
+        :param step_function: The to progress the swarm.
+        :param s_best_crossover: The crossover percentage with the best particle in the swarm. Must be between 0.0 and 1.0.
+        :param p_best_crossover: The crossover percentage with the personal best of a particle. Must be between 0.0 and 1.0.
+        :param mutation: The mutation percentage of a particle. Must be between 0.0 and 1.0.
+        :param maximize: Whether to maximize the fitness function.
+        :param n_threads: Number of threads to use for the optimization. If None, use all available threads.
+        """
         self.step_func = step_func
         self.size = swarm_size
         self.s_crossover = s_best_crossover
@@ -130,26 +177,38 @@ class ParticleSwarmOptimization():
         self.maximize = maximize
         self.swarm: List[Particle] = []
         self.pool: Optional[Pool] = None
-        n_threads = min(n_threads, cpu_count()) if n_threads is not None else cpu_count()
-        if n_threads > 1: 
+        n_threads = (
+            min(n_threads, cpu_count()) if n_threads is not None else cpu_count()
+        )
+        if n_threads > 1:
             self.pool = Pool(n_threads)
 
     def __getstate__(self):
         state = self.__dict__.copy()
         # Don't pickle baz
-        #del state["fitness_func"]
+        # del state["fitness_func"]
         del state["pool"]
         return state
 
     def __setstate__(self, state):
         self.__dict__.update(state)
         # Add baz back since it doesn't exist in the pickle
-        #self.fitness_func = None
+        # self.fitness_func = None
         self.pool = None
 
     def _create_swarm(self, n):
-        self.swarm = [Particle(n, self.step_func, self.s_crossover, self.p_crossover, self.mutation, self.maximize, id=i) 
-                        for i in range(self.size)]
+        self.swarm = [
+            Particle(
+                n,
+                self.step_func,
+                self.s_crossover,
+                self.p_crossover,
+                self.mutation,
+                self.maximize,
+                id=i,
+            )
+            for i in range(self.size)
+        ]
         # Start with 1 particle with initial permutation
         self.swarm[0].current = np.arange(n)
 
@@ -159,7 +218,13 @@ class ParticleSwarmOptimization():
         for i in range(n_steps):
             self._update_swarm()
             if not quiet:
-                print("PSO - Iteration", i, "best fitness:", self.best_particle.best, self.best_particle.best_point)
+                print(
+                    "PSO - Iteration",
+                    i,
+                    "best fitness:",
+                    self.best_particle.best,
+                    self.best_particle.best_point,
+                )
         if close_pool and self.pool:
             self.pool.close()
             self.pool.join()
@@ -173,38 +238,55 @@ class ParticleSwarmOptimization():
 
     def _update_swarm(self):
         if self.pool is not None:
-            self.swarm = self.pool.map(self.particle_update_func, [(self.best_particle, p) for p in self.swarm])
+            self.swarm = self.pool.map(
+                self.particle_update_func, [(self.best_particle, p) for p in self.swarm]
+            )
         else:
-            self.swarm = [self.particle_update_func((self.best_particle, p)) for p in self.swarm]
+            self.swarm = [
+                self.particle_update_func((self.best_particle, p)) for p in self.swarm
+            ]
         if self.maximize:
-            top = max(self.swarm, key=lambda p: p.best if p.best is not None else -np.inf)
+            top = max(
+                self.swarm, key=lambda p: p.best if p.best is not None else -np.inf
+            )
         else:
-            top = min(self.swarm, key=lambda p: p.best if p.best is not None else np.inf)
+            top = min(
+                self.swarm, key=lambda p: p.best if p.best is not None else np.inf
+            )
         if self.best_particle is None or top.compare(self.best_particle.best):
             self.best_particle = top
 
-class Particle():
 
-    def __init__(self, size, step_func, s_best_crossover, p_best_crossover, mutation, maximize=False, id=None):
+class Particle:
+    def __init__(
+        self,
+        size,
+        step_func,
+        s_best_crossover,
+        p_best_crossover,
+        mutation,
+        maximize=False,
+        id=None,
+    ):
         self.step_func = step_func
         self.size = size
         self.current = np.random.permutation(size)
         self.best_point = self.current
         self.best = None
         self.best_solution = None
-        self.s_crossover = int(s_best_crossover*size)
-        self.p_crossover = int(p_best_crossover*size)
-        self.mutation = int(mutation*size)
+        self.s_crossover = int(s_best_crossover * size)
+        self.p_crossover = int(p_best_crossover * size)
+        self.mutation = int(mutation * size)
         self.maximize = maximize
         self.id = id
-    
+
     def compare(self, x):
-        if x is None: 
+        if x is None:
             return True
         if self.maximize:
             return x < self.best
         else:
-            return x > self.best 
+            return x > self.best
 
     def step(self, swarm_best):
         new, solution, fitness = self.step_func(self.current)
@@ -218,7 +300,11 @@ class Particle():
             new = self._crossover(new, self.best_point, self.p_crossover)
             new = self._crossover(new, swarm_best.best_point, self.s_crossover)
             # Sanity check TODO can be removed!
-            if any([i not in new for i in range(self.size)]): raise Exception("The new particle point is not a permutation anymore!" + str(self.current))
+            if any([i not in new for i in range(self.size)]):
+                raise Exception(
+                    "The new particle point is not a permutation anymore!"
+                    + str(self.current)
+                )
         self.current = new
         return is_better
 
@@ -232,12 +318,12 @@ class Particle():
 
     def _crossover(self, particle, best_particle, n):
         cross_idxs = np.random.choice(self.size, size=n, replace=False)
-        new_particle = -1*np.ones_like(particle)
+        new_particle = -1 * np.ones_like(particle)
         new_particle[cross_idxs] = best_particle[cross_idxs]
         idx = 0
         for i, gen in enumerate(new_particle):
-            if gen == -1: # skip over the parent1 part in child
-                while(particle[idx] in new_particle):
+            if gen == -1:  # skip over the parent1 part in child
+                while particle[idx] in new_particle:
                     idx += 1
                     if idx == len(particle):
                         break
@@ -245,23 +331,21 @@ class Particle():
                     new_particle[i] = particle[idx]
         return new_particle
 
+if __name__ == "__main__":
 
-if __name__ == '__main__':
     def fitness_func(chromosome):
         t1 = 1
         t2 = 1
         size = len(chromosome)
-        f1 = [chromosome[i]-i for i in range(size)]
+        f1 = [chromosome[i] - i for i in range(size)]
         f2 = [size - g for g in f1]
         f1.sort()
         f2.sort()
         for i in range(1, size):
-            t1 += int(f1[i] == f1[i-1])
-            t2 += int(f2[i] == f2[i-1])
+            t1 += int(f1[i] == f1[i - 1])
+            t2 += int(f2[i] == f2[i - 1])
         return t1 + t2
-
 
     optimizer = GeneticAlgorithm(1000, 0.8, 0.2, fitness_func)
     optimizer.find_optimum(8, 300)
     print(optimizer.population)
-

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -16,7 +16,6 @@
 
 
 from typing import Any, Dict, Iterable, List, Optional, Union
-from pyzx.generate import cnots as generate_cnots
 from pyzx.circuit import Circuit, Gate, gate_types, CNOT
 from pyzx.linalg import Z2, Mat2, MatLike
 
@@ -135,31 +134,6 @@ class CNOT_tracker(Circuit):
     def from_qasm_file(fname: str) -> "CNOT_tracker":
         circuit = Circuit.from_qasm_file(fname)
         return CNOT_tracker.from_circuit(circuit)
-
-
-def build_random_parity_map(qubits: int, n_cnots: int, circuit=None) -> MatLike:
-    """
-    Builds a random parity map.
-
-    :param qubits: The number of qubits that participate in the parity map
-    :param n_cnots: The number of CNOTs in the parity map
-    :param circuit: A (list of) circuit object(s) that implements a row_add() method to add the generated CNOT gates [optional]
-    :return: a 2D numpy array that represents the parity map.
-    """
-    if circuit is None:
-        circuit = []
-    if not isinstance(circuit, list):
-        circuit = [circuit]
-    g = generate_cnots(qubits=qubits, depth=n_cnots)
-    c = Circuit.from_graph(g)
-    matrix = Mat2.id(qubits)
-    for gate in c.gates:
-        if not hasattr(gate, "control") or not hasattr(gate, "target"):
-            continue
-        matrix.row_add(gate.control, gate.target)  # type: ignore
-        for c in circuit:
-            c.row_add(gate.control, gate.target)  # type: ignore
-    return matrix.data
 
 class Parity:
     """

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -15,69 +15,85 @@
 # limitations under the License.
 
 
-import sys
+from typing import Any, Dict, Iterable, List, Optional, Union
 from pyzx.generate import cnots as generate_cnots
-from pyzx.circuit import Circuit, gates, gate_types, CNOT
-from pyzx.linalg import Mat2, MatLike
-
-# try:
-#     import numpy as np
-# except:
-#     np = None
-# NOTE: numpy is not used optionally in code below.
+from pyzx.circuit import Circuit, Gate, gate_types, CNOT
+from pyzx.linalg import Z2, Mat2, MatLike
 
 import numpy as np
 
 class CNOT_tracker(Circuit):
-    def __init__(self, n_qubits, **kwargs):
+    """
+    A circuit-like object that keeps track of row and column operations
+    applied during Gauss elimination via CNOT gates.
+    """
+
+    matrix: Mat2
+    """The qubit parity matrix computed from the CNOT gates."""
+
+    row_perm: np.ndarray
+    """The row permutation of the qubit parity matrix."""
+
+    col_perm: np.ndarray
+    """The column permutation of the qubit parity matrix."""
+
+    def __init__(self, n_qubits: int, **kwargs):
         super().__init__(n_qubits, **kwargs)
         self.matrix = Mat2(np.identity(n_qubits, dtype=np.int32).tolist())
         self.row_perm = np.arange(n_qubits)
         self.col_perm = np.arange(n_qubits)
         self.n_qubits = n_qubits
 
-    def count_cnots(self):
-        return len([g for g in self.gates if hasattr(g, "name") and g.name in ["CNOT", "CZ"]])
+    def count_cnots(self) -> int:
+        """Returns the number of CNOT gates in the tracker."""
+        return len(
+            [g for g in self.gates if hasattr(g, "name") and g.name in ["CNOT", "CZ"]]
+        )
 
-    def cnot_depth(self):
+    def cnot_depth(self) -> int:
+        """Returns the CNOT/CZ depth of the tracked circuit."""
         depth = 1
-        previous_gates = []
+        previous_gates: List[int] = []
         for g in self.gates:
             if hasattr(g, "name") and g.name in ["CNOT", "CZ"]:
-                if g.control in previous_gates or g.target in previous_gates: # type: ignore # Overlapping gate
+                if g.control in previous_gates or g.target in previous_gates:  # type: ignore # Overlapping gate
                     # Start a new CNOT layer
-                    previous_gates = [] 
+                    previous_gates = []
                     depth += 1
                 else:
-                    previous_gates += [g.control, g.target] # type: ignore
+                    previous_gates += [g.control, g.target]  # type: ignore
         return depth
 
-    def row_add(self, q0, q1):
+    def row_add(self, q0: int, q1: int):
+        """Track a row addition operation on the matrix"""
         self.add_gate("CNOT", q0, q1)
         self.matrix.row_add(q0, q1)
 
-    def add_gate(self, gate, *args, **kwargs):
+    def add_gate(self, gate: Union[Gate,str], *args, **kwargs):
         if isinstance(gate, CNOT):
             self.row_add(gate.control, gate.target)
         else:
             super().add_gate(gate, *args, **kwargs)
 
-    def col_add(self, q0, q1):
+    def col_add(self, q0: int, q1: int):
+        """Track a column addition operation on the matrix"""
         self.prepend_gate("CNOT", q1, q0)
         self.matrix.col_add(q0, q1)
 
     @staticmethod
-    def get_metric_names():
+    def get_metric_names() -> List[str]:
+        """Metric names for the CNOT tracker."""
         return ["n_cnots", "depth"]
 
-    def gather_metrics(self):
+    def gather_metrics(self) -> Dict[str, int]:
+        """Gather metrics for the CNOT tracker."""
         metrics = {}
         metrics["n_cnots"] = self.count_cnots()
         metrics["depth"] = self.cnot_depth()
         return metrics
 
-    def prepend_gate(self, gate, *args, **kwargs):
-        """Adds a gate to the circuit. ``gate`` can either be 
+    def prepend_gate(self, gate: Union[Gate, str], *args, **kwargs):
+        """Adds a gate to the circuit. ``gate`` can either be
         an instance of a :class:`Gate`, or it can be the name of a gate,
         in which case additional arguments should be given.
 
@@ -87,35 +103,39 @@ class CNOT_tracker(Circuit):
             circuit.add_gate("ZPhase", 2, phase=Fraction(3,4)) # Adds a ZPhase gate on qubit 2 with phase 3/4
         """
         if isinstance(gate, str):
-            gate_class = gates.gate_types[gate]
+            gate_class = gate_types[gate]
             gate = gate_class(*args, **kwargs)
         self.gates.insert(0, gate)
 
-    def to_qasm(self):
+    def to_qasm(self) -> str:
         qasm = super().to_qasm()
         initial_perm = "// Initial wiring: " + str(self.row_perm)
         end_perm = "// Resulting wiring: " + str(self.col_perm)
-        return '\n'.join([initial_perm, end_perm, qasm])
+        return "\n".join([initial_perm, end_perm, qasm])
 
     @staticmethod
-    def from_circuit(circuit):
+    def from_circuit(circuit: Circuit) -> "CNOT_tracker":
         new_circuit = CNOT_tracker(circuit.qubits, name=circuit.name)
         new_circuit.gates = circuit.gates
         new_circuit.update_matrix()
         return new_circuit
 
     def update_matrix(self):
+        """Rebuilds the parity matrix from the gates in the circuit."""
         self.matrix = Mat2.id(self.n_qubits)
         for gate in self.gates:
             if hasattr(gate, "name") and gate.name == "CNOT":
-                self.matrix.row_add(gate.control, gate.target)
+                self.matrix.row_add(gate.control, gate.target) # type: ignore
             else:
-                print("Warning: CNOT tracker can only be used for circuits with only CNOT gates!")
+                print(
+                    "Warning: CNOT tracker can only be used for circuits with only CNOT gates!"
+                )
 
     @staticmethod
-    def from_qasm_file(fname):
+    def from_qasm_file(fname: str) -> "CNOT_tracker":
         circuit = Circuit.from_qasm_file(fname)
         return CNOT_tracker.from_circuit(circuit)
+
 
 def build_random_parity_map(qubits: int, n_cnots: int, circuit=None) -> MatLike:
     """
@@ -136,7 +156,62 @@ def build_random_parity_map(qubits: int, n_cnots: int, circuit=None) -> MatLike:
     for gate in c.gates:
         if not hasattr(gate, "control") or not hasattr(gate, "target"):
             continue
-        matrix.row_add(gate.control, gate.target) # type: ignore
+        matrix.row_add(gate.control, gate.target)  # type: ignore
         for c in circuit:
-            c.row_add(gate.control, gate.target) # type: ignore
+            c.row_add(gate.control, gate.target)  # type: ignore
     return matrix.data
+
+class Parity:
+    """
+    A set of qubits XORed together.
+    """
+    parity: List[bool]
+
+    def __init__(self, par: Union[str, int, Iterable[Any]], n_qubits: Optional[int] = None):
+        if isinstance(par, int):
+            self.parity = [bool(par & (1 << i)) for i in reversed(range(par.bit_length()))]
+        elif isinstance(par, str):
+            self.parity = [p != "0" for p in par]
+        else:
+            self.parity = [bool(x) for x in par]
+        if n_qubits is not None and len(self.parity) < n_qubits:
+            self.parity += [False] * (n_qubits - len(self.parity))
+
+    def count(self) -> int:
+        """Returns the number of qubits interacting in the parity."""
+        return sum(self.parity)
+
+    def n_qubits(self) -> int:
+        """Returns the total number of qubits."""
+        return len(self.parity)
+    
+    def to_mat2_row(self) -> List[Z2]:
+        return [1 if b else 0 for b in self.parity]
+
+    def __str__(self):
+        return "".join(["1" if p else "0" for p in self.parity])
+
+    def __repr__(self):
+        return "Parity(" + str(self) + ")"
+
+    def __len__(self):
+        return len(self.parity)
+
+    def __iter__(self):
+        return iter(self.parity)
+
+    def __getitem__(self, i):
+        return self.parity[i]
+
+    def __set_item__(self, i, v):
+        self.parity[i] = v
+
+    def __eq__(self, other):
+        if isinstance(other, Parity):
+            return self.parity == other.parity
+        if isinstance(other, str):
+            return str(self) == other
+        return False
+
+    def __hash__(self):
+        return hash(str(self))

--- a/pyzx/routing/steiner.py
+++ b/pyzx/routing/steiner.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -16,20 +16,29 @@
 
 from typing import List, Tuple, Optional
 
+from pyzx.routing.parity_maps import CNOT_tracker
+
 from .architecture import Architecture
 from ..linalg import Mat2
 
 debug = False
 
-def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x=None, y=None):
+
+def steiner_gauss(
+    matrix: Mat2,
+    architecture: Architecture,
+    full_reduce: bool = False,
+    x: Optional[CNOT_tracker] = None,
+    y: Optional[CNOT_tracker] = None,
+):
     """
-    Performs Gaussian elimination that is constraint by the given architecture
-    
+    Performs Gaussian elimination that is constrained by the given architecture
+
     :param matrix: PyZX Mat2 matrix to be reduced
     :param architecture: The Architecture object to conform to
     :param full_reduce: Whether to fully reduce or only create an upper triangular form
-    :param x: 
-    :param y: 
+    :param x: Optional CNOT_tracker object to track row operations
+    :param y: Optional CNOT_tracker object to track column operations
     :return: Rank of the given matrix
     """
 
@@ -37,8 +46,10 @@ def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x
         matrix.row_add(c0, c1)
         if debug:
             print("Reducing", c0, c1)
-        if x != None: x.row_add(c0, c1)
-        if y != None: y.col_add(c1, c0)
+        if x != None:
+            x.row_add(c0, c1)
+        if y != None:
+            y.col_add(c1, c0)
 
     def steiner_reduce(col: int, root: int, nodes: List[int], upper: bool):
         steiner_tree = architecture.steiner_tree(root, nodes, upper)
@@ -57,7 +68,9 @@ def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x
                     row_add(s1, s0)
                     if debug:
                         print(matrix[s0, col], matrix[s1, col])
-            if next_check is not None and matrix[next_check[0], col] == 0:  # root is zero
+            if (
+                next_check is not None and matrix[next_check[0], col] == 0
+            ):  # root is zero
                 print("WARNING : Root is 0 => reducing non-pivot column", matrix.data)
             if debug:
                 print("Step 1: remove zeros", matrix[:, col])
@@ -89,22 +102,20 @@ def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x
         found_pivot = False
         nodes = []
         while not found_pivot and pivot < cols:
-            nodes = [r for r in range(current_row,rows)
-                       if matrix[r,pivot] == 1]
+            nodes = [r for r in range(current_row, rows) if matrix[r, pivot] == 1]
             if len(nodes) > 0:
                 p_cols.append(pivot)
                 found_pivot = True
             else:
                 pivot += 1
         # no more pivots left
-        if not found_pivot: break
+        if not found_pivot:
+            break
 
         if nodes[0] != current_row:
-            nodes.insert(0,current_row)
+            nodes.insert(0, current_row)
         steiner_reduce(pivot, current_row, nodes, True)
-        pivot+=1
-
-
+        pivot += 1
 
     # for c in range(cols):
     #     nodes = [r for r in range(pivot, rows) if pivot==r or matrix[r,c] == 1]
@@ -122,7 +133,7 @@ def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x
     if full_reduce:
         for current_row in reversed(range(len(p_cols))):
             pivot = p_cols[current_row]
-            nodes = [r for r in range(0, current_row) if matrix[r,pivot] == 1]
+            nodes = [r for r in range(0, current_row) if matrix[r, pivot] == 1]
             if len(nodes) > 0:
                 nodes.append(current_row)
                 steiner_reduce(pivot, current_row, nodes, False)
@@ -137,16 +148,26 @@ def steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce=False, x
     #         pivot -= 1
     return rank
 
-def rec_steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce: bool=False, x=None, y=None, permutation=None, **kwargs):
+
+def rec_steiner_gauss(
+    matrix: Mat2,
+    architecture: Architecture,
+    full_reduce: bool = False,
+    x: Optional[CNOT_tracker] = None,
+    y: Optional[CNOT_tracker] = None,
+    permutation: Optional[List[int]] = None,
+    **kwargs,
+):
     """
-    Performs Gaussian elimination that is constraint bij the given architecture according to https://arxiv.org/pdf/1904.00633.pdf
+    Performs Gaussian elimination that is constrained bij the given architecture according to https://arxiv.org/pdf/1904.00633.pdf
     Only works on full rank, square matrices.
-    
+
     :param matrix: PyZX Mat2 matrix to be reduced
     :param architecture: The Architecture object to conform to
     :param full_reduce: Whether to fully reduce or only create an upper triangular form
-    :param x: 
-    :param y: 
+    :param x: Optional CNOT_tracker object to track row operations
+    :param y: Optional CNOT_tracker object to track column operations
+    :param permutation: Optional permutation of the qubits
     """
     if permutation is None:
         permutation = [i for i in range(matrix.rows())]
@@ -157,17 +178,34 @@ def rec_steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce: boo
         matrix.row_add(c0, c1)
         if debug:
             print("Reducing", c0, c1)
-        if x != None: x.row_add(c0, c1)
-        if y != None: y.col_add(c1, c0)
+        if x != None:
+            x.row_add(c0, c1)
+        if y != None:
+            y.col_add(c1, c0)
 
     def steiner_reduce(col, root, nodes, usable_nodes, rec_nodes, upper):
         if not all([q in usable_nodes for q in nodes]):
-            raise Exception("Terminals not in the subgraph "+ str(upper) + str((col, root, nodes, usable_nodes, rec_nodes)))
-        generator = steiner_reduce_column(architecture, [row[col] for row in matrix.data], root, nodes, usable_nodes, rec_nodes, upper)
+            raise Exception(
+                "Terminals not in the subgraph "
+                + str(upper)
+                + str((col, root, nodes, usable_nodes, rec_nodes))
+            )
+        generator = steiner_reduce_column(
+            architecture,
+            [row[col] for row in matrix.data],
+            root,
+            nodes,
+            usable_nodes,
+            rec_nodes,
+            upper,
+        )
         cnot = next(generator, None)
         tree_nodes = []
         while cnot is not None:
-            if cnot[0] not in usable_nodes+rec_nodes or cnot[1] not in usable_nodes + rec_nodes:
+            if (
+                cnot[0] not in usable_nodes + rec_nodes
+                or cnot[1] not in usable_nodes + rec_nodes
+            ):
                 raise Exception("Steiner tree not sticking to constraints")
             tree_nodes.extend(cnot)
             row_add(*cnot)
@@ -181,12 +219,16 @@ def rec_steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce: boo
         pivots = list(sorted(qubit_removal_order))
         for pivot_idx, c in enumerate(pivots):
             # Get all the nodes in the row below the diagonal (rows[i:]) where the entry equals 1 or it is the diagonal
-            nodes = [r for r in pivots[pivot_idx:] if c==r or matrix.data[r][c] == 1] 
+            nodes = [r for r in pivots[pivot_idx:] if c == r or matrix.data[r][c] == 1]
             # Perform the steiner_reduce on the current column (c) with root rows2[pivot] and you can use the full matrix
             steiner_reduce(c, c, nodes, pivots[pivot_idx:], [], True)
-        #Quick check upper triangular form - should never be printing!
-        if not all([all([matrix.data[i][j]== 0 for j in range(0, i)]) for i in range(size)]):
-            print("This should never be printed. If you read this, there is a bug in pyzx/routing/steiner.py")
+        # Quick check upper triangular form - should never be printing!
+        if not all(
+            [all([matrix.data[i][j] == 0 for j in range(0, i)]) for i in range(size)]
+        ):
+            print(
+                "This should never be printed. If you read this, there is a bug in pyzx/routing/steiner.py"
+            )
             print()
             print("not upper triangular form?")
             for row in matrix.data:
@@ -197,33 +239,51 @@ def rec_steiner_gauss(matrix: Mat2, architecture: Architecture, full_reduce: boo
             # We precalculated the maximal leafs in R (in the qubit_removal_order)
             for i, c in enumerate(qubit_removal_order):
                 # Vertices we can still use steiner trees
-                usable_nodes = qubit_removal_order[i:] # = R
+                usable_nodes = qubit_removal_order[i:]  # = R
 
                 # Pick the maximal vertex k in R: k = max(usable_nodes)
                 # Pick the maximal leaf k' in R: k' = cols[i] = c
                 # Let W be the set of vertices in the shortest path from k' to k (inclusive)
-                path = architecture.shortest_path(c, max(usable_nodes))#, usable_nodes) 
+                path = architecture.shortest_path(
+                    c, max(usable_nodes)
+                )  # , usable_nodes)
                 if path is None:
-                    raise ValueError(f"The architecture is not connected using when considering nodes 0..{max(usable_nodes)}")
+                    raise ValueError(
+                        f"The architecture is not connected using when considering nodes 0..{max(usable_nodes)}"
+                    )
                 rec_qubits = [architecture.vertex2qubit(v) for v in path]
 
                 # Apply steiner up:
                 # Pick the nodes of the steiner tree: all rows with a 1 in column c or the pivot row (diagonal)
-                nodes = [r for r in usable_nodes if (r==c or matrix.data[r][c] == 1)]
+                nodes = [r for r in usable_nodes if (r == c or matrix.data[r][c] == 1)]
 
-                if len(nodes) > 1: # Otherwise it is the diagonal, which is trivial/done
+                if (
+                    len(nodes) > 1
+                ):  # Otherwise it is the diagonal, which is trivial/done
                     steiner_reduce(c, c, nodes, usable_nodes, rec_qubits, False)
 
                 # Do recursion on the recursive nodes that were allowed to break the the upper triangular form.
-                if len(rec_qubits) > 1: # Trivial otherwise
-                    rec_step(list(reversed(rec_qubits)))#[n for n in rows if n in rec_qubits])
+                if len(rec_qubits) > 1:  # Trivial otherwise
+                    rec_step(
+                        list(reversed(rec_qubits))
+                    )  # [n for n in rows if n in rec_qubits])
 
     # The qubit order is the order in which the spanning tree R is traversed
     rec_step(architecture.reduce_order)
 
 
-def steiner_reduce_column(architecture: Architecture, col: List[int], root: int, nodes: List[int], usable_nodes: List[int], rec_nodes, upper: bool):
-    steiner_tree = architecture.rec_steiner_tree(root, nodes, usable_nodes, rec_nodes, upper)
+def steiner_reduce_column(
+    architecture: Architecture,
+    col: List[int],
+    root: int,
+    nodes: List[int],
+    usable_nodes: List[int],
+    rec_nodes,
+    upper: bool,
+):
+    steiner_tree = architecture.rec_steiner_tree(
+        root, nodes, usable_nodes, rec_nodes, upper
+    )
     # Remove all zeros
     next_check = next(steiner_tree)
     if debug:
@@ -238,7 +298,7 @@ def steiner_reduce_column(architecture: Architecture, col: List[int], root: int,
         while len(zeros) > 0:
             s0, s1 = zeros.pop(-1)
             if col[s0] == 0:
-                col[s0] = (col[s1]+col[s0])%2
+                col[s0] = (col[s1] + col[s0]) % 2
                 yield s1, s0
                 if debug:
                     print(col[s0], col[s1])
@@ -252,7 +312,7 @@ def steiner_reduce_column(architecture: Architecture, col: List[int], root: int,
         while next_check is not None:
             s0, s1 = next_check
             if col[s1] == 0:  # s1 is a new steiner point
-                col[s1] = (col[s1]+col[s0])%2
+                col[s1] = (col[s1] + col[s0]) % 2
                 yield s0, s1
             next_check = next(steiner_tree)
     # Reduce stuff
@@ -261,7 +321,7 @@ def steiner_reduce_column(architecture: Architecture, col: List[int], root: int,
     next_add = next(steiner_tree)
     while next_add is not None:
         s0, s1 = next_add
-        col[s1] = (col[s1]+col[s0])%2
+        col[s1] = (col[s1] + col[s0]) % 2
         yield s0, s1
         next_add = next(steiner_tree)
         if debug:

--- a/pyzx/scripts/cnot_generator.py
+++ b/pyzx/scripts/cnot_generator.py
@@ -18,7 +18,8 @@
 import argparse
 import os
 from ..utils import make_into_list
-from ..routing.parity_maps import build_random_parity_map, CNOT_tracker
+from ..routing.parity_maps import CNOT_tracker
+from ..generate import build_random_parity_map
 
 description = "Generates random CNOT circuits and stores them as QASM files."
 

--- a/pyzx/scripts/phase_poly_generator.py
+++ b/pyzx/scripts/phase_poly_generator.py
@@ -17,10 +17,7 @@
 import argparse
 import os
 from ..utils import make_into_list
-from ..routing.phase_poly import (
-    make_random_phase_poly,
-    make_random_phase_poly_from_gadgets,
-)
+from .. import generate
 
 description = (
     "Generates random phase polynomial circuits and stores them as QASM files."
@@ -73,7 +70,7 @@ def main(args):
             for i in range(n_maps):
                 filename = "Original" + str(i) + ".qasm"
                 dest_file = os.path.join(dest_folder, filename)
-                circuit = make_random_phase_poly_from_gadgets(q, p, True)
+                circuit = generate.phase_poly_from_gadgets(q, p)
                 with open(dest_file, "w") as f:
                     f.write(circuit.to_qasm())
 
@@ -118,6 +115,6 @@ def main_old(args):
                 for i in range(n_maps):
                     filename = "Original" + str(i) + ".qasm"
                     dest_file = os.path.join(dest_folder, filename)
-                    circuit = make_random_phase_poly(q, p, n, True)
+                    circuit = generate.phase_poly(q, p, n)
                     with open(dest_file, "w") as f:
                         f.write(circuit.to_qasm())

--- a/tests/test_cnot_mapper.py
+++ b/tests/test_cnot_mapper.py
@@ -10,9 +10,10 @@ import numpy as np
 
 from pyzx.linalg import Mat2, MatLike
 from pyzx.routing.cnot_mapper import (
+    CostMetric,
     gauss,
     ElimMode,
-    cnot_fitness_func,
+    FitnessFunction,
     sequential_gauss,
 )
 from pyzx.routing.architecture import (
@@ -27,7 +28,7 @@ from pyzx.routing.architecture import (
 )
 from pyzx.routing.parity_maps import CNOT_tracker, build_random_parity_map
 from pyzx.routing.machine_learning import GeneticAlgorithm
-from pyzx.circuit import CNOT, Circuit
+from pyzx.circuit import CNOT
 from pyzx.extract import permutation_as_swaps
 from pyzx.routing.steiner import steiner_gauss
 
@@ -252,7 +253,7 @@ class TestSteiner(unittest.TestCase):
                     population,
                     crossover_prob,
                     mutate_prob,
-                    cnot_fitness_func(ElimMode.STEINER_MODE, self.matrix[i], self.arch),
+                    FitnessFunction(CostMetric.COUNT, self.matrix[i], ElimMode.STEINER_MODE, self.arch),
                 )
                 best_permutation = optimizer.find_optimum(self.n_qubits, n_iter)
                 self.do_permuted_gauss(
@@ -290,11 +291,11 @@ class TestSteiner(unittest.TestCase):
                             )
                             if not permute_input:
                                 self.assertListEqual(
-                                    perms[0].tolist(), [i for i in range(self.n_qubits)]
+                                    perms[0], [i for i in range(self.n_qubits)]
                                 )
                             if not permute_output:
                                 self.assertListEqual(
-                                    perms[-1].tolist(),
+                                    perms[-1],
                                     [i for i in range(self.n_qubits)],
                                 )
                             aggr_c = CNOT_tracker(self.n_qubits)

--- a/tests/test_cnot_mapper.py
+++ b/tests/test_cnot_mapper.py
@@ -26,10 +26,11 @@ from pyzx.routing.architecture import (
     FULLY_CONNECTED,
     IBMQ_SINGAPORE,
 )
-from pyzx.routing.parity_maps import CNOT_tracker, build_random_parity_map
+from pyzx.routing.parity_maps import CNOT_tracker
 from pyzx.routing.machine_learning import GeneticAlgorithm
 from pyzx.circuit import CNOT
 from pyzx.extract import permutation_as_swaps
+from pyzx.generate import build_random_parity_map
 from pyzx.routing.steiner import steiner_gauss
 
 SEED = 42


### PR DESCRIPTION
This PR adds more docstrings to the changes from #108.
The root module `pyzx.routing` now re-exports some common operations, which are also shown in the API reference section of the docs. I also added a short usage example there.

There are some small changes to the code like moving the circuit generation routines to `generate`, and adding an explicit `Parity` class instead of using strings of "0"s and "1"s. There should be no functionality changes.