### PR TITLE
Using 'text' tikz class results in an error; replace it with 'label'

### DIFF
--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -135,7 +135,7 @@ tikz_classes = {
     'H': 'hadamard',
     'W': 'W triangle',
     'W input': 'W input',
-    'dummy': 'text',
+    'dummy': 'label',
     'edge': '',
     'H-edge': 'hadamard edge',
     'W-io-edge': 'W io edge'


### PR DESCRIPTION
We can't use 'text' as a name of a tikz style. See https://tex.stackexchange.com/questions/250540/error-in-tikz-text