### PR TITLE
fix multigraph handling of parallel mixed simple/Hadamard edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ## [Unreleased]
 
+### Fixed
+- Multigraph handling of parallel mixed simple/Hadamard edges in tensor contraction, several rewrite rules, and `PauliWeb` (by @dlyongemallo).
+
 ## [0.10.2] - 2026-05-01
 
 ## [0.10.1] - 2026-04-28

--- a/pyzx/pauliweb.py
+++ b/pyzx/pauliweb.py
@@ -39,6 +39,28 @@ def h_pauli(p: str) -> str:
     else: return 'X'
 
 
+def _resolve_edge(g: BaseGraph[VT, ET], s: VT, t: VT) -> ET:
+    """Resolve a single edge between `s` and `t` for PauliWeb's per-pair semantics.
+
+    PauliWeb labels edges by ordered vertex pair, which has no canonical answer
+    on multigraphs with mixed parallel edges. We prefer the SIMPLE edge when
+    both types exist; otherwise we return whatever edge is there.
+    """
+    fallback: Optional[ET] = None
+    for e in g.edges(s, t):
+        if g.edge_type(e) == EdgeType.SIMPLE:
+            return e
+        fallback = e
+    if fallback is not None:
+        return fallback
+    raise ValueError(f"No edge between {s} and {t}")
+
+
+def _resolve_edge_type(g: BaseGraph[VT, ET], s: VT, t: VT) -> EdgeType:
+    """Like :func:`_resolve_edge` but returns the resolved edge type."""
+    return g.edge_type(_resolve_edge(g, s, t))
+
+
 class PauliWeb(Generic[VT, ET]):
     """A Pauli web
     
@@ -93,7 +115,7 @@ class PauliWeb(Generic[VT, ET]):
     
     def add_edge(self, v_pair: Tuple[VT, VT], pauli: str):
         s, t = v_pair
-        et = self.g.edge_type(self.g.edge(s, t))
+        et = _resolve_edge_type(self.g, s, t)
         self.add_half_edge((s,t), pauli)
         self.add_half_edge((t,s), pauli if et == EdgeType.SIMPLE else h_pauli(pauli))
     
@@ -132,7 +154,7 @@ class PauliWeb(Generic[VT, ET]):
             p0 = self.es.get((s,t), 'I')
             p1 = self.es.get((t,s), 'I')
             
-            e = g.edge(s, t)
+            e = _resolve_edge(g, s, t)
             et = g.edge_type(e)
             g.remove_edge(e)
             

--- a/pyzx/rewrite_rules/add_identity_rule.py
+++ b/pyzx/rewrite_rules/add_identity_rule.py
@@ -38,10 +38,24 @@ from pyzx.graph.base import BaseGraph, VT, ET, upair
 
 
 def check_edge(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
-    """Checks if two vertices are connected in the graph.
+    """Checks if two vertices are connected by an unambiguous SIMPLE or HADAMARD edge.
+
+    Returns False if `v` and `w` are the same vertex (self-loops are not
+    supported), if they are connected by parallel edges of more than one type,
+    since the rule then has no canonical edge to act on, or if any connecting
+    edge is of type ``W_IO`` (which the rule does not support).
      """
+    if v == w: return False
     if not (v in g.vertices() and w in g.vertices()): return False
     if not g.connected(v,w): return False
