### PR TITLE
Fix gflow

### DIFF
--- a/pyzx/gflow.py
+++ b/pyzx/gflow.py
@@ -109,7 +109,7 @@ def gflow(
                 l[u] = k
 
         if not correct:
-            if not candidates:
+            if vertices.difference(processed) == inputs.difference(pattern_inputs):
                 return l, gflow, k
             return None
         else:


### PR DESCRIPTION
Changed the gflow function to prevent it from returning a gflow if any vertices outside of boundary type inputs remain unprocessed in the end. Should solve issue #114