### PR TITLE
Add helpful suggestion to `parse_gate` when called with non-basic gate.

### DIFF
--- a/pyzx/optimize.py
+++ b/pyzx/optimize.py
@@ -512,9 +512,9 @@ class Optimizer(object):
             else: # Only the control has a hadamard gate in front of it
                 self.add_hadamard(c)
                 self.add_cnot(g)
-        
+
         else:
-            raise TypeError("Unknown gate {}".format(str(g)))
+            raise TypeError("Unknown gate {}. Maybe simplify the gates with circuit.to_basic_gates()?".format(str(g)))
 
 
 


### PR DESCRIPTION
This also makes the error message consistent with the one in `phase_block_optimize`.

See #196 for context.