+    if g.num_edges(v, w, EdgeType.W_IO) > 0:
+        return False
+    types_present = sum(
+        1 for et in (EdgeType.SIMPLE, EdgeType.HADAMARD)
+        if g.num_edges(v, w, et) > 0
+    )
+    if types_present != 1:
+        return False
     return True
 
 def add_Z_identity( g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
@@ -52,7 +66,11 @@ def add_Z_identity( g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
 
 
 def unsafe_add_Z_identity(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
-    """Adds a Z spider to the edge given by the input vertices"""
+    """Adds a Z spider to the edge given by the input vertices.
+
+    Assumes there is a unique edge type between `v` and `w`; on a multigraph
+    with mixed parallel edges, callers must pre-disambiguate (e.g. by gating
+    on :func:`check_edge`)."""
     etab = {}
 
     e = g.edge(v, w)

--- a/pyzx/rewrite_rules/hopf_rule.py
+++ b/pyzx/rewrite_rules/hopf_rule.py
@@ -74,11 +74,20 @@ def unsafe_hopf(g: BaseGraph[VT, ET], v: VT, w: VT) -> bool:
     etab: Dict[Tuple[VT, VT], List[int]] = dict()
     rem_edges: List[ET] = []
 
-    et = g.edge_type(g.edge(v, w))
+    # Determine the edge type to remove from the spider colours, matching
+    # the logic in `check_hopf`. Looking up the type via `g.edge(v, w)` is
+    # unsafe on multigraphs where parallel edges of mixed types may coexist.
+    if vertex_is_z_like(g.type(v)) == vertex_is_z_like(g.type(w)):
+        et = EdgeType.HADAMARD
+    else:
+        et = EdgeType.SIMPLE
 
-    n = g.num_edges(v, w, et)
+    # Filter via ``g.edges`` rather than ``g.edge(v, w, et)``: the ``et``
+    # parameter is not supported on all graph backends.
+    matching = [e for e in g.edges(v, w) if g.edge_type(e) == et]
+    n = len(matching)
     parity = n % 2
-    rem_edges.extend([g.edge(v, w, et)] * (n - parity))
+    rem_edges.extend(matching[: n - parity])
     g.scalar.add_power(-(n - parity))
 
     g.add_edge_table(etab)

--- a/pyzx/rewrite_rules/remove_id_rule.py
+++ b/pyzx/rewrite_rules/remove_id_rule.py
@@ -68,6 +68,13 @@ def check_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
     """Checks if the given vertex of type zx can be removed."""
     if not g.vertex_degree(v) == 2:
         return False
+    # Reject self-loops: identity removal does not cover them, and on some
+    # backends a single self-loop contributes 2 to ``vertex_degree`` while
+    # producing only one entry in ``incident_edges``.
+    for e in g.incident_edges(v):
+        s, t = g.edge_st(e)
+        if s == t:
+            return False
     if g.type(v) == VertexType.Z_BOX and get_z_box_label(g, v) == 1:
         return True
     elif g.type(v) != VertexType.Z_BOX and g.phase(v) == 0:
@@ -75,15 +82,21 @@ def check_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
     return False
 
 def unsafe_remove_zx(g: BaseGraph[VT,ET], v: VT) -> bool:
-    """Removes the identity spider v of type ZX"""
-    neighbors = list(g.neighbors(v))
-    if len(neighbors) == 2:
-        v1, v2 = neighbors[0], neighbors[1]
-    else: # self loop
-        v1, v2 = neighbors[0], neighbors[0]
-    g.add_edge((v1,v2), edgetype=EdgeType.SIMPLE
-    if g.edge_type(g.edge(v,v1)) == g.edge_type(g.edge(v,v2))
-    else EdgeType.HADAMARD)
+    """Removes the identity spider v of type ZX. Does not handle self-loops,
+    which ``check_remove_zx`` rejects (a single self-loop on a degree-2 vertex
+    yields only one incident edge on some backends)."""
+    incident = list(g.incident_edges(v))
+    if len(incident) != 2:
+        return False
+    e1, e2 = incident[0], incident[1]
+    s1, t1 = g.edge_st(e1)
+    s2, t2 = g.edge_st(e2)
+    v1 = t1 if s1 == v else s1
+    v2 = t2 if s2 == v else s2
+    new_type = (EdgeType.SIMPLE
+                if g.edge_type(e1) == g.edge_type(e2)
+                else EdgeType.HADAMARD)
+    g.add_edge((v1, v2), edgetype=new_type)
     g.remove_vertex(v)
     return True
 

--- a/pyzx/tensor.py
+++ b/pyzx/tensor.py
@@ -164,10 +164,11 @@ def tensorfy_naive(g: 'BaseGraph[VT,ET]', preserve_scalar: bool = True) -> NDArr
         for v in sorted(verts_row[r]):
             if types[v] == VertexType.DUMMY:
                 continue
+            incident = list(g.incident_edges(v))
             neigh = list(itertools.chain.from_iterable(
-                set(g.edge_st(e)) - {v} for e in g.incident_edges(v)
+                set(g.edge_st(e)) - {v} for e in incident
             ))
-            self_loops = [e for e in g.incident_edges(v) if g.edge_s(e) == g.edge_t(e)]
+            self_loops = [e for e in incident if g.edge_s(e) == g.edge_t(e)]
             d = len(neigh) + len(self_loops) * 2
             if v in inputs:
                 if types[v] != VertexType.BOUNDARY: raise ValueError("Wrong type for input:", v, types[v])
@@ -209,11 +210,19 @@ def tensorfy_naive(g: 'BaseGraph[VT,ET]', preserve_scalar: bool = True) -> NDArr
                     t = np.trace(t)
                 else:
                     raise NotImplementedError(f"Tensor contraction with {repr(sl)} self-loops is not implemented.")
-            nn = list(filter(lambda n: rows[n]<r or (rows[n]==r and n<v), neigh)) # TODO: allow ordering on vertex indices?
-            ety = {n:g.edge_type(g.edge(v,n)) for n in nn}
-            nn.sort(key=lambda n: ety[n] == EdgeType.HADAMARD)
-            for n in nn:
-                if ety[n] == EdgeType.HADAMARD:
+            # Iterate over incident edges rather than neighbours so parallel
+            # edges of different types are kept as distinct legs.
+            leg_ety = []
+            for e in incident:
+                if g.edge_s(e) == g.edge_t(e): continue  # self-loop, handled above
+                s, tgt = g.edge_st(e)
+                n = tgt if s == v else s
+                if rows[n] < r or (rows[n] == r and n < v):
+                    leg_ety.append((n, g.edge_type(e)))
+            leg_ety.sort(key=lambda ne: ne[1] == EdgeType.HADAMARD)
+            nn = [n for n, _ in leg_ety]
+            for _, et in leg_ety:
+                if et == EdgeType.HADAMARD:
                     t = np.tensordot(t,had,(0,0)) # Hadamard edges are moved to the last index of t
             contr = pop_and_shift(nn,indices) #the last indices in contr correspond to hadamard contractions
             tensor = np.tensordot(tensor,t,axes=(contr,list(range(len(t.shape)-len(contr),len(t.shape)))))

--- a/tests/test_add_identity_rule.py
+++ b/tests/test_add_identity_rule.py
@@ -1,0 +1,88 @@
+# PyZX - Python library for quantum circuit rewriting
+#        and optimization using the ZX-calculus
+# Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import sys
+
+if __name__ == '__main__':
+    sys.path.append('..')
+    sys.path.append('.')
+
+from pyzx.graph.multigraph import Multigraph
+from pyzx.utils import EdgeType, VertexType
+from pyzx.rewrite_rules.add_identity_rule import check_edge, add_Z_identity
+
+
+class TestAddIdentityRule(unittest.TestCase):
+
+    def test_check_edge_rejects_mixed_parallels(self):
+        """check_edge rejects vertex pairs with mixed parallel edges, since
+        the rule has no canonical edge to act on."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        self.assertFalse(check_edge(g, v1, v2))
+
+    def test_check_edge_accepts_parallel_same_type(self):
+        """check_edge accepts parallel edges of the same type (only mixed
+        types are ambiguous)."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        self.assertTrue(check_edge(g, v1, v2))
+
+    def test_safe_add_Z_identity_skips_ambiguous(self):
+        """The safe `add_Z_identity` should be a no-op on ambiguous parallels."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        verts_before = g.num_vertices()
+        self.assertFalse(add_Z_identity(g, v1, v2))
+        self.assertEqual(g.num_vertices(), verts_before)
+
+    def test_check_edge_rejects_w_io(self):
+        """check_edge rejects vertex pairs joined by W_IO edges, since the rule
+        only operates on SIMPLE/HADAMARD edges."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        w_in = g.add_vertex(VertexType.W_INPUT, 0, 0)
+        w_out = g.add_vertex(VertexType.W_OUTPUT, 0, 1)
+        g.add_edge((w_in, w_out), EdgeType.W_IO)
+        self.assertFalse(check_edge(g, w_in, w_out))
+
+    def test_check_edge_rejects_self_loop(self):
+        """check_edge rejects self-loops, since `unsafe_add_Z_identity` assumes
+        two distinct vertices."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v = g.add_vertex(VertexType.Z, 0, 0)
+        g.add_edge((v, v), EdgeType.SIMPLE)
+        self.assertFalse(check_edge(g, v, v))
+        self.assertFalse(add_Z_identity(g, v, v))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hopf_rule.py
+++ b/tests/test_hopf_rule.py
@@ -1,0 +1,67 @@
+# PyZX - Python library for quantum circuit rewriting
+#        and optimization using the ZX-calculus
+# Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import sys
+
+if __name__ == '__main__':
+    sys.path.append('..')
+    sys.path.append('.')
+
+from pyzx.graph.multigraph import Multigraph
+from pyzx.utils import EdgeType, VertexType
+from pyzx.rewrite_rules.hopf_rule import check_hopf, unsafe_hopf
+
+
+class TestHopfRule(unittest.TestCase):
+    """Regression tests for the Hopf rule on multigraphs with mixed parallel edges."""
+
+    def test_hopf_same_color_with_extra_simple(self):
+        """Two Z spiders with two HADAMARD edges plus one SIMPLE edge: Hopf
+        removes only the HADAMARD pair, leaving the SIMPLE edge untouched."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+
+        self.assertTrue(check_hopf(g, v1, v2))
+        self.assertTrue(unsafe_hopf(g, v1, v2))
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.HADAMARD), 0)
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.SIMPLE), 1)
+
+    def test_hopf_different_color_with_extra_hadamard(self):
+        """Z and X spiders with two SIMPLE edges plus one HADAMARD edge: Hopf
+        removes only the SIMPLE pair, leaving the HADAMARD edge untouched."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.X, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+
+        self.assertTrue(check_hopf(g, v1, v2))
+        self.assertTrue(unsafe_hopf(g, v1, v2))
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.SIMPLE), 0)
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.HADAMARD), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pauliweb.py
+++ b/tests/test_pauliweb.py
@@ -1,0 +1,49 @@
+# PyZX - Python library for quantum circuit rewriting
+#        and optimization using the ZX-calculus
+# Copyright (C) 2024 - Aleks Kissinger and John van de Wetering
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import sys
+
+if __name__ == '__main__':
+    sys.path.append('..')
+    sys.path.append('.')
+
+from pyzx.graph.multigraph import Multigraph
+from pyzx.pauliweb import PauliWeb
+from pyzx.utils import EdgeType, VertexType
+
+
+class TestPauliWeb(unittest.TestCase):
+
+    def test_add_edge_multigraph_mixed_parallels_uses_simple(self):
+        """On a multigraph with mixed parallel edges, PauliWeb.add_edge falls
+        back to the SIMPLE edge for its per-pair labelling."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        pw = PauliWeb(g)
+        pw.add_edge((v1, v2), 'X')
+        # Treated as a SIMPLE edge: both half-edges carry the same Pauli.
+        self.assertEqual(pw[(v1, v2)], 'X')
+        self.assertEqual(pw[(v2, v1)], 'X')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_remove_id_rule.py
+++ b/tests/test_remove_id_rule.py
@@ -23,8 +23,69 @@ if __name__ == '__main__':
     sys.path.append('.')
 
 from pyzx.graph import Graph
