### PR TITLE
In `full_reduce`, raise error if input graph contains `H_BOX`.

### DIFF
--- a/pyzx/simplify.py
+++ b/pyzx/simplify.py
@@ -196,6 +196,9 @@ def reduce_scalar(g: BaseGraph[VT,ET], quiet:bool=True, stats:Optional[Stats]=No
 def full_reduce(g: BaseGraph[VT,ET], quiet:bool=True, stats:Optional[Stats]=None) -> None:
     """The main simplification routine of PyZX. It uses a combination of :func:`clifford_simp` and
     the gadgetization strategies :func:`pivot_gadget_simp` and :func:`gadget_simp`."""
+    if any(g.types()[h] == VertexType.H_BOX for h in g.vertices()):
+        raise ValueError("Input graph is not a ZX-diagram as it contains an H-box. "
+                         "Maybe call pyzx.hsimplify.from_hypergraph_form(g) first?")
     interior_clifford_simp(g, quiet=quiet, stats=stats)
     pivot_gadget_simp(g,quiet=quiet, stats=stats)
     while True:

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -20,6 +20,8 @@ import random
 import sys
 from types import ModuleType
 from typing import Optional
+
+from pyzx import VertexType
 
 if __name__ == '__main__':
     sys.path.append('..')
@@ -112,6 +114,21 @@ class TestSimplify(unittest.TestCase):
         g = c.to_graph()
         to_graph_like(g)
         self.assertTrue(compare_tensors(c,g))
+
+    def test_full_reduce_with_h_box(self):
+        """Test that calls to :func:`full_reduce` with a graph containing H-boxes raises an error.
+        This is a common mistake made by users (e.g., see issues #161 and #200).
+        """
+        g = Graph()
+        v0 = g.add_vertex(VertexType.BOUNDARY, 0, 0)
+        v1 = g.add_vertex(VertexType.H_BOX, 0, 1)
+        v2 = g.add_vertex(VertexType.BOUNDARY, 0, 2)
+        g.add_edge((v0, v1))
+        g.add_edge((v1, v2))
+
+        with self.assertRaises(ValueError) as context:
+            full_reduce(g)
+        self.assertTrue("Input graph is not a ZX-diagram" in str(context.exception))
 
 
 qasm_1 = """OPENQASM 2.0;


### PR DESCRIPTION
The function requires that the input is a ZX-diagram (i.e., no `H_BOX`es). See #161 and #200 for context.

Note: This does not guard `clifford_simp` or other simplification subroutines, which will still silently fail if there are `H_BOX`es. Putting a check into each subroutine would be redundant and expensive.