### PR TITLE
Fix edge sorting in `tensorfy_naive` to correctly handle W_IO edges

### DIFF
--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -211,7 +211,7 @@ def tensorfy_naive(g: 'BaseGraph[VT,ET]', preserve_scalar: bool = True) -> NDArr
                     raise NotImplementedError(f"Tensor contraction with {repr(sl)} self-loops is not implemented.")
             nn = list(filter(lambda n: rows[n]<r or (rows[n]==r and n<v), neigh)) # TODO: allow ordering on vertex indices?
             ety = {n:g.edge_type(g.edge(v,n)) for n in nn}
-            nn.sort(key=lambda n: ety[n])
+            nn.sort(key=lambda n: ety[n] == EdgeType.HADAMARD)
             for n in nn:
                 if ety[n] == EdgeType.HADAMARD:
                     t = np.tensordot(t,had,(0,0)) # Hadamard edges are moved to the last index of t


### PR DESCRIPTION
### Summary

Fix incorrect tensor contraction ordering in `tensorfy_naive` when graphs contain `W_IO` edges alongside `HADAMARD` edges. 
Fixes https://github.com/zxcalc/zxlive/issues/361

### Problem

In `tensorfy_naive` (`pyzx/tensor.py:214`), neighbor vertices are sorted by edge type so that Hadamard edges come last — this is required because the subsequent contraction loop applies Hadamard matrices to the trailing indices of the tensor.

The old sort key was:

```python
nn.sort(key=lambda n: ety[n])
```

This sorts by the raw `IntEnum` value (`SIMPLE=1`, `HADAMARD=2`, `W_IO=3`). Because `W_IO` (3) is greater than `HADAMARD` (2), any `W_IO` edges get sorted *after* Hadamard edges. This breaks the contraction logic, which assumes all Hadamard edges are at the end of the sorted neighbor list.

### Fix

The sort key is changed to a boolean predicate:

```python
nn.sort(key=lambda n: ety[n] == EdgeType.HADAMARD)
```

This maps non-Hadamard edges (both `SIMPLE` and `W_IO`) to `False` (0) and Hadamard edges to `True` (1), ensuring Hadamard edges are always sorted last regardless of what other edge types are present. The relative order among non-Hadamard edges is preserved by Python's stable sort.

### Impact

This fixes tensor verification (`compare_tensors`) for graphs containing W nodes (which use `W_IO` edges), where the previous sorting could silently produce incorrect tensor values.