+from pyzx.graph.multigraph import Multigraph
 from pyzx.utils import EdgeType, VertexType
-from pyzx.rewrite_rules.remove_id_rule import check_remove_id, remove_id
+from pyzx.rewrite_rules.remove_id_rule import check_remove_id, remove_id, unsafe_remove_zx
+
+
+class TestRemoveZxId(unittest.TestCase):
+
+    def test_remove_zx_parallel_mixed_edges(self):
+        """A degree-2 Z spider whose two legs are parallel edges to the same
+        neighbour must, on removal, leave a self-loop whose edge type reflects
+        the actual parity of the original edge types (mixed simple+Hadamard
+        becomes a Hadamard self-loop)."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        x = g.add_vertex(VertexType.X, 0, 0)
+        z = g.add_vertex(VertexType.Z, 1, 0)
+        g.add_edge((x, z), EdgeType.SIMPLE)
+        g.add_edge((x, z), EdgeType.HADAMARD)
+
+        self.assertTrue(remove_id(g, z))
+        self.assertEqual(g.num_vertices(), 1)
+        edges = list(g.edges())
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(g.edge_type(edges[0]), EdgeType.HADAMARD)
+
+    def test_remove_zx_parallel_same_edges(self):
+        """Parallel edges of matching type collapse to a simple self-loop."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        x = g.add_vertex(VertexType.X, 0, 0)
+        z = g.add_vertex(VertexType.Z, 1, 0)
+        g.add_edge((x, z), EdgeType.HADAMARD)
+        g.add_edge((x, z), EdgeType.HADAMARD)
+
+        self.assertTrue(remove_id(g, z))
+        self.assertEqual(g.num_vertices(), 1)
+        edges = list(g.edges())
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(g.edge_type(edges[0]), EdgeType.SIMPLE)
+
+    def test_remove_zx_rejects_self_loop(self):
+        """A degree-2 vertex carrying a self-loop is not an identity spider;
+        the safe rule must refuse to apply."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        z = g.add_vertex(VertexType.Z, 0, 0)
+        g.add_edge((z, z), EdgeType.SIMPLE)
+        g.add_edge((z, z), EdgeType.HADAMARD)
+
+        self.assertFalse(check_remove_id(g, z))
+        self.assertFalse(remove_id(g, z))
+        self.assertEqual(g.num_vertices(), 1)
+
+    def test_unsafe_remove_zx_self_loop_no_crash(self):
+        """``unsafe_remove_zx`` on a self-loop-only vertex must return
+        ``False`` rather than crash (a single self-loop contributes 2 to
+        ``vertex_degree`` but yields only one incident edge)."""
+        g = Graph()
+        z = g.add_vertex(VertexType.Z, 0, 0)
+        g.add_edge((z, z), EdgeType.SIMPLE)
+
+        self.assertFalse(unsafe_remove_zx(g, z))
+        self.assertEqual(g.num_vertices(), 1)
 
 
 class TestWNodeRemoveId(unittest.TestCase):

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -118,6 +118,38 @@ class TestSimplify(unittest.TestCase):
     def test_id_simp(self):
         self.func_test(id_simp)
 
+    def test_full_reduce_preserves_h_edge_difference_on_multigraph(self):
+        """full_reduce must preserve the semantics of multigraph diagrams
+        with parallel mixed simple/Hadamard edges. Regression test:
+        previously the (left simple, right H) variant was reduced to identity
+        instead of X because parallel mixed edges were mishandled."""
+        from pyzx.graph.multigraph import Multigraph
+        from pyzx import VertexType, EdgeType
+
+        def build(left_edge):
+            g = Multigraph()
+            b_in  = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+            x1    = g.add_vertex(VertexType.X,        qubit=0, row=1)
+            x2    = g.add_vertex(VertexType.X,        qubit=0, row=2)
+            b_out = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=3)
+            z     = g.add_vertex(VertexType.Z,        qubit=1, row=1)
+            g.add_edge((b_in, x1),  EdgeType.SIMPLE)
+            g.add_edge((x1, x2),    EdgeType.SIMPLE)
+            g.add_edge((x2, b_out), EdgeType.SIMPLE)
+            g.add_edge((x1, z),     left_edge)
+            g.add_edge((x2, z),     EdgeType.HADAMARD)
+            g.set_inputs((b_in,)); g.set_outputs((b_out,))
+            return g
+
+        g_id = build(EdgeType.HADAMARD)  # both H-edges → identity
+        g_x  = build(EdgeType.SIMPLE)    # mixed → X gate
+        t_id_before = g_id.to_tensor()
+        t_x_before  = g_x.to_tensor()
+        full_reduce(g_id)
+        full_reduce(g_x)
+        self.assertTrue(compare_tensors(t_id_before, g_id.to_tensor()))
+        self.assertTrue(compare_tensors(t_x_before,  g_x.to_tensor()))
+
     def test_to_gh(self):
         self.func_test(to_gh)
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -185,6 +185,25 @@ class TestTensor(unittest.TestCase):
         g.add_edges([(i2, i2), (i2, i3)], 2)
         self.assertTrue(compare_tensors(g, np.array([[0,0],[1,0]])))
 
+    def test_parallel_mixed_edges_map(self):
+        """An X spider connected to a Z spider by one simple AND one Hadamard
+        edge in parallel implements the X gate up to scalar; tensorfy must not
+        treat the parallel pair as if both edges were the same type."""
+        from pyzx.utils import EdgeType
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        b_in  = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        x     = g.add_vertex(VertexType.X,        qubit=0, row=1)
+        b_out = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=2)
+        z     = g.add_vertex(VertexType.Z,        qubit=-1, row=1)
+        g.add_edge((b_in, x),  EdgeType.SIMPLE)
+        g.add_edge((x, b_out), EdgeType.SIMPLE)
+        g.add_edge((x, z),     EdgeType.SIMPLE)
+        g.add_edge((x, z),     EdgeType.HADAMARD)
+        g.set_inputs((b_in,)); g.set_outputs((b_out,))
+        self.assertTrue(compare_tensors(g, np.array([[0,1],[1,0]]),
+                                        preserve_scalar=False))
+
     def test_to_tensor_equivalent(self):
         g = Graph()
         g.add_vertex(VertexType.Z, phase=1)


### PR DESCRIPTION
## Description

Changes:
- `tensorfy_naive` treats parallel edges of different types as distinct legs during contraction.
- `unsafe_remove_zx` now supports parallel mixed edges; `check_remove_zx` rejects self-loops.
- `unsafe_hopf` derives the removed edge type from spider colours, matching `check_hopf`.
- `add_Z_identity` rejects vertex pairs joined by mixed parallel edges or `W_IO` edges.
- `PauliWeb.add_edge` and `PauliWeb.graph_with_errors` prefer the SIMPLE edge to preserve per-pair labelling.

## Related issue

#439

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.