### PR TITLE
Include pyzx.web in package build information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "pyzx.routing",
         "pyzx.local_search",
         "pyzx.scripts",
+        "pyzx.web"
     ],
     python_requires='>=3.9',
     install_requires=["typing_extensions>=4.5.0",
@@ -41,6 +42,7 @@ setup(
                       "pyperclip>=1.8.1",
                       "tqdm>=4.56.0",
                       "ipywidgets>=7.5",
-                      "lark>=1.2.2"],
+                      "lark>=1.2.2",
+                      "galois>=0.4.7"],
     include_package_data=True,
 )


### PR DESCRIPTION
The additions in #372 weren't added to the package index, so the submodule `pyzx.web` is not actually available when the package is built. This PR includes the relevant additions in `setup.py` to fix this.