### PR TITLE
add classical control / feedforward support

### DIFF
--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -283,7 +283,11 @@ class Gate(object):
         param = ""
         if self.print_phase:
             if hasattr(self, "phase"):
-                param = "({}*pi)".format(float(self.phase))
+                try:
+                    param = "({}*pi)".format(float(self.phase))
+                except (TypeError, ValueError):
+                    # Symbolic (Poly) phase — emit as-is.
+                    param = "({}*pi)".format(self.phase)
             elif hasattr(self, "phases"):
                 param = "({})".format(",".join("{}*pi".format(float(p)) for p in self.phases))
         return "{}{} {};".format(n, param, ", ".join(args))
@@ -1373,6 +1377,120 @@ class PostSelect(Gate):
         return g
 
 
+class ConditionalGate(Gate):
+    """A gate that is applied only when a classical register equals a given value.
+
+    Corresponds to the OpenQASM 2 ``if (creg == val) gate args;`` syntax.
+    In the ZX-diagram, single-qubit Z/X-rotation inner gates are represented
+    by multiplying the gate's phase by a boolean condition polynomial built
+    from the register bits.
+
+    Limitations:
+
+    * Only single-qubit Z and X rotations (ZPhase, Z, S, T, XPhase, NOT,
+      and their subclasses) are supported as inner gates.  Other gates,
+      including HAD (which is single-qubit but not a Z/X rotation),
+      CNOT, and CZ, raise ``NotImplementedError`` in ``to_graph()``.
+      Conditional HAD is a known gap for QEC Pauli-frame-correction use
+      cases and requires a decomposition into Z/X rotations or a
+      dedicated graph representation.
+
+    * Conditional X rotations (XPhase, NOT) convert to the graph correctly
+      but cannot be recovered by ``graph_to_circuit()`` because X-type
+      vertices with boolean phases are indistinguishable from measurement
+      outcome vertices.  They are emitted as raw ``XPhase`` gates with a
+      symbolic ``Poly`` phase instead.  The QASM round-trip (Circuit →
+      QASM string → Circuit) is unaffected.
+    """
+    name = 'ConditionalGate'
+
+    def __init__(self, condition_register: str, condition_value: int,
+                 inner_gate: 'Gate', register_size: int) -> None:
+        if condition_value < 0 or condition_value >= (1 << register_size):
+            raise ValueError(
+                "Condition value {} is out of range for a {}-bit register "
+                "(must be 0..{})".format(
+                    condition_value, register_size, (1 << register_size) - 1))
+        self.condition_register = condition_register
+        self.condition_value = condition_value
+        self.inner_gate = inner_gate
+        self.register_size = register_size
+        self.target = inner_gate.target  # type: ignore
+
+    def __str__(self) -> str:
+        return "if({}=={}) {}".format(
+            self.condition_register, self.condition_value, self.inner_gate)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ConditionalGate):
+            return False
+        return (self.condition_register == other.condition_register
+                and self.condition_value == other.condition_value
+                and self.inner_gate == other.inner_gate
+                and self.register_size == other.register_size)
+
+    def _max_target(self) -> int:
+        return self.inner_gate._max_target()
+
+    def copy(self) -> 'ConditionalGate':
+        return ConditionalGate(
+            self.condition_register, self.condition_value,
+            self.inner_gate.copy(), self.register_size)
+
+    def reposition(self, mask, bit_mask=None):
+        g = self.copy()
+        g.inner_gate = g.inner_gate.reposition(mask, bit_mask)
+        g.target = g.inner_gate.target  # type: ignore
+        return g
+
+    def to_qasm(self) -> str:
+        inner_qasm = self.inner_gate.to_qasm()
+        return "if({}=={}) {}".format(
+            self.condition_register, self.condition_value, inner_qasm)
+
+    def _build_condition_poly(self, g: BaseGraph[VT, ET]) -> 'Poly':  # type: ignore[name-defined]
+        """Build a boolean polynomial representing the register condition.
+
+        For ``if (reg == val)`` with an *n*-bit register, the condition is
+        the product over all bits *i* of either ``bit_var_i`` (when bit *i*
+        of *val* is 1) or ``(1 - bit_var_i)`` (when bit *i* is 0).
+        """
+        from ..symbolic import Poly, new_var as sym_new_var, new_const
+        result: Poly = new_const(1)
+        for i in range(self.register_size):
+            bit_var = sym_new_var(
+                "{}[{}]".format(self.condition_register, i),
+                is_bool=True, registry=g.var_registry)
+            if (self.condition_value >> i) & 1:
+                result = result * bit_var
+            else:
+                result = result * (new_const(1) - bit_var)
+        return result
+
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT],
+                 c_mapper: TargetMapper[VT]) -> None:
+        inner = self.inner_gate
+        # Single-qubit Z or X rotations: multiply phase by condition polynomial.
+        if isinstance(inner, ZPhase):
+            cond = self._build_condition_poly(g)
+            phase = cond * inner.phase
+            self.graph_add_node(g, q_mapper, VertexType.Z, inner.target,
+                                q_mapper.next_row(inner.target), phase)
+            q_mapper.advance_next_row(inner.target)
+        elif isinstance(inner, XPhase):
+            cond = self._build_condition_poly(g)
+            phase = cond * inner.phase
+            self.graph_add_node(g, q_mapper, VertexType.X, inner.target,
+                                q_mapper.next_row(inner.target), phase)
+            q_mapper.advance_next_row(inner.target)
+        else:
+            raise NotImplementedError(
+                "ConditionalGate.to_graph() is not supported for gate type "
+                "'{}'. Only single-qubit Z and X rotations (ZPhase, Z, S, T, "
+                "XPhase, NOT, and their subclasses) are currently "
+                "supported.".format(type(inner).__name__))
+
+
 class DiscardBit(Gate):
     name = 'DiscardBit'
     def __init__(self, target):
