### PR TITLE
Use @deprecated decorator instead of print-based deprecation notice.

### DIFF
--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -19,6 +19,7 @@ __all__ = ['extract_circuit', 'extract_simple', 'graph_to_swaps', 'extract_cliff
 
 from fractions import Fraction
 import itertools
+from typing_extensions import deprecated
 
 from .utils import EdgeType, VertexType, toggle_edge
 from .linalg import Mat2, Z2
@@ -52,14 +53,15 @@ def connectivity_from_biadj(
             elif not m.data[i][j] and g.connected(right[i],left[j]):
                 g.remove_edge(g.edge(right[i],left[j]))
 
+@deprecated("streaming_extract is deprecated, use extract_circuit instead")
 def streaming_extract(
-        g:BaseGraph[VT,ET], 
-        optimize_czs:bool=True, 
-        optimize_cnots:int=2, 
+        g:BaseGraph[VT,ET],
+        optimize_czs:bool=True,
+        optimize_cnots:int=2,
         quiet:bool=True
         ) -> Circuit:
-    print("This function is deprecated. Call extract_circuit() instead.")
-    return extract_circuit(g, optimize_czs, optimize_cnots, quiet)
+    """Deprecated: Use :func:`extract_circuit` instead."""
+    return extract_circuit(g, optimize_czs=optimize_czs, optimize_cnots=optimize_cnots, quiet=quiet)
 
 def permutation_as_swaps(perm:Dict[int,int]) -> List[Tuple[int,int]]:
     """Returns a series of swaps that realises the given permutation. 

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -19,8 +19,10 @@ __all__ = ['string_to_phase','to_graphml']
 import json
 import re
 import ast
+import warnings
 from fractions import Fraction
 from typing import List, Dict, Tuple, Any, Optional, Callable, Union, TYPE_CHECKING
+from typing_extensions import deprecated
 
 from pyzx.graph.multigraph import Multigraph
 
@@ -65,8 +67,9 @@ def string_to_phase(string: str, g: Optional[Union[BaseGraph,'GraphDiff']] = Non
         except Exception as e:
             raise ValueError(e)
 
+@deprecated("json_to_graph_old is deprecated, use json_to_graph or dict_to_graph instead")
 def json_to_graph_old(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) -> BaseGraph:
-    """This method is deprecated. Use `json_to_graph` or `dict_to_graph` instead.
+    """Deprecated: Use :func:`json_to_graph` or :func:`dict_to_graph` instead.
 
     Converts the json representation of a .qgraph Quantomatic graph into
     a pyzx graph. If JSON is given as a string, parse it first."""
@@ -242,8 +245,10 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
     return d
 
 
+@deprecated("graph_to_dict_old is deprecated, use graph_to_dict instead")
 def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, Any]:
-    """This method is deprecated, and replaced by `graph_to_dict`.
+    """Deprecated: Use :func:`graph_to_dict` instead.
+
     Converts a PyZX graph into Python dict for JSON output that is compatible with the Quantomatic format.
     If include_scalar is set to True (the default), then this includes the value
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
@@ -356,8 +361,11 @@ def dict_to_graph(d: Dict[str,Any], backend: Optional[str]=None) -> BaseGraph:
     If backend is given, it will be used as the backend for the graph, 
     otherwise the backend will be read from the dict description."""
     if not 'version' in d:
-        # "Version is not specified in dictionary, will try to parse it as an older format")
-        return json_to_graph_old(d, backend)
+        # Version is not specified in dictionary, will try to parse it as an older format.
+        # Suppress the deprecation warning since this is an internal fallback.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            return json_to_graph_old(d, backend)
     else:
         if d['version'] != 2:
             raise ValueError("Unsupported version "+str(d['version']))

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "pyzx.scripts",
     ],
     python_requires='>=3.9',
-    install_requires=["typing_extensions>=3.7.4",
+    install_requires=["typing_extensions>=4.5.0",
                       "numpy>=1.14",
                       "pyperclip>=1.8.1",
                       "tqdm>=4.56.0",


### PR DESCRIPTION
Fixes #204.

Also fixes a bug where `streaming_extract` passes incorrect parameters to `extract_circuit`.