### PR TITLE
Update D3 import source in draw_d3 function to use esm.sh

### DIFF
--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -432,7 +432,7 @@ def draw_d3(
     text = """<div style="overflow:auto; background-color: white" id="graph-output-{id}"></div>
 <script type="module">
 var d3;
-if (d3 == null) {{ d3 = await import("https://cdn.skypack.dev/d3@5"); }}
+if (d3 == null) {{ d3 = await import("https://esm.sh/d3@5"); }}
 var _settings_colors = JSON.parse('{colors}');
 {library_code}
 showGraph('#graph-output-{id}',


### PR DESCRIPTION
Drawing diagrams failed for me today. The issue is the import of d3. The response from `https://cdn.skypack.dev/d3@5` is 

```
A server error has occurred

FUNCTION_INVOCATION_FAILED

gru1::m6mp6-1768938276003-74cbecfca4b7
```

skypack seems to have general issues: https://github.com/skypackjs/skypack-cdn/issues/362

It may be worth switching - this is what this PR proposes.