@@ -1425,6 +1543,11 @@ class Measurement(Gate):
 
     def to_qasm(self) -> str:
         if self.result_symbol is not None:
+            if '[' not in self.result_symbol:
+                raise TypeError(
+                    "Measurement result_symbol '{}' is not a valid QASM "
+                    "classical bit reference (expected 'reg[index]')".format(
+                        self.result_symbol))
             return "measure q[{:d}] -> {};".format(self.target, self.result_symbol)
         if self.result_bit is not None:
             return "measure q[{:d}] -> c[{:d}];".format(self.target, self.result_bit)
@@ -1467,8 +1590,13 @@ class Measurement(Gate):
     def to_graph_symbolic_boolean(self, g, q_mapper):
         """Represent the measurement as a node with symbolic boolean phases."""
         r = q_mapper.next_row(self.target)
-        symbol_name = self.result_symbol if self.result_symbol is not None else f"m{self.target}"
-        phase = new_var(name=f"{symbol_name}", is_bool=True, registry=g.var_registry) 
+        if self.result_symbol is not None:
+            symbol_name = self.result_symbol
+        elif self.result_bit is not None:
+            symbol_name = "c[{}]".format(self.result_bit)
+        else:
+            symbol_name = "m{}".format(self.target)
+        phase = new_var(name=symbol_name, is_bool=True, registry=g.var_registry)
         _ = self.graph_add_node(g,
             q_mapper,
             VertexType.X,
@@ -1525,6 +1653,7 @@ gate_types: Dict[str,Type[Gate]] = {
     "PostSelect": PostSelect,
     "DiscardBit": DiscardBit,
     "Measurement": Measurement,
+    "ConditionalGate": ConditionalGate,
 }
 
 qasm_gate_table: Dict[str, Type[Gate]] = {

--- a/pyzx/circuit/graphparser.py
+++ b/pyzx/circuit/graphparser.py
@@ -14,14 +14,116 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict, List, Optional
+import warnings
+from typing import Dict, List, Optional, Union
 
 from . import Circuit
-from .gates import InitAncilla, Measurement, Reset, TargetMapper
-from ..utils import EdgeType, VertexType, FloatInt, FractionLike
+from .gates import (Gate, InitAncilla, Measurement, Reset, TargetMapper,
+                     ConditionalGate, ZPhase, XPhase, NOT, Z, S, T)
+from ..utils import EdgeType, VertexType, FloatInt, FractionLike, settings
 from ..graph import Graph
 from ..graph.base import BaseGraph, VT, ET
 from ..symbolic import Poly, new_var
+
+def _poly_phase_to_conditional_gate(
+    phase: Poly, vertex_type: VertexType, qubit: int
+) -> Optional[ConditionalGate]:
+    """Try to convert a symbolic Poly phase into a ConditionalGate.
+
+    The polynomial must consist entirely of boolean variables from the
+    same classical register (with names like ``reg[i]``).  The function
+    evaluates the polynomial at every possible bit assignment to find
+    the unique assignment that produces a non-zero result, which gives
+    both the condition value and the inner gate phase.
+
+    Returns ``None`` when the polynomial cannot be interpreted as a
+    condition — e.g. variables from different registers, non-boolean
+    variables, complex coefficients, or more than one non-zero
+    assignment (which would mean the phase is not a simple conditional).
+
+    This function is only called for Z-type vertices.  X-type vertices
+    are skipped because their boolean phases are ambiguous with
+    measurement outcome vertices (see the call site in
+    ``graph_to_circuit``).
+    """
+    from fractions import Fraction
+    from ..symbolic import Var
+    import re
+    # Collect all boolean variables across all terms.
+    bit_pattern = re.compile(r'^(\w+)\[(\d+)\]$')
+    reg_name: Optional[str] = None
+    bit_vars: Dict[int, Var] = {}
+    for _coeff, term in phase.terms:
+        for var, _exp in term.vars:
+            if not var.is_bool:
+                return None
+            m = bit_pattern.match(var.name)
+            if m is None:
+                return None
+            name = m.group(1)
+            idx = int(m.group(2))
+            if reg_name is None:
+                reg_name = name
+            elif reg_name != name:
+                return None  # Variables from different registers.
+            bit_vars[idx] = var
+    if reg_name is None or not bit_vars:
+        return None
+    reg_size = max(bit_vars.keys()) + 1
+    # Evaluate the polynomial at each possible bit assignment.
+    # A valid condition polynomial is non-zero for exactly one assignment.
+    if reg_size > 16:
+        warnings.warn(
+            "Conditional gate extraction is O(2^n) in register size; "
+            "register '{}' has {} bits ({} evaluations).".format(
+                reg_name, reg_size, 1 << reg_size))
+    cond_value: Optional[int] = None
+    inner_phase_value: Optional[Fraction] = None
+    for val in range(1 << reg_size):
+        var_map: Dict[Var, Union[float, complex, Fraction]] = {}
+        for idx, var in bit_vars.items():
+            var_map[var] = Fraction((val >> idx) & 1)
+        result = phase.substitute(var_map)
+        # After full substitution, sum all constant coefficients and
+        # reduce mod 2 since phases are in units of pi.
+        total: Fraction = Fraction(0)
+        for c, t in result.terms:
+            if t.vars:
+                return None  # Not fully substituted.
+            if isinstance(c, complex):
+                return None
+            total += Fraction(c)
+        total = total % 2
+        if total == 0:
+            continue
+        if cond_value is not None:
+            return None  # Non-zero for more than one assignment.
+        cond_value = val
+        inner_phase_value = Fraction(total).limit_denominator(settings.float_to_fraction_max_denominator)
+    if cond_value is None or inner_phase_value is None:
+        return None
+    inner_phase = inner_phase_value
+    if vertex_type == VertexType.Z:
+        if inner_phase == 1:
+            inner_gate: Gate = Z(qubit)
+        elif inner_phase == Fraction(1, 2):
+            inner_gate = S(qubit)
+        elif inner_phase == Fraction(-1, 2) or inner_phase == Fraction(3, 2):
+            inner_gate = S(qubit, adjoint=True)
+        elif inner_phase == Fraction(1, 4):
+            inner_gate = T(qubit)
+        elif inner_phase == Fraction(-1, 4) or inner_phase == Fraction(7, 4):
+            inner_gate = T(qubit, adjoint=True)
+        else:
+            inner_gate = ZPhase(qubit, inner_phase)
+    else:
+        # X-type vertices are skipped at the call site because their
+        # boolean phases are ambiguous with measurement outcomes.
+        raise ValueError(
+            "Unsupported vertex type {} for conditional gate "
+            "extraction.".format(vertex_type))
+    return ConditionalGate(reg_name, cond_value, inner_gate, reg_size)
+
 
 def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
     inputs = g.inputs()
@@ -83,7 +185,23 @@ def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
                 # (The corresponding Reset gate is emitted when the state
                 # preparation vertex on this qubit is processed.)
                 continue
-            if phase!=0 and not split_phases:
+            if isinstance(phase, Poly):
+                # Only extract Z-type vertices as conditional gates.
+                # X-type vertices with boolean phases are ambiguous:
+                # measurement outcomes (from Measurement.to_graph_symbolic_boolean)
+                # produce the same X spider structure as conditional NOT/XPhase
+                # gates, so we cannot distinguish them here.  Conditional
+                # Z rotations are unambiguous because measurements never
+                # create Z spiders with boolean phases.
+                cgate = None
+                if t == VertexType.Z:
+                    cgate = _poly_phase_to_conditional_gate(phase, t, int(q))
+                if cgate is not None:
+                    c.add_gate(cgate)
+                elif phase != 0:
+                    gate_name = "ZPhase" if t == VertexType.Z else "XPhase"
+                    c.add_gate(gate_name, q, phase=phase)
+            elif phase!=0 and not split_phases:
                 if t == VertexType.Z: c.add_gate("ZPhase", q, phase=phase)
                 else: c.add_gate("XPhase", q, phase=phase)
             elif t == VertexType.Z and phase.denominator == 2:

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -21,7 +21,7 @@ from fractions import Fraction
 from typing import List, Dict, Tuple, Optional
 
 from . import Circuit
-from .gates import Gate, qasm_gate_table, Measurement, Reset
+from .gates import Gate, qasm_gate_table, Measurement, Reset, ConditionalGate
 from ..utils import settings
 
 
@@ -76,7 +76,8 @@ class QASMParser(object):
             j = data.find("}", i)
             self.parse_custom_gate(data[i:j+1])
             data = data[:i] + data[j+1:]
-        # parse the regular commands
+        data = self._expand_if_blocks(data)
+        # Parse the regular commands.
         commands = [s.strip() for s in data.split(";") if s.strip()]
         for c in commands:
             self.gates.extend(self.parse_command(c, self.registers))
@@ -86,6 +87,42 @@ class QASMParser(object):
         circ.gates = self.gates
         self.circuit = circ
         return self.circuit
+
+    @staticmethod
+    def _expand_if_blocks(s: str) -> str:
+        """Expand braced if-blocks into flat if-statements.
+
+        E.g. ``if (c==1) { x q[0]; z q[1]; }`` becomes
+        ``if (c==1) x q[0]; if (c==1) z q[1];``
+
+        This is done before semicolon-splitting so that the braces do
+        not break the command boundaries.  Nested if-blocks (e.g.
+        ``if (c==1) { if (c==0) { x q[0]; } }``) are rejected.
+        """
+        pattern = re.compile(r'if\s*\([^)]*\)\s*\{')
+        while True:
+            m = pattern.search(s)
+            if m is None:
+                break
+            prefix = m.group()          # e.g. "if (c==1) {"
+            condition = prefix[:prefix.rfind('{')].strip()  # "if (c==1)"
+            brace_start = m.end()
+            try:
+                brace_end = s.index('}', brace_start)
+            except ValueError:
+                raise TypeError(
+                    "Unterminated if-block (missing closing '}}') near: "
+                    "{}".format(s[m.start():m.start() + 80].strip()))
+            body = s[brace_start:brace_end]
+            # Reject nested if-blocks.
+            if '{' in body:
+                raise TypeError(
+                    "Nested if-blocks are not supported: {}".format(
+                        s[m.start():brace_end + 1].strip()))
+            inner_cmds = [c.strip() for c in body.split(';') if c.strip()]
+            expanded = '; '.join(condition + ' ' + c for c in inner_cmds) + ';'
+            s = s[:m.start()] + expanded + s[brace_end + 1:]
+        return s
 
     def parse_custom_gate(self, data: str) -> None:
         data = data[5:]
@@ -136,7 +173,7 @@ class QASMParser(object):
         phases = []
         if left_bracket != -1:
             if right_bracket == -1:
-                raise TypeError(f"Mismatched bracket: {name}.")
+                raise TypeError("Mismatched bracket: {}.".format(name))
             vals = name[left_bracket+1:right_bracket].split(',')
             phases = [self.parse_phase_arg(val) for val in vals]
             name = name[:left_bracket]
@@ -144,6 +181,20 @@ class QASMParser(object):
 
     def parse_command(self, c: str, registers: Dict[str,Tuple[int,int]]) -> List[Gate]:
         gates: List[Gate] = []
+        # Handle `if (creg == val) gate args;` before extract_command_parts,
+        # because the parentheses in `if(...)` confuse the phase parser.
+        if_match = re.match(r'if\s*\(\s*(\w+)\s*==\s*(\d+)\s*\)\s*(.*)', c)
+        if if_match:
+            reg_name = if_match.group(1)
+            cond_val = int(if_match.group(2))
+            inner_cmd = if_match.group(3)
+            if reg_name not in self.cregisters:
+                raise TypeError("Unknown classical register '{}'".format(reg_name))
+            reg_size = self.cregisters[reg_name]
+            inner_gates = self.parse_command(inner_cmd, registers)
+            for ig in inner_gates:
+                gates.append(ConditionalGate(reg_name, cond_val, ig, reg_size))
+            return gates
         name, phases, args = self.extract_command_parts(c)
         if name in ("barrier", "id"): return gates
         if name == "creg":
@@ -172,7 +223,7 @@ class QASMParser(object):
                         "of size {}".format(
                             result_index, result_reg_name,
                             self.cregisters[result_reg_name]))
-                gate = Measurement(target_qbit, result_symbol=f"{result_reg_name}[{result_index}]")
+                gate = Measurement(target_qbit, result_symbol="{}[{}]".format(result_reg_name, result_index))
                 gates.append(gate)
             else:
                 # Register broadcast: measure q -> c.
@@ -189,7 +240,7 @@ class QASMParser(object):
                             target, size, result_bit,
                             self.cregisters[result_bit]))
                 for i in range(size):
