### PR TITLE
Match symbolic phase gadgets

### DIFF
--- a/pyzx/rules.py
+++ b/pyzx/rules.py
@@ -778,7 +778,12 @@ def match_phase_gadgets(g: BaseGraph[VT,ET]) -> List[MatchGadgetType[VT]]:
     outputs = g.outputs()
     # First we find all the phase-gadgets, and the list of vertices they act on
     for v in g.vertices():
-        if phases[v] != 0 and hasattr(phases[v], 'denominator') and phases[v].denominator > 2 and len(list(g.neighbors(v)))==1:
+        non_clifford = phases[v] != 0 and getattr(phases[v], 'denominator', 1) > 2
+        try: # symbol check
+            float(phases[v])
+        except:
+            non_clifford = True
+        if non_clifford and len(list(g.neighbors(v)))==1:
             n = list(g.neighbors(v))[0]
             if phases[n] not in (0,1): continue # Not a real phase gadget (happens for scalar diagrams)
             if n in gadgets: continue # Not a real phase gadget (happens for scalar diagrams)


### PR DESCRIPTION
```python
from sympy.abc import phi, psi
from pyzx import full_reduce
from pyzx import Circuit

c = Circuit(1)
c.add_gate("ZPhase", 0, phi)
c.add_gate("NOT", 0)
c.add_gate("ZPhase", 0, psi)
# c.add_gate("NOT", 0)

g = c.to_graph()
draw(g)
full_reduce(g)
draw(g)
```

<img width="132" alt="image" src="https://github.com/Quantomatic/pyzx/assets/13847804/613fe0b4-d4c4-4ac6-9018-adfa4ef18518">

Previously:
<img width="143" alt="image" src="https://github.com/Quantomatic/pyzx/assets/13847804/d5abbc43-4b7f-48d1-8666-96743fb44fd1">
