### PR TITLE
refactor: make scalar-handling backend agnostic

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -592,7 +592,7 @@ class CNOT(Gate):
         g.add_edge((t,c))
         for r_ in range(top, bot + 1):
           q_mapper.set_next_row(r_, r+1)
-        g.scalar.add_power(1)
+        g.mult_scalar_by_sqrt2_power(1)
 
     def to_emoji(self,strings: List[List[str]]) -> None:
         c,t = self.control, self.target
@@ -634,7 +634,7 @@ class CZ(Gate):
         g.add_edge((t,c), EdgeType.HADAMARD)
         q_mapper.set_next_row(self.target, r+1)
         q_mapper.set_next_row(self.control, r+1)
-        g.scalar.add_power(1)
+        g.mult_scalar_by_sqrt2_power(1)
 
     def to_emoji(self,strings: List[List[str]]) -> None:
         c,t = self.control, self.target
@@ -656,7 +656,7 @@ class XCX(CZ):
         g.add_edge((t,c), EdgeType.HADAMARD)
         q_mapper.set_next_row(self.target, r+1)
         q_mapper.set_next_row(self.control, r+1)
-        g.scalar.add_power(1)
+        g.mult_scalar_by_sqrt2_power(1)
 
     def to_basic_gates(self):
         return [HAD(self.control), CNOT(self.control,self.target), HAD(self.control)]
@@ -912,7 +912,7 @@ class FSim(Gate):
         #rs[self.control] = r+2
 
         q_mapper.shift_all_rows(4)
-        g.scalar.add_power(1)
+        g.mult_scalar_by_sqrt2_power(1)
 
         # c1 = self.graph_add_node(g, q_mapper, VertexType.Z, self.control,r)
         # t1 = self.graph_add_node(g, q_mapper, VertexType.Z, self.target,r)

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -299,6 +299,10 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Multiplies the scalar by a phase factor."""
         self.scalar.add_phase(phase)
 
+    def mult_scalar_by_one_plus_phase(self, phase: FractionLike) -> None:
+        """Multiplies the scalar by a phase factor."""
+        self.scalar.add_node(phase)
+
     def mult_scalar_by_sqrt2_power(self, power: int) -> None:
         """Multiplies the scalar by sqrt(2) raised to the given power."""
         self.scalar.add_power(power)

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -287,6 +287,31 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
     # Backends may wish to override these methods to implement them more efficiently
 
+
+    # Helper functions for mutating the scalar
+    #
+    # AK: I suggest new code *only* uses these functions to modify the scalar and we deprecate mutating
+    # the scalar directly (which doesn't work correctly with the Rust backend). I also picked slightly
+    # clearer names for these options, as the "add_..." method names are misleading for these operations,
+    # which all entail scalar multiplication.
+
+    def mult_scalar_by_phase(self, phase: FractionLike) -> None:
+        """Multiplies the scalar by a phase factor."""
+        self.scalar.add_phase(phase)
+
+    def mult_scalar_by_sqrt2_power(self, power: int) -> None:
+        """Multiplies the scalar by sqrt(2) raised to the given power."""
+        self.scalar.add_power(power)
+    
+    def mult_scalar_by_scalar(self, scalar: Scalar) -> None:
+        """Multiplies scalar with the given scalar"""
+        self.scalar.mult_with_scalar(scalar)
+
+    def mult_scalar_by_spider_pair(self, phase1: FractionLike, phase2: FractionLike) -> None:
+        """Multiplies scalar with a 'spider pair', i.e. a pair of phased Z-spiders connected by an H edge"""
+        self.scalar.add_spider_pair(phase1, phase2)
+
+
     # These methods return mappings from vertices to various pieces of data. If the backend
     # stores these e.g. as Python dicts, just return the relevant dicts.
     def phases(self) -> Mapping[VT, FractionLike]:

--- a/pyzx/graph/scalar.py
+++ b/pyzx/graph/scalar.py
@@ -245,7 +245,7 @@ class Scalar(object):
         if other.is_zero: self.is_zero = True
         if other.is_unknown: self.is_unknown = True
 
-    def add_spider_pair(self, p1: FractionLike,p2: FractionLike) -> None:
+    def add_spider_pair(self, p1: FractionLike, p2: FractionLike) -> None:
         """Add the scalar corresponding to a connected pair of spiders (p1)-H-(p2)."""
         # These if statements look quite arbitrary, but they are just calculations of the scalar
         # of a pair of connected single wire spiders of opposite colors.


### PR DESCRIPTION
Currently the way PyZX handles scalars is not compatible with the Rust backend. The reason for this is Rust stores its scalars differently, so asking for the scalar from the python bindings returns a (lossy) copy of the current scalar. Hence, code like this which mutates the scalar doesn't work as expected:

```python
g.scalar.add_power(5)  # no-op for the Rust backend
```

I suggest we deprecate mutating the scalar directly, and do this all via helper methods added to `BaseGraph`, which are added by this PR:

```python
def mult_scalar_by_phase(self, phase: FractionLike) -> None:
    """Multiplies the scalar by a phase factor."""
    self.scalar.add_phase(phase)

def mult_scalar_by_sqrt2_power(self, power: int) -> None:
    """Multiplies the scalar by sqrt(2) raised to the given power."""
    self.scalar.add_power(power)

def mult_scalar_by_scalar(self, scalar: Scalar) -> None:
    """Multiplies scalar with the given scalar"""
    self.scalar.mult_with_scalar(scalar)

def mult_scalar_by_spider_pair(self, phase1: FractionLike, phase2: FractionLike) -> None:
    """Multiplies scalar with a 'spider pair', i.e. a pair of phased Z-spiders connected by an H edge"""
    self.scalar.add_spider_pair(phase1, phase2)
```

This lets the Rust backend override these methods to do the correct thing.

I will probably go ahead and merge this soon and also change all of the instances I find of mutating the scalar, since this shouldn't break anything. However, on the long term, we might want to look at e.g. renaming `Basegraph.scalar` to `Basegraph._scalar` to enforce using the helpers.