-                    gate = Measurement(start + i, result_symbol=f"{result_bit}[{i}]")
+                    gate = Measurement(start + i, result_symbol="{}[{}]".format(result_bit, i))
                     gates.append(gate)
             return gates
         if name == "reset":
@@ -210,7 +261,7 @@ class QASMParser(object):
                     for i in range(size):
                         gates.append(Reset(start + i))
             return gates
-        if name in ("opaque", "if"):
+        if name in ("opaque",):
             raise TypeError("Unsupported operation {}".format(c))
         if name == "qreg":
             regname, sizep = args[0].split("[",1)
@@ -315,7 +366,7 @@ class QASMParser(object):
                     elif val == '-': phase = -1
                     else: phase = float(val)
             except: raise TypeError("Invalid specification {}".format(val))
-        phase = Fraction(phase).limit_denominator(100000000)
+        phase = Fraction(phase).limit_denominator(settings.float_to_fraction_max_denominator)
         return phase
 
 

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -798,6 +798,402 @@ class TestQASM(unittest.TestCase):
             """)
         self.assertIn("is larger than", str(ctx.exception))
 
+    def test_parse_if_single_bit(self):
+        """Test parsing a single-bit conditional gate."""
+        from pyzx.circuit.gates import ConditionalGate, NOT
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if(c==1) x q[0];
+        """)
+        self.assertEqual(len(c.gates), 1)
+        gate = c.gates[0]
+        self.assertIsInstance(gate, ConditionalGate)
+        self.assertEqual(gate.condition_register, "c")
+        self.assertEqual(gate.condition_value, 1)
+        self.assertIsInstance(gate.inner_gate, NOT)
+        self.assertEqual(gate.inner_gate.target, 0)
+        self.assertEqual(gate.register_size, 1)
+
+    def test_parse_if_multi_bit(self):
+        """Test parsing a conditional gate with a multi-bit register."""
+        from pyzx.circuit.gates import ConditionalGate, ZPhase
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[3];
+        if(c==5) rz(pi) q[0];
+        """)
+        self.assertEqual(len(c.gates), 1)
+        gate = c.gates[0]
+        self.assertIsInstance(gate, ConditionalGate)
+        self.assertEqual(gate.condition_register, "c")
+        self.assertEqual(gate.condition_value, 5)
+        self.assertIsInstance(gate.inner_gate, ZPhase)
+        self.assertEqual(gate.register_size, 3)
+
+    def test_parse_if_zero_condition(self):
+        """Test parsing if (c == 0), which negates all bits."""
+        from pyzx.circuit.gates import ConditionalGate
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[2];
+        if(c==0) z q[0];
+        """)
+        self.assertEqual(len(c.gates), 1)
+        gate = c.gates[0]
+        self.assertIsInstance(gate, ConditionalGate)
+        self.assertEqual(gate.condition_value, 0)
+        self.assertEqual(gate.register_size, 2)
+
+    def test_conditional_gate_to_graph_z(self):
+        """Test that a conditional Z gate creates a vertex with symbolic boolean phase."""
+        from pyzx.circuit.gates import ConditionalGate, Measurement, Z
+        from pyzx.symbolic import Poly
+        c = Circuit(1)
+        c.gates = [
+            Measurement(0, result_symbol="c[0]"),
+            ConditionalGate("c", 1, Z(0), 1),
+        ]
+        g = c.to_graph()
+        # Find vertices with symbolic phases.
+        sym_verts = [v for v in g.vertices() if isinstance(g.phase(v), Poly)]
+        # Should have at least 2: the measurement outcome and the conditional gate.
+        self.assertGreaterEqual(len(sym_verts), 2)
+
+    def test_conditional_gate_to_graph_negated(self):
+        """Test that if(c==0) round-trips through graph extraction."""
+        from pyzx.circuit.gates import ConditionalGate, Z
+        from pyzx.circuit.graphparser import graph_to_circuit
+        from pyzx.symbolic import Poly
+        c1 = Circuit(1)
+        c1.gates = [ConditionalGate("c", 0, Z(0), 1)]
+        g = c1.to_graph()
+        sym_verts = [v for v in g.vertices() if isinstance(g.phase(v), Poly)]
+        self.assertEqual(len(sym_verts), 1)
+        # Extract back and verify the condition is recovered.
+        c2 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_register, "c")
+        self.assertEqual(cond_gates[0].condition_value, 0)
+
+    def test_conditional_gate_multi_bit_graph_extraction(self):
+        """Test that multi-bit Z conditions (including 0-bits) round-trip through graph."""
+        from pyzx.circuit.gates import ConditionalGate, Z
+        from pyzx.circuit.graphparser import graph_to_circuit
+        # if(c==1) with a 2-bit register: bit 0 set, bit 1 clear.
+        c1 = Circuit(1)
+        c1.gates = [ConditionalGate("c", 1, Z(0), 2)]
+        g = c1.to_graph()
+        c2 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_value, 1)
+        self.assertEqual(cond_gates[0].register_size, 2)
+        # if(c==0) with a 2-bit register: both bits clear.
+        c3 = Circuit(1)
+        c3.gates = [ConditionalGate("c", 0, Z(0), 2)]
+        g = c3.to_graph()
+        c4 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c4.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_value, 0)
+        self.assertEqual(cond_gates[0].register_size, 2)
+
+    def test_conditional_gate_qasm_round_trip(self):
+        """Test that conditional gates survive a QASM round-trip."""
+        from pyzx.circuit.gates import ConditionalGate
+        qasm_in = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        creg c[1];
+        h q[0];
+        measure q[0] -> c[0];
+        if(c==1) x q[1];
+        """
+        c1 = Circuit.from_qasm(qasm_in)
+        qasm_out = c1.to_qasm()
+        self.assertIn("if(c==1)", qasm_out)
+        self.assertIn("creg c[1]", qasm_out)
+        c2 = Circuit.from_qasm(qasm_out)
+        self.assertEqual(len(c1.gates), len(c2.gates))
+        for g1, g2 in zip(c1.gates, c2.gates):
+            self.assertEqual(type(g1), type(g2))
+
+    def test_conditional_gate_graph_extraction(self):
+        """Test that a conditional gate round-trips through the graph."""
+        from pyzx.circuit.gates import ConditionalGate, Z
+        from pyzx.circuit.graphparser import graph_to_circuit
+        c1 = Circuit(1)
+        c1.gates = [ConditionalGate("c", 1, Z(0), 1)]
+        g = c1.to_graph()
+        c2 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_register, "c")
+        self.assertEqual(cond_gates[0].condition_value, 1)
+
+    def test_qec_measure_conditional_correction(self):
+        """End-to-end test: measure + conditional Pauli correction (QEC pattern)."""
+        from pyzx.circuit.gates import ConditionalGate, Measurement
+        qasm = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c[1];
+        cx q[0],q[1];
+        cx q[0],q[2];
+        h q[0];
+        measure q[0] -> c[0];
+        if(c==1) z q[1];
+        if(c==1) z q[2];
+        """
+        c = Circuit.from_qasm(qasm)
+        # 2 CNOTs + 1 HAD + 1 measure + 2 conditional gates = 6.
+        self.assertEqual(len(c.gates), 6)
+        self.assertIsInstance(c.gates[3], Measurement)
+        self.assertIsInstance(c.gates[4], ConditionalGate)
+        self.assertIsInstance(c.gates[5], ConditionalGate)
+
+        # Convert to graph and back.
+        g = c.to_graph()
+        qasm_out = c.to_qasm()
+        c2 = Circuit.from_qasm(qasm_out)
+        self.assertEqual(len(c.gates), len(c2.gates))
+
+    def test_conditional_unsupported_gate(self):
+        """Test that unsupported conditional gates raise NotImplementedError."""
+        from pyzx.circuit.gates import ConditionalGate, HAD
+        c = Circuit(1)
+        c.gates = [ConditionalGate("c", 1, HAD(0), 1)]
+        with self.assertRaises(NotImplementedError):
+            c.to_graph()
+
+    def test_conditional_gate_with_spaces(self):
+        """Test that if statement parsing tolerates whitespace variations."""
+        from pyzx.circuit.gates import ConditionalGate
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if ( c == 1 ) x q[0];
+        """)
+        self.assertEqual(len(c.gates), 1)
+        self.assertIsInstance(c.gates[0], ConditionalGate)
+
+    def test_parse_if_braced_block_qasm3(self):
+        """Test parsing OpenQASM 3 braced if-block with multiple gates."""
+        from pyzx.circuit.gates import ConditionalGate, NOT, Z
+        c = Circuit.from_qasm("""
+        OPENQASM 3;
+        include "stdgates.inc";
+        qubit[2] q;
+        bit[1] c;
+        if (c == 1) { x q[0]; z q[1]; }
+        """)
+        self.assertEqual(len(c.gates), 2)
+        self.assertIsInstance(c.gates[0], ConditionalGate)
+        self.assertIsInstance(c.gates[1], ConditionalGate)
+        self.assertIsInstance(c.gates[0].inner_gate, NOT)
+        self.assertIsInstance(c.gates[1].inner_gate, Z)
+        self.assertEqual(c.gates[0].inner_gate.target, 0)
+        self.assertEqual(c.gates[1].inner_gate.target, 1)
+
+    def test_parse_if_braced_block_qasm2(self):
+        """Test that braced if-blocks also work in OpenQASM 2."""
+        from pyzx.circuit.gates import ConditionalGate
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[2];
+        creg c[1];
+        if(c==1) { x q[0]; z q[1]; }
+        """)
+        self.assertEqual(len(c.gates), 2)
+        for gate in c.gates:
+            self.assertIsInstance(gate, ConditionalGate)
+            self.assertEqual(gate.condition_register, "c")
+            self.assertEqual(gate.condition_value, 1)
+
+    def test_parse_if_braced_single_gate(self):
+        """Test that a braced if-block with a single gate works."""
+        from pyzx.circuit.gates import ConditionalGate, NOT
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if(c==1) { x q[0]; }
+        """)
+        self.assertEqual(len(c.gates), 1)
+        self.assertIsInstance(c.gates[0], ConditionalGate)
+        self.assertIsInstance(c.gates[0].inner_gate, NOT)
+
+    def test_parse_if_nested_braces_rejected(self):
+        """Nested if-blocks should raise a clear error."""
+        with self.assertRaises(TypeError) as ctx:
+            Circuit.from_qasm("""
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            creg c[1];
+            if(c==1) { if(c==0) { x q[0]; } }
+            """)
+        self.assertIn("Nested if-blocks", str(ctx.exception))
+
+    def test_expand_if_blocks_static_method(self):
+        """_expand_if_blocks is a static method callable on the parser class."""
+        from pyzx.circuit.qasmparser import QASMParser
+        result = QASMParser._expand_if_blocks(
+            "if (c==1) { x q[0]; z q[1]; }")
+        self.assertIn("if (c==1) x q[0]", result)
+        self.assertIn("if (c==1) z q[1]", result)
+        self.assertNotIn("{", result)
+
+    def test_creg_declaration_for_result_bit(self):
+        """Measurement with result_bit should produce a creg declaration."""
+        from pyzx.circuit.gates import Measurement
+        c = Circuit(2)
+        c.gates = [Measurement(0, result_bit=0), Measurement(1, result_bit=2)]
+        qasm = c.to_qasm()
+        self.assertIn("creg c[3]", qasm)
+
+    def test_invalid_result_symbol_rejected(self):
+        """Measurement with result_symbol missing '[' should raise in to_qasm."""
+        from pyzx.circuit.gates import Measurement
+        m = Measurement(0, result_symbol="bad_name")
+        with self.assertRaises(TypeError) as ctx:
+            m.to_qasm()
+        self.assertIn("not a valid QASM", str(ctx.exception))
+
+    def test_conditional_value_out_of_range(self):
+        """Condition value exceeding register capacity should raise ValueError."""
+        from pyzx.circuit.gates import ConditionalGate, Z
+        with self.assertRaises(ValueError) as ctx:
+            ConditionalGate("c", 5, Z(0), 2)  # 5 >= 2^2
+        self.assertIn("out of range", str(ctx.exception))
+        # Boundary: 3 fits in 2 bits, 4 does not.
+        ConditionalGate("c", 3, Z(0), 2)  # should not raise
+        with self.assertRaises(ValueError):
+            ConditionalGate("c", 4, Z(0), 2)
+        with self.assertRaises(ValueError):
+            ConditionalGate("c", -1, Z(0), 2)
+
+    def test_measurement_result_bit_variable_name(self):
+        """Measurement with result_bit should create a c[i] variable matching ConditionalGate."""
+        from pyzx.circuit.gates import Measurement, ConditionalGate, Z
+        from pyzx.symbolic import Poly
+        c = Circuit(2, bit_amount=1)
+        c.gates = [
+            Measurement(0, result_bit=0),
+            ConditionalGate("c", 1, Z(1), 1),
+        ]
+        g = c.to_graph()
+        # Both should use the same variable name "c[0]".
+        sym_phases = [g.phase(v) for v in g.vertices()
+                      if isinstance(g.phase(v), Poly)]
+        var_names = set()
+        for p in sym_phases:
+            for _, term in p.terms:
+                for var, _ in term.vars:
+                    var_names.add(var.name)
+        self.assertEqual(var_names, {"c[0]"})
+
+    def test_measure_not_extracted_as_conditional(self):
+        """Measurement X spiders must not be misidentified as conditional gates."""
+        from pyzx.circuit.gates import ConditionalGate, Measurement, Z
+        from pyzx.circuit.graphparser import graph_to_circuit
+        c1 = Circuit(2)
+        c1.gates = [
+            Measurement(0, result_symbol="c[0]"),
+            ConditionalGate("c", 1, Z(0), 1),
+        ]
+        g = c1.to_graph()
+        c2 = graph_to_circuit(g)
+        # Only the Z-type conditional should be extracted; the measurement
+        # X spider should NOT become a second ConditionalGate.
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_value, 1)
+
+    def test_conditional_s_graph_round_trip(self):
+        """Test that conditional S gate preserves phase through graph."""
+        from pyzx.circuit.gates import ConditionalGate, S
+        from pyzx.circuit.graphparser import graph_to_circuit
+        c1 = Circuit(1)
+        c1.gates = [ConditionalGate("c", 1, S(0), 1)]
+        g = c1.to_graph()
+        c2 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertIsInstance(cond_gates[0].inner_gate, S)
+        self.assertEqual(cond_gates[0].inner_gate.phase, Fraction(1, 2))
+
+    def test_conditional_sdg_qasm_round_trip(self):
+        """Test that conditional sdg survives QASM round-trip."""
+        from pyzx.circuit.gates import ConditionalGate, S
+        c1 = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        creg c[1];
+        if(c==1) sdg q[0];
+        """)
+        qasm_out = c1.to_qasm()
+        self.assertIn("sdg", qasm_out)
+        c2 = Circuit.from_qasm(qasm_out)
+        self.assertEqual(len(c2.gates), 1)
+        self.assertIsInstance(c2.gates[0], ConditionalGate)
+        self.assertIsInstance(c2.gates[0].inner_gate, S)
+        self.assertTrue(c2.gates[0].inner_gate.adjoint)
+
+    def test_conditional_broadcast_over_register(self):
+        """Test that if(c==1) x q; broadcasts over the entire register."""
+        from pyzx.circuit.gates import ConditionalGate
+        c = Circuit.from_qasm("""
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        creg c[1];
+        if(c==1) x q;
+        """)
+        self.assertEqual(len(c.gates), 3)
+        for i, gate in enumerate(c.gates):
+            self.assertIsInstance(gate, ConditionalGate)
+            self.assertEqual(gate.inner_gate.target, i)
+
+    def test_conditional_unknown_register_error(self):
+        """Test that referencing an undeclared creg raises TypeError."""
+        with self.assertRaises(TypeError) as ctx:
+            Circuit.from_qasm("""
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            if(c==1) x q[0];
+            """)
+        self.assertIn("Unknown classical register", str(ctx.exception))
+
+    def test_conditional_multi_bit_partial_value_graph_round_trip(self):
+        """Test if(c==2) with 2-bit register (bit 1 set, bit 0 clear)."""
+        from pyzx.circuit.gates import ConditionalGate, Z
+        from pyzx.circuit.graphparser import graph_to_circuit
+        c1 = Circuit(1)
+        c1.gates = [ConditionalGate("c", 2, Z(0), 2)]
+        g = c1.to_graph()
+        c2 = graph_to_circuit(g)
+        cond_gates = [gt for gt in c2.gates if isinstance(gt, ConditionalGate)]
+        self.assertEqual(len(cond_gates), 1)
+        self.assertEqual(cond_gates[0].condition_value, 2)
+        self.assertEqual(cond_gates[0].register_size, 2)
+
     def test_classical_bits_in_c_mapper(self):
         """Classical bit labels should be in c_mapper, not q_mapper."""
         from pyzx.circuit.graphparser import circuit_to_graph
