### PR TITLE
Fix merge_phase_gadget_rule for boolean Poly phases

### DIFF
--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -26,7 +26,7 @@ from typing import Optional
 
 from pyzx.utils import  FractionLike, phase_is_pauli
 from pyzx.graph.base import BaseGraph, VT, ET
-from pyzx.symbolic import Poly
+from pyzx.symbolic import Poly, new_const
 
 
 __all__ = ['merge_phase_gadgets_for_simp',
@@ -85,12 +85,30 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
         if len(gad) == 1:
             n = gad[0]
             v = gadgets[n]
-            if phases[n] != 0: # If the phase of the axel vertex is pi, we change the phase of the gadget
+            if phases[n] != 0 or isinstance(phases[n], Poly): # If the phase of the axel vertex is pi, we change the phase of the gadget
                 g.scalar.add_phase(phases[v])
                 g.phase_negate(v)
-                m.append((v,n,-phases[v],[],[]))
+                if isinstance(phases[n], Poly):
+                    
+                    gadget_phase = new_const(phases[v]) if not isinstance(phases[v], Poly) else phases[v]
+                    neg_gadget = -gadget_phase
+                    new_phase = gadget_phase + (neg_gadget - gadget_phase) * phases[n]
+                    m.append((v, n, new_phase, [], []))
+                else:
+                    m.append((v, n, -phases[v], [], []))
         else:
-            totphase = sum((1 if phases[n]==0 else -1)*phases[gadgets[n]] for n in gad)%2
+            totphase = 0
+            for n in gad:
+                gadget_phase = phases[gadgets[n]]
+                if isinstance(phases[n], Poly):
+                    gp = new_const(gadget_phase) if not isinstance(gadget_phase, Poly) else gadget_phase
+                    totphase += gp + (-gp - gp) * phases[n]
+                else:
+                    if phases[n] == 0:
+                        totphase += gadget_phase
+                    else:
+                        totphase += -gadget_phase
+            totphase = totphase % 2
             for n in gad:
                 if phases[n] != 0:
                     g.scalar.add_phase(phases[gadgets[n]])

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -96,8 +96,8 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
                         gadget_phase: FractionLike = phases[v]
                     else:
                         gadget_phase = new_const(cast(Union[int, Fraction], phases[v]))
-                    neg_gadget = -gadget_phase
-                    new_phase = gadget_phase + (neg_gadget - gadget_phase) * phases[n]
+                  
+                    new_phase = gadget_phase + (-2 * gadget_phase) * phases[n]
                     m.append((v, n, new_phase, [], []))
                 else:
                     m.append((v, n, -phases[v], [], []))

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -90,8 +90,10 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
                 g.scalar.add_phase(phases[v])
                 g.phase_negate(v)
                 if isinstance(phases[n], Poly):
-                    
-                    gadget_phase: FractionLike = phases[v] if isinstance(phases[v], Poly) else new_const(phases[v])
+                    if isinstance(phases[v], Poly):
+                        gadget_phase: FractionLike = phases[v]
+                    else:
+                        gadget_phase = new_const(phases[v])
                     neg_gadget = -gadget_phase
                     new_phase = gadget_phase + (neg_gadget - gadget_phase) * phases[n]
                     m.append((v, n, new_phase, [], []))

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -21,7 +21,7 @@ This rule acts on an entire graph and the matcher modifies the graph, so this ru
 using the using simplify.gadget_simp(g) or simplify.gadget_simp.apply(g).
 """
 
-from typing import Tuple, List, Dict, FrozenSet
+from typing import Tuple, List, Dict, FrozenSet, Union, cast
 from typing import Optional
 
 from pyzx.utils import  FractionLike, phase_is_pauli
@@ -93,7 +93,7 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
                     if isinstance(phases[v], Poly):
                         gadget_phase: FractionLike = phases[v]
                     else:
-                        gadget_phase = new_const(phases[v])
+                        gadget_phase = new_const(cast(Union[int, Fraction], phases[v]))
                     neg_gadget = -gadget_phase
                     new_phase = gadget_phase + (neg_gadget - gadget_phase) * phases[n]
                     m.append((v, n, new_phase, [], []))

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -98,11 +98,11 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
                 else:
                     m.append((v, n, -phases[v], [], []))
         else:
-            totphase = Fraction(0)
+            totphase: FractionLike = Fraction(0)
             for n in gad:
                 gadget_phase = phases[gadgets[n]]
                 if isinstance(phases[n], Poly):
-                    gp = new_const(gadget_phase) if not isinstance(gadget_phase, Poly) else gadget_phase
+                    gp: FractionLike = gadget_phase if isinstance(gadget_phase, Poly) else new_const(gadget_phase)
                     totphase += gp + (-gp - gp) * phases[n]
                 else:
                     if phases[n] == 0:

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -27,6 +27,7 @@ from typing import Optional
 from pyzx.utils import  FractionLike, phase_is_pauli
 from pyzx.graph.base import BaseGraph, VT, ET
 from pyzx.symbolic import Poly, new_const
+from fractions import Fraction
 
 
 __all__ = ['merge_phase_gadgets_for_simp',
@@ -90,14 +91,14 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
                 g.phase_negate(v)
                 if isinstance(phases[n], Poly):
                     
-                    gadget_phase = new_const(phases[v]) if not isinstance(phases[v], Poly) else phases[v]
+                    gadget_phase: FractionLike = phases[v] if isinstance(phases[v], Poly) else new_const(phases[v])
                     neg_gadget = -gadget_phase
                     new_phase = gadget_phase + (neg_gadget - gadget_phase) * phases[n]
                     m.append((v, n, new_phase, [], []))
                 else:
                     m.append((v, n, -phases[v], [], []))
         else:
-            totphase = 0
+            totphase = Fraction(0)
             for n in gad:
                 gadget_phase = phases[gadgets[n]]
                 if isinstance(phases[n], Poly):

--- a/pyzx/rewrite_rules/merge_phase_gadget_rule.py
+++ b/pyzx/rewrite_rules/merge_phase_gadget_rule.py
@@ -86,10 +86,12 @@ def match_phase_gadgets(g: BaseGraph[VT,ET], vertices:Optional[List[VT]]=None) -
         if len(gad) == 1:
             n = gad[0]
             v = gadgets[n]
-            if phases[n] != 0 or isinstance(phases[n], Poly): # If the phase of the axel vertex is pi, we change the phase of the gadget
+            axel_phase = phases[n]
+            is_symbolic = isinstance(axel_phase, Poly) and len(axel_phase.free_vars()) > 0
+            if axel_phase != 0 or is_symbolic:
                 g.scalar.add_phase(phases[v])
                 g.phase_negate(v)
-                if isinstance(phases[n], Poly):
+                if is_symbolic:
                     if isinstance(phases[v], Poly):
                         gadget_phase: FractionLike = phases[v]
                     else:

--- a/tests/test_symbolic_parsing.py
+++ b/tests/test_symbolic_parsing.py
@@ -1,9 +1,9 @@
 import sys
 import unittest
 from fractions import Fraction
-
+import pyzx as zx
 from pyzx.symbolic import Poly, Term, Var, VarRegistry, new_const, new_var, parse
-
+ 
 if __name__ == '__main__':
     sys.path.append('..')
     sys.path.append('.')
@@ -318,6 +318,33 @@ class TestPolyConjugate(unittest.TestCase):
     def test_conjugate_pure_imaginary(self):
         p = Poly([(2j, Term([]))])
         self.assertEqual(p.conjugate().terms[0][0], -2j)
+
+class TestSymbolicBooleanRewrite(unittest.TestCase):
+
+    def test_t_injection_reduces_correctly(self):
+        """T injection should reduce to phase pi/4 regardless of measurement result."""
+
+        circ = zx.qasm("""
+OPENQASM 2.0;
+include "qelib1.inc";
+qreg q[2];
+creg c[1];
+reset q[1];
+h q[1];
+t q[1];
+cx q[0],q[1];
+measure q[1] -> c[0];
+if (c==1) s q[0];
+""")
+        g = circ.to_graph()
+        zx.full_reduce(g)
+
+        phases = g.phases()
+        non_zero = {v: p for v, p in phases.items() if p != 0}
+        self.assertEqual(len(non_zero), 1, f"Expected 1 non-zero phase, got {non_zero}")
+
+        actual_phase = list(non_zero.values())[0]
+        self.assertEqual(actual_phase, Fraction(1, 4), f"Expected Fraction(1,4), got {actual_phase}")
 
 
 

--- a/tests/test_symbolic_parsing.py
+++ b/tests/test_symbolic_parsing.py
@@ -1,7 +1,8 @@
 import sys
 import unittest
-from fractions import Fraction
 import pyzx as zx
+
+from fractions import Fraction
 from pyzx.symbolic import Poly, Term, Var, VarRegistry, new_const, new_var, parse
  
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #436.

The `match_phase_gadgets` function used `phases[n] != 0` to check whether an axel's phase is pi before negating the gadget phase. For `Fraction` phases this works correctly, but for `Poly` phases the check tests whether the polynomial object is non-empty, which is always true regardless of what the boolean variable evaluates to. This caused unconditional negation even when `c[0]=0` should have left the phase unchanged.

The fix replaces the unconditional `-phases[v]` with:

```python
gp + (-gp - gp) * phases[n]
```

This evaluates to `gp` when `phases[n]=0` and `-gp` when `phases[n]=1`, keeping the boolean variable alive without introducing a coefficient of 2. The same pattern is applied to the `totphase` computation in the multi-gadget case. A test using the T injection circuit from the issue is also included.

Happy to make any changes if needed.

cc @lia-approves