### PR TITLE
W fusion bug fix

### DIFF
--- a/pyzx/basicrules.py
+++ b/pyzx/basicrules.py
@@ -223,12 +223,10 @@ def fuse_w(g: BaseGraph[VT,ET], v1: VT, v2: VT) -> bool:
     if not check_fuse_w(g, v1, v2): return False
     v1_in, v1_out = get_w_io(g, v1)
     v2_in, v2_out = get_w_io(g, v2)
-    if g.edge_type(g.edge(v1_out, v2_in)) == EdgeType.SIMPLE:
-        apply_rule(g, w_fusion, [(v1, v2)])
-    else:
+    if not g.connected(v1_out, v2_in):
         g.set_position(v2_in, g.qubit(v1_in), g.row(v1_in))
         g.set_position(v2_out, g.qubit(v1_out), g.row(v1_out))
-        apply_rule(g, w_fusion, [(v2, v1)])
+    apply_rule(g, w_fusion, [(v2, v1)])
     return True
 
 def check_remove_id(g: BaseGraph[VT,ET], v: VT) -> bool:

--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -305,12 +305,15 @@ def w_fusion(g: BaseGraph[VT,ET], matches: List[MatchSpiderType[VT]]) -> Rewrite
     for v0, v1 in matches:
         v0_in, v0_out = get_w_io(g, v0)
         v1_in, v1_out = get_w_io(g, v1)
+        if not g.connected(v0_out, v1_in):
+            v0_in, v1_in = v1_in, v0_in
+            v0_out, v1_out = v1_out, v0_out
         # always delete the second vertex in the match
         rem_verts.extend([v1_in, v1_out])
 
         # edges from the second vertex are transferred to the first
         for w in g.neighbors(v1_out):
-            if w == v1_in:
+            if w == v1_in or w == v0_in:
                 continue
             if w == v1_out:
                 w = v0_out


### PR DESCRIPTION
I forgot to check which W node is the input and which one is the output when fusing them. This led to the fusion bug described by @jvdwetering in here: https://github.com/Quantomatic/zxlive/pull/77. This PR fixes that bug.