### PR TITLE
Add .venv to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .mypy_cache
 local-scratchpads
 venv
+.venv
 .idea
 notebooks/.ipynb_checkpoints
 doc/_build


### PR DESCRIPTION
(This is consistent with what's used in zxlive, and also suggested in venv's documentation.)