### PR TITLE
Fix `to_quimb_tensor()`

### DIFF
--- a/pyzx/quimb.py
+++ b/pyzx/quimb.py
@@ -27,7 +27,7 @@ except ImportError:
 
 from .utils import EdgeType, VertexType
 from .graph.base import BaseGraph
-from .simplify import to_gh
+from .simplify import to_gh, unfuse_phase_spiders
 
 def to_quimb_tensor(g: BaseGraph) -> 'qtn.TensorNetwork':
     """Converts tensor network representing the given :func:`pyzx.graph.Graph`.
@@ -44,7 +44,10 @@ def to_quimb_tensor(g: BaseGraph) -> 'qtn.TensorNetwork':
 
     # only Z spiders are handled below
     to_gh(g)
-    
+
+    # unfuse spiders with phase
+    unfuse_phase_spiders(g)
+
     tensors = []
 
     # Here we have phase tensors corresponding to Z-spiders with only one output and no input.

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -183,6 +183,15 @@ def match_spider_parallel(
                 m.append((v0,v1))
     return m
 
+def unfuse_phase_spiders(g: BaseGraph[VT,ET]) -> None:
+    """ Unfuses all spiders with non-zero phase. """
+    vs = list(g.vertices())
+    for v in vs:
+        p = g.phase(v)
+        if p != 0:
+            g.set_phase(v, 0)
+            nv = g.add_vertex(ty=g.types()[v], phase=p)
+            g.add_edge(g.edge(v, nv))
 
 def spider(g: BaseGraph[VT,ET], matches: List[MatchSpiderType[VT]]) -> RewriteOutputType[ET,VT]:
     '''Performs spider fusion given a list of matchings from ``match_spider(_parallel)``


### PR DESCRIPTION
Support phased spiders with more than 1 leg, fulfilling the condition stated in https://github.com/Quantomatic/pyzx/blob/e93a0829ef467bd6c9887332b4899e0f7c1ddc80/pyzx/quimb.py#L50

Example code
```python
from pyzx import Circuit
from pyzx.circuit.gates import Z, NOT
from pyzx.quimb import to_quimb_tensor

c = Circuit(1)
c.add_gate(Z(0))
c.add_gate(NOT(0))

g = c.to_graph()
inds = [str(i) for i in [*g.inputs(), *g.outputs()]]
print(to_quimb_tensor(g).contract(output_inds=inds).data)
```