### PR TITLE
Add basic support for OpenQASM 3.

### DIFF
--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -126,6 +126,7 @@ class Settings(object): # namespace class
     topt_command: Optional[List[str]] = None # Argument-separated command to run TOpt such as ["wsl", "./TOpt"]
     show_labels: bool = False
     tikz_classes: Dict[str,str] = tikz_classes
+    default_qasm_version: int = 2
 
 settings = Settings()
 


### PR DESCRIPTION
Addresses issue #116:
- accept OpenQASM 3 file header produced by qiskit
- condition behaviour of `rz` based on version:
  - OpenQASM 2: same as `ZPhase` = `diag(1, exp(i*phi))` (unchanged)
  - OpenQASM 3: acts like `diag(exp(-i*phi/2), exp(i*phi/2))`
- add `p` as an alias for `ZPhase` in OpenQASM 3
- add `u1` as an alias for `ZPhase` in both versions