@@ -875,16 +1271,9 @@ class TestQASM(unittest.TestCase):
         This is the T-injection protocol example from tqec/tqec#708: prepare an
         ancilla in |T>, CNOT with the data qubit, measure the ancilla, and
         conditionally apply S-dagger. Three rounds are performed.
-
-        The ``if(c==1) sdg q[0];`` conditional corrections are not yet
-        supported by the parser (they require classical control / feedforward).
-        For now they are omitted, and the test verifies the structural
-        skeleton: reset, gates, measure, and QASM round-trip.
         """
-        from pyzx.circuit.gates import Measurement, Reset
+        from pyzx.circuit.gates import ConditionalGate, Measurement, Reset
 
-        # Full circuit would include ``if(c==1) sdg q[0];`` after each
-        # measure, but that requires feedforward support (ConditionalGate).
         qasm = """
         OPENQASM 2.0;
         include "qelib1.inc";
@@ -897,6 +1286,7 @@ class TestQASM(unittest.TestCase):
         cx q[0],q[1];
         h q[1];
         measure q[1] -> c[0];
+        if(c==1) sdg q[0];
         h q[0];
         reset q[1];
         h q[1];
@@ -904,6 +1294,7 @@ class TestQASM(unittest.TestCase):
         cx q[0],q[1];
         h q[1];
         measure q[1] -> c[0];
