### PR TITLE
Add Gaussian distribution CNOT spread

### DIFF
--- a/pyzx/generate.py
+++ b/pyzx/generate.py
@@ -27,7 +27,7 @@ __all__ = [
     "qft",
 ]
 
-import random, types
+import random, types, math
 from fractions import Fraction
 
 from typing import Optional, List, Set, Union
@@ -128,7 +128,8 @@ def CNOT_HAD_PHASE_circuit(
         p_had: float = 0.2,
         p_t: float = 0.2,
         clifford:bool=False,
-        seed:Optional[int]=None
+        seed:Optional[int]=None,
+        sigma:Optional[float]=None
         ) -> Circuit:
     """Construct a Circuit consisting of CNOT, HAD and phase gates.
     The default phase gate is the T gate, but if ``clifford=True``\\ , then
@@ -140,6 +141,10 @@ def CNOT_HAD_PHASE_circuit(
         p_had: probability that each gate is a Hadamard gate
         p_t: probability that each gate is a T gate (or if ``clifford`` is set, S gate)
         clifford: when set to True, the phase gates are S gates instead of T gates.
+        seed: When given, this specifies the RNG seed.
+        sigma: standard deviation (hence sigma^2 = variance) of CNOT spread across qubits, following a normal distribution.
+        i.e. sigma=inf means all qubits are weighted equally when deciding spread of CNOT, sigma=1 means
+        CNOTs always span exactly a one qubit gap, and e.g. epsilion=2 favours local qubits over long-range connections, etc.
 
     Returns:
         A random circuit consisting of Hadamards, CNOT gates and phase gates.
@@ -158,21 +163,23 @@ def CNOT_HAD_PHASE_circuit(
             if not clifford: c.add_gate("T",rand.randrange(qubits))
             else: c.add_gate("S",rand.randrange(qubits))
         else:
-            tgt = rand.randrange(qubits)
-            while True:
-                ctrl = rand.randrange(qubits)
-                if ctrl!=tgt: break
-            c.add_gate("CNOT",tgt,ctrl)
+            q0 = rand.randrange(qubits)
+            q1 = gaussian_random_qubit_target(rand,q0,qubits,sigma)
+            c.add_gate("CNOT",q0,q1)
     return c
 
 
-def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int]=None) -> BaseGraph:
+def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int]=None, sigma:Optional[float]=None) -> BaseGraph:
     """Generates a circuit consisting of randomly placed CNOT gates.
     
     Args:
     qubits: Amount of qubits in circuit
     depth: Depth of circuit
     backend: When given, should be one of the possible :ref:`graph_api` backends.
+    seed: When given, this specifies the RNG seed.
+    sigma: standard deviation (hence sigma^2 = variance) of CNOT spread across qubits, following a normal distribution.
+        i.e. sigma=inf means all qubits are weighted equally when deciding spread of CNOT, sigma=1 means
+        CNOTs always span exactly a one qubit gap, and e.g. epsilion=2 favours local qubits over long-range connections, etc.
     
     Returns:
         Instance of graph of the given backend
