### PR TITLE
Improve error message and type hints for Pauli web generation

### DIFF
--- a/pyzx/web/red_green.py
+++ b/pyzx/web/red_green.py
@@ -150,8 +150,12 @@ def _euler_expand_edges(g: BaseGraph[int, Tuple[int, int]]) -> Iterable[Expanded
     for v in list(g.vertices()):
         if g.type(v) != VertexType.H_BOX:
             continue
-
-        v1, v2 = g.neighbors(v)
+        
+        try:
+            v1, v2 = g.neighbors(v)
+        except ValueError:
+            raise ValueError(f"Hadamard vertex {v} does not have exactly two neighbors.")
+        
         v1_edge_type = g.edge_type((v1, v))
         v2_edge_type = g.edge_type((v2, v))
 


### PR DESCRIPTION
This PR provides two improvements:
- Previously when computing Pauli webs using the new `pyzx.web` module, a cryptic exception was thrown if the graph included a Hadamard box which did not have exactly two legs. The error message has been updated to identify the problem more clearly.
- The `Pauliweb` class previously had incomplete type annotations, causing information about the underlying edge/vertex type to often be lost when performing operations. The annotations have been further specified to address this issue.
