### PR TITLE
Rename CX class to XCX to reduce confusion.

### DIFF
--- a/doc/simplify.rst
+++ b/doc/simplify.rst
@@ -83,9 +83,9 @@ pre-defined :class:`~pyzx.routing.Architecture` objects.::
 	ibm_arch = architecture.create_architecture(architecture.IBM_QX5)
 
 PyZX provides a function for routing phase-polynomial circuits. These circuits
-composed of CNOT, CX and ZPhase gates, which can be directly translated to phase
-gadgets in ZX. The module :mod:`~pyzx.generate` provides a function for creating
-such circuits to an architecture.::
+are composed of CNOT, XCX, and ZPhase gates, which can be directly translated
+to phase gadgets in ZX. The module :mod:`~pyzx.generate` provides a function
+for creating such circuits to an architecture.::
 
 	c_pp = zx.generate.phase_poly(n_qubits=16, n_phase_layers=10, cnots_per_layer=10)
 	routed_circuit = zx.routing.route_phase_poly(c_pp, ibm_arch)

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -19,7 +19,7 @@ from typing import List, Union, Optional, Iterator, Dict
 
 import numpy as np
 
-from .gates import Gate, gate_types, ZPhase, XPhase, CZ, CX, CNOT, HAD, SWAP, CCZ, Tofolli, Measurement
+from .gates import Gate, gate_types, ZPhase, XPhase, CZ, XCX, CNOT, HAD, SWAP, CCZ, Tofolli, Measurement
 
 from ..graph.base import BaseGraph
 from ..utils import EdgeType
@@ -460,7 +460,7 @@ class Circuit(object):
             elif isinstance(g, HAD):
                 hadamard += 1
                 clifford += 1
-            elif isinstance(g, (CZ, CX, CNOT)):
+            elif isinstance(g, (CZ, XCX, CNOT)):
                 twoqubit += 1
                 clifford += 1
                 if isinstance(g, CNOT): cnot += 1

--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -550,7 +550,8 @@ class CZ(Gate):
         strings[t].append(':H_:')
 
 
-class CX(CZ):
+class XCX(CZ):
+    '''This class represents the X-controlled-X gate.'''
     name = 'CX'
     quippername = 'X'
     qasm_name = 'undefined'
@@ -966,7 +967,7 @@ gate_types: Dict[str,Type[Gate]] = {
     "CNOT": CNOT,
     "CZ": CZ,
     "ParityPhase": ParityPhase,
-    "CX": CX,
+    "XCX": XCX,
     "SWAP": SWAP,
     "CRZ": CRZ,
     "HAD": HAD,

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -25,7 +25,7 @@ from .linalg import Mat2, Z2
 from .simplify import id_simp, tcount,full_reduce
 from .rules import apply_rule, pivot, match_spider_parallel, spider
 from .circuit import Circuit
-from .circuit.gates import Gate, ParityPhase, CNOT, HAD, ZPhase, XPhase, CZ, CX, SWAP, InitAncilla
+from .circuit.gates import Gate, ParityPhase, CNOT, HAD, ZPhase, XPhase, CZ, XCX, SWAP, InitAncilla
 
 from .graph.base import BaseGraph, VT, ET
 
@@ -767,7 +767,7 @@ def extract_simple(g: BaseGraph[VT, ET], up_to_perm: bool = True) -> Circuit:
                     elif g.type(v1) == VertexType.X and g.type(v2) == VertexType.X:
                         # conjugate CZ
                         progress = True
-                        circ.prepend_gate(CX(control=q1,target=q2))
+                        circ.prepend_gate(XCX(control=q1, target=q2))
                         g.remove_edge(g.edge(v1,v2))
 
     return graph_to_swaps(g, up_to_perm) + circ

--- a/pyzx/gadget_extract.py
+++ b/pyzx/gadget_extract.py
@@ -7,7 +7,7 @@ from .linalg import Mat2, Z2
 from .simplify import id_simp, tcount
 from .rules import apply_rule, pivot, match_spider_parallel, spider
 from .circuit import Circuit
-from .circuit.gates import Gate, ParityPhase, CNOT, HAD, ZPhase, XPhase, CZ, CX, SWAP, InitAncilla
+from .circuit.gates import Gate, ParityPhase, CNOT, HAD, ZPhase, XPhase, CZ, XCX, SWAP, InitAncilla
 from .graph.base import BaseGraph, VT, ET, FractionLike
 
 from typing import List, Optional, Tuple, Dict, Set, Union, Iterator


### PR DESCRIPTION
XCX represents an X-controlled-X gate, whereas CX is typically a synonym for CNOT, i.e., a Z-controlled-X gate.