+        if(c==1) sdg q[0];
         h q[0];
         reset q[1];
         h q[1];
@@ -911,6 +1302,7 @@ class TestQASM(unittest.TestCase):
         cx q[0],q[1];
         h q[1];
         measure q[1] -> c[0];
+        if(c==1) sdg q[0];
         """
 
         # Parse.
@@ -919,11 +1311,17 @@ class TestQASM(unittest.TestCase):
 
         # Count gate types.
         measurements = [g for g in c.gates if isinstance(g, Measurement)]
+        conditionals = [g for g in c.gates if isinstance(g, ConditionalGate)]
         resets = [g for g in c.gates if isinstance(g, Reset)]
         self.assertEqual(len(measurements), 3)
+        self.assertEqual(len(conditionals), 3)
         self.assertEqual(len(resets), 3)
-        # TODO: once feedforward is implemented, assert 3 ConditionalGate
-        # instances wrapping sdg on q[0], each conditioned on c==1.
+
+        # Each conditional should be sdg on q[0].
+        for cg in conditionals:
+            self.assertEqual(cg.condition_register, "c")
+            self.assertEqual(cg.condition_value, 1)
+            self.assertEqual(cg.inner_gate.target, 0)
 
         # Convert to graph.
         g = c.to_graph()


### PR DESCRIPTION
Fixes #345. Relates to https://github.com/tqec/tqec/issues/708.

* parses OpenQASM 2/3 `if (creg == val) gate args;` statements (including braced blocks)
* converts conditional single-qubit rotations to ZX-diagrams with symbolic boolean phases
* extracts them back to ConditionalGate objects
* Note: only Z-type vertices are extracted as conditional gates, X-type vertices are left as-is to avoid ambiguity with measurement outcome spiders.