### PR TITLE
In qasmparser.py, reset the parser state between calls to `parse`.

### DIFF
--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -33,6 +33,11 @@ class QASMParser(object):
         self.circuit: Optional[Circuit] = None
 
     def parse(self, s: str, strict:bool=True) -> Circuit:
+        self.gates = []
+        self.customgates = {}
+        self.registers = {}
+        self.qubit_count = 0
+        self.circuit = None
         lines = s.splitlines()
         r = []
         #strip comments
@@ -62,7 +67,6 @@ class QASMParser(object):
             data = data[:i] + data[j+1:]
         #parse the regular commands
         commands = [s.strip() for s in data.split(";") if s.strip()]
-        gates: List[Gate] = []
         for c in commands:
             self.gates.extend(self.parse_command(c, self.registers))
 

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -122,5 +122,20 @@ class TestCircuit(unittest.TestCase):
         self.assertTrue(c1.verify_equality(c2,up_to_swaps=True))
         self.assertFalse(c1.verify_equality(c2,up_to_swaps=False))
 
+    def test_parser_state_reset(self):
+        from pyzx.circuit.qasmparser import QASMParser
+        s = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        h q[0];
+        """
+        p = QASMParser()
+        c1 = p.parse(s)
+        c2 = p.parse(s)
+        self.assertEqual(c2.qubits, 1)
+        self.assertEqual(len(c2.gates), 1)
+        self.assertTrue(c1.verify_equality(c2))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #148.