### PR TITLE
spread out parallel-edge vertices created from bialgebra rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - `subgraph_from_vertices` copies only variables used in the subgraph (by @dlyongemallo).
 - `extract_circuit` raises `ValueError` for graphs containing ground vertices or mismatched input/output counts, instead of a `KeyError` crash (by @dlyongemallo).
 - Missed copying `_grounds` in `clone()`, incorrectly checking destination `is_ground` instead of source in `tensor()` (by @dlyongemallo).
+- Bialgebra rule to accept parallel edges; spread out the resulting vertices so they don't overlap (by @dlyongemallo).
 
 ### Changed
 - Migrated project configuration from `setup.py` to `pyproject.toml`. Make the `galois` package an optional dependency, as it is only used in `pyzx.web`. (by @dlyongemallo)

--- a/pyzx/rewrite_rules/bialgebra_rule.py
+++ b/pyzx/rewrite_rules/bialgebra_rule.py
@@ -53,7 +53,7 @@ def check_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT) -> bool:
     Supports both Z-X bialgebra and X-H bialgebra (X spider with standard H-box)."""
     if not (v1 in g.vertices() and v2 in g.vertices()): return False
 
-    if not (g.num_edges(v1, v2) == 1 and
+    if not (g.num_edges(v1, v2) >= 1 and
             g.num_edges(v1, v1) == 0 and
             g.num_edges(v2, v2) == 0 and
             EdgeType.SIMPLE in [g.edge_type(edge) for edge in g.edges(v1,v2)]):
@@ -130,18 +130,36 @@ def unsafe_bialgebra(g: BaseGraph[VT,ET], v1: VT, v2: VT ) -> bool:
 
     for i, j in [(0, 1), (1, 0)]:
         multi_edge_found = False
+        neighbour_edge_count: dict = {}
         for e in g.incident_edges(v[i]):
             source, target = g.edge_st(e)
             other_vertex = source if source != v[i] else target
             if other_vertex != v[j] or multi_edge_found:
                 q = 0.4*g.qubit(other_vertex) + 0.6*g.qubit(v[i])
                 r = 0.4*g.row(other_vertex) + 0.6*g.row(v[i])
+                # Offset vertices from parallel edges to the same
+                # neighbour so they don't overlap.
+                n = neighbour_edge_count.get(other_vertex, 0)
+                if n > 0:
+                    dq_n = g.qubit(other_vertex) - g.qubit(v[i])
+                    dr_n = g.row(other_vertex) - g.row(v[i])
+                    len_n = (dq_n**2 + dr_n**2)**0.5
+                    if len_n > 0:
+                        pq, pr = -dr_n / len_n, dq_n / len_n
+                    else:
+                        pq, pr = 1.0, 0.0
+                    q += n * 0.5 * pq
+                    r += n * 0.5 * pr
+                neighbour_edge_count[other_vertex] = n + 1
                 newv = g.add_vertex(copy_type[i], qubit=q, row=r)
                 g.set_phase(newv, copy_phase[i])
                 new_verts[i].append(newv)
                 if other_vertex == v[j]:
                     q = 0.4*g.qubit(v[i]) + 0.6*g.qubit(other_vertex)
                     r = 0.4*g.row(v[i]) + 0.6*g.row(other_vertex)
+                    if n > 0:
+                        q += n * 0.5 * pq
+                        r += n * 0.5 * pr
                     newv2 = g.add_vertex(copy_type[j], qubit=q, row=r)
                     g.set_phase(newv2, copy_phase[j])
                     new_verts[j].append(newv2)

--- a/tests/test_bialgebra_rule.py
+++ b/tests/test_bialgebra_rule.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
     sys.path.append('.')
 
 from pyzx.graph import Graph
+from pyzx.graph.multigraph import Multigraph
 from pyzx.symbolic import new_var
 from pyzx.utils import EdgeType, VertexType, set_h_box_label
 from pyzx.rewrite_rules.bialgebra_rule import (
@@ -325,6 +326,65 @@ class TestBialgebraApplyXH(unittest.TestCase):
         g_orig = g.copy()
         unsafe_bialgebra(g, h, x)
         self.assertTrue(compare_tensors(g, g_orig, preserve_scalar=True))
+
+
+class TestBialgebraParallelEdgePositions(unittest.TestCase):
+    """Tests that parallel-edge vertices get distinct positions.
+
+    These tests use Multigraph with auto-simplify off, since the default
+    GraphS backend does not support true parallel edges."""
+
+    def test_parallel_edges_between_matched_pair(self):
+        """Parallel edges between the matched spiders should produce
+        offset vertex pairs with distinct positions."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        z = g.add_vertex(VertexType.Z, 0, 0)
+        x = g.add_vertex(VertexType.X, 0, 2)
+        b_in = g.add_vertex(VertexType.BOUNDARY, 0, -1)
+        b_out = g.add_vertex(VertexType.BOUNDARY, 0, 3)
+        g.add_edge((b_in, z))
+        for _ in range(3):
+            g.add_edge((z, x))
+        g.add_edge((x, b_out))
+
+        verts_before = set(g.vertices())
+        self.assertTrue(bialgebra(g, z, x))
+        new_verts = [v for v in g.vertices() if v not in verts_before
+                     and g.type(v) != VertexType.BOUNDARY]
+        positions = [(g.qubit(v), g.row(v)) for v in new_verts]
+        self.assertEqual(len(set(positions)), len(positions),
+                         f"Overlapping positions: {positions}")
+
+    def test_parallel_edges_to_third_vertex(self):
+        """Regression test for zxcalc/zxlive#306: applying bialgebra
+        to a pair where one spider has parallel edges to a third vertex
+        must not produce overlapping vertices."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v0 = g.add_vertex(VertexType.Z, qubit=-3.0, row=-2.5)
+        v1 = g.add_vertex(VertexType.Z, qubit=-1.75, row=-1.0)
+        v2 = g.add_vertex(VertexType.X, qubit=-1.75, row=-3.0)
+        for q, r in [(-3, -5), (-1.75, -5), (-3, 0.75),
+                      (-1.75, 0.75), (-0.5, 0.5), (-0.25, -2)]:
+            g.add_vertex(VertexType.BOUNDARY, qubit=q, row=r)
+        # Edges matching zxlive#306 test case (v0-v2 has 2 parallel edges).
+        g.add_edge((v0, 3))
+        g.add_edge((v0, v2))
+        g.add_edge((v0, v2))
+        g.add_edge((v0, 5))
+        g.add_edge((v1, v2))
+        g.add_edge((v1, 6))
+        g.add_edge((v1, 7))
+        g.add_edge((v2, 4))
+        g.add_edge((v2, 8))
+
+        self.assertTrue(bialgebra(g, v1, v2))
+        non_boundary = [v for v in g.vertices()
+                        if g.type(v) != VertexType.BOUNDARY]
+        positions = [(g.qubit(v), g.row(v)) for v in non_boundary]
+        self.assertEqual(len(set(positions)), len(positions),
+                         f"Overlapping positions: {positions}")
 
 
 class TestCheckBialgebraReduce(unittest.TestCase):


### PR DESCRIPTION
## Description

This change allows parallel edges through `check_algebra` and spreads vertices created from parallel edges out perpendicularly to the `v1`-`v2` axis. 

## Related issue

https://github.com/zxcalc/zxlive/issues/306

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.