### PR TITLE
Change `FSim` by putting `control` and `target` parameters first.

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -680,7 +680,7 @@ class FSim(Gate):
     name = 'FSim'
     qsim_name = 'fs'
     print_phase = True
-    def __init__(self, theta:FractionLike, phi:FractionLike, control:int, target:int):
+    def __init__(self, control:int, target:int, theta:FractionLike, phi:FractionLike):
         self.control = control
         self.target = target
         self.theta = theta
@@ -695,7 +695,7 @@ class FSim(Gate):
         return False
 
     def __str__(self) -> str:
-        return "FSim({!s}, {!s}, {!s}, {!s})".format(self.theta, self.phi, self.control, self.target)
+        return "FSim({!s}, {!s}, {!s}, {!s})".format(self.control, self.target, self.theta, self.phi)
 
     def reposition(self, mask, bit_mask = None):
         g = self.copy()

--- a/pyzx/circuit/qsimparser.py
+++ b/pyzx/circuit/qsimparser.py
@@ -53,7 +53,7 @@ def parse_qsim(data: str) -> Circuit:
             q1 = int(gdesc[3])
             theta = float(gdesc[4]) / math.pi
             phi = float(gdesc[5]) / math.pi
-            gates.append(FSim(Fraction(theta), Fraction(phi), q, q1))
+            gates.append(FSim(q, q1, Fraction(theta), Fraction(phi)))
 
     c = Circuit(qcount)
     c.gates = gates

--- a/scratchpads/FSim gate.ipynb
+++ b/scratchpads/FSim gate.ipynb
@@ -366,7 +366,7 @@
    ],
    "source": [
     "c = zx.Circuit(2)\n",
-    "c.gates = [zx.gates.FSim(Fraction(1,2), Fraction(1,6), 0, 1)]\n",
+    "c.gates = [zx.gates.FSim(0, 1, Fraction(1,2), Fraction(1,6))]\n",
     "g = c.to_graph(zh=True)\n",
     "zx.draw(g)"
    ]


### PR DESCRIPTION
This makes it more consistent with the parameter order of other `Gate`s as well as the `.qsim` file format.

Fixes #146.