@@ -203,8 +210,7 @@ def cnots(qubits: int, depth: int, backend:Optional[str]=None, seed:Optional[int
     else: rand = random
     for i in range(depth):
         c = rand.randint(0, qubits-1)
-        t = rand.randint(0, qubits-2)
-        if t >= c: t += 1
+        t = gaussian_random_qubit_target(rand,c,qubits,sigma)
         es += [(q[c], v), (q[t], v+1), (v, v+1)]
         q[c] = v
         q[t] = v+1
@@ -266,7 +272,8 @@ def cliffordTmeas(
         p_cnot:Optional[float]=None, 
         p_meas:Optional[float]=None, 
         backend:Optional[str]=None,
-        seed:Optional[int]=None
+        seed:Optional[int]=None,
+        sigma:Optional[float]=None
         ) -> BaseGraph:
     """Generates a circuit consisting of randomly placed Clifford+T gates. Optionally, take
     probabilities of adding T, S, HSH, CNOT, and measurements.
@@ -282,6 +289,10 @@ def cliffordTmeas(
     :param p_meas: Probability that each gate is a measurement.
     :param backend: When given, should be one of the possible :ref:`graph_api` backends.
     :rtype: Instance of graph of the given backend.
+    :param seed: When given, this specifies the RNG seed.
+    :param sigma: standard deviation (hence sigma^2 = variance) of CNOT spread across qubits, following a normal distribution.
+        i.e. sigma=inf means all qubits are weighted equally when deciding spread of CNOT, sigma=1 means
+        CNOTs always span exactly a one qubit gap, and e.g. epsilion=2 favours local qubits over long-range connections, etc.
     """
     g = Graph(backend)
     qs = list(range(qubits))  # tracks qubit indices of vertices
@@ -347,8 +358,7 @@ def cliffordTmeas(
 
         if p > 1 - p_cnot:
             # apply CNOT gate
-            q1 = rand.randrange(qubits-1)
-            if q1 >= q0: q1 += 1
+            q1 = gaussian_random_qubit_target(rand,q0,qubits,sigma)
 
             g.add_vertex(VertexType.X,q1,r-1)
             g.add_edge((qs[q1], v))
@@ -396,7 +406,8 @@ def cliffordT(
         p_hsh:Optional[float]=None,
         p_cnot:Optional[float]=None,
         backend:Optional[str]=None,
-        seed:Optional[int]=None
+        seed:Optional[int]=None,
+        sigma:Optional[float]=None
         ) -> BaseGraph:
     """Generates a circuit consisting of randomly placed Clifford+T gates. Optionally, take
     probabilities of adding T, S, HSH, and CNOT. If probabilities for only a subset of gates
@@ -411,8 +422,12 @@ def cliffordT(
     :param p_cnot: Probability that each gate is a CNOT-gate.
     :param backend: When given, should be one of the possible :ref:`graph_api` backends.
     :rtype: Instance of graph of the given backend.
+    :param seed: When given, this specifies the RNG seed.
+    :param sigma: standard deviation (hence sigma^2 = variance) of CNOT spread across qubits, following a normal distribution.
+        i.e. sigma=inf means all qubits are weighted equally when deciding spread of CNOT, sigma=1 means
+        CNOTs always span exactly a one qubit gap, and e.g. epsilion=2 favours local qubits over long-range connections, etc.
     """
-    return cliffordTmeas(qubits, depth, p_t, p_s, p_hsh, p_cnot, 0, backend, seed)
+    return cliffordTmeas(qubits, depth, p_t, p_s, p_hsh, p_cnot, 0, backend, seed, sigma)
 
 def cliffords(
         qubits: int, 
@@ -420,7 +435,8 @@ def cliffords(
         no_hadamard:bool=False,
         t_gates:bool=False,
         backend:Optional[str]=None,
-        seed:Optional[int]=None
+        seed:Optional[int]=None,
+        sigma:Optional[float]=None
         ):
     """Generates a circuit consisting of randomly placed Clifford gates.
     Uses a different approach to generating Clifford circuits then :func:`cliffordT`.
@@ -430,6 +446,10 @@ def cliffords(
     :param no_hadamard: Whether hadamard edges are allowed to be placed.
     :param backend: When given, should be one of the possible :ref:`graph_api` backends.
     :rtype: Instance of graph of the given backend.
+    :param seed: When given, this specifies the RNG seed.
+    :param sigma: standard deviation (hence sigma^2 = variance) of CNOT spread across qubits, following a normal distribution.
+        i.e. sigma=inf means all qubits are weighted equally when deciding spread of CNOT, sigma=1 means
+        CNOTs always span exactly a one qubit gap, and e.g. epsilion=2 favours local qubits over long-range connections, etc.
     """
 
     #randomness parameters
@@ -466,8 +486,7 @@ def cliffords(
     else: rand = random
     for i in range(depth):
         c = rand.randint(0, qubits-1)
-        t = rand.randint(0, qubits-2)
-        if t >= c: t += 1
+        t = gaussian_random_qubit_target(rand,c,qubits,sigma)
         if accept(p_two_qubit,rand):
             if no_hadamard or accept(p_cnot,rand): 
                 es1.append((v, v+1))
@@ -738,3 +757,50 @@ def qft(qubits: int) -> Circuit:
         for j in range(i+1, qubits):
             c.add_gate('CPhase', j, i, Fraction(1, 2**(j-i+1)))
     return c
+
+def gaussian_random_qubit_target(rand: Union[random.Random, types.ModuleType], q0: int, qubits: int, sigma: float|None) -> int:
+    """Selects a random target qubit according to a discrete Gaussian distribution
+    favouring short-range interactions.
+
+    Given a control qubit ``q0``, this function samples a distinct target qubit
+    ``q1`` with probability proportional to:
+
+    P(dq) = 1/\sqrt{2*pi*sigma^2} * exp{-(dq-1)^2/(2*sigma^2)}
+
+    where ``dq = |q1 - q0|`` is the span between the qubits and ``sigma``
+    controls the variance of the distribution. Smaller values of ``sigma``
+    strongly favour nearest-neighbour interactions, while larger values approach
+    a more uniform distribution.
+
+    Args:
+        rand: Random number generator instance.
+        q0: Control qubit index.
+        qubits: Total number of qubits.
+        sigma: Standard deviation parameter controlling locality bias.
+            0 always returns a neighbouring qubit and float("inf") acts as a uniform distribution.
+
+    Returns:
+        A randomly selected target qubit index distinct from ``q0`` with locality preference influenced by sigma.
+    """
+
+    if (sigma is None): # uniform distribution for qubit spread of CNOT (essentially sigma=float("inf") but more efficient to just make this a special case)
+        q1 = rand.randrange(qubits-1)
+        if q1 >= q0: q1 += 1
+        return q1
+    elif (sigma==0): sigma=1e-100 # avoids a "divide by zero" error
+
+    choices = []
+    weights = []
+
+    for q1 in range(qubits):
+        if q1 == q0:
+            continue
+
+        dq = abs(q1 - q0)
+
+        weight = math.exp(-((dq - 1) ** 2) / (2 * sigma ** 2))
+
+        choices.append(q1)
+        weights.append(weight)
+
+    return rand.choices(choices, weights=weights, k=1)[0]


### PR DESCRIPTION
When generating random circuits via the pyzx.generate functions, every CNOT places its control and target on separate randomly selected qubits (with equal probability weighting to all qubits, i.e. on a uniform distribution). However, it can be useful to generate random circuits whose CNOTs favour short-range connections (i.e. connecting nearby qubits) as there are some arguments to suggest such circuits are more realistic.

As such, switching from effectively a uniform distribution to a normal/Gaussian distribution to determine the span of each CNOT would be handy. The standard deviation, sigma, (such that sigma^2 is the variance) can be included in the circuit generation functions as an extra optional argument (which effectively defaults to infinity, i.e. a normal distribution, so these functions behave exactly as before when sigma is not explicitly specified).

sigma=float("inf") (or sigma=None) means a uniform distribution and sigma=0 means every CNOT will connect to an immediate neighbour qubit, and e.g. sigma=1.5 means high preference for short-range CNOTs. See bottom of page 12 and figure 7a in https://arxiv.org/pdf/2409.00828 for extra clarity.

Examples:
<img width="1020" height="549" alt="image" src="https://github.com/user-attachments/assets/83088562-4a86-4c3a-b984-99f17c4cc430" />
<img width="1004" height="539" alt="image" src="https://github.com/user-attachments/assets/7f83e708-af3c-48d0-ab15-834276a36c25" />
<img width="1022" height="556" alt="image" src="https://github.com/user-attachments/assets/bcb7944e-6ce7-4fb4-8c6b-2375b1a2b9dd" />
<img width="1003" height="543" alt="image" src="https://github.com/user-attachments/assets/64df7190-72d0-4df6-922d-fc0f3453c875" />
