### PR TITLE
Fix symbolic Poly phase handling in pivot_rule and push_pauli_rule

### DIFF
--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -286,7 +286,7 @@ def pivot(g: BaseGraph[VT,ET], v: VT, v1: VT) -> bool:
 
 def unsafe_pivot(g: BaseGraph[VT,ET], v0: VT, v1: VT) -> bool:
     """Perform a pivoting rewrite"""
-
+    
     rem_verts: List[VT] = []
     rem_edges: List[ET] = []
     etab: Dict[Tuple[VT,VT],List[int]] = dict()
@@ -320,7 +320,7 @@ def unsafe_pivot(g: BaseGraph[VT,ET], v0: VT, v1: VT) -> bool:
         if not g.is_ground(v):
             g.add_to_phase(v, 1)
 
-    if g.phase(m[0][0]) and g.phase(m[0][1]): g.scalar.add_phase(Fraction(1))
+    g.scalar.add_phase(g.phase(m[0][0]) * g.phase(m[0][1]))
     if not m[1][0] and not m[1][1]:
         g.scalar.add_power(-(k0+k1+2*k2-1))
     elif not m[1][0]:
@@ -400,7 +400,7 @@ def pivot_NOT_REWORKED(g: BaseGraph[VT,ET], matches: List[MatchPivotType[VT]]) -
             if not g.is_ground(v):
                 g.add_to_phase(v, 1)
 
-        if g.phase(m[0][0]) and g.phase(m[0][1]): g.scalar.add_phase(Fraction(1))
+        g.scalar.add_phase(g.phase(m[0][0]) * g.phase(m[0][1]))
         if not m[1][0] and not m[1][1]:
             g.scalar.add_power(-(k0+k1+2*k2-1))
         elif not m[1][0]:

--- a/pyzx/rewrite_rules/push_pauli_rule.py
+++ b/pyzx/rewrite_rules/push_pauli_rule.py
@@ -100,7 +100,7 @@ def unsafe_pauli_push(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
     new_verts = []
     if vertex_is_zx(g.type(v)):
         g.scalar.add_phase(g.phase(v))
-        g.set_phase(v,((1 - 2 * pauli_phase) * g.phase(v)) % 2) # 1-2a is -1 if a=1 (i.e. pi) and 1 if a=0 (i.e. 0). We need to do it this way to handle boolean symbolic phases.
+        g.set_phase(v, (g.phase(v) - 2 * (pauli_phase * g.phase(v))) % 2) # phase*(1-2a): unchanged when a=0, negated when a=1. Multiply phase first to avoid 2*a cancelling mod 2.
         t = toggle_vertex(g.type(v))
         p: FractionLike = pauli_phase
     else:


### PR DESCRIPTION
Follow-up to #451, addressing two more bugs from #436.

**pivot_rule.py**

The line:

```python
if g.phase(m[0][0]) and g.phase(m[0][1]): g.scalar.add_phase(Fraction(1))
```

always fires for non-empty Poly phases because Python's `bool()` on a Poly is always `True`, unconditionally adding π to the scalar. As suggested by @dlyongemallo, replaced with:

```python
g.scalar.add_phase(g.phase(m[0][0]) * g.phase(m[0][1]))
```

Applied to both `unsafe_pivot` and `pivot_NOT_REWORKED`.

**push_pauli_rule.py**

The line:

```python
g.set_phase(v, ((1 - 2 * pauli_phase) * g.phase(v)) % 2)
```

is broken for boolean Poly phases. `2 * pauli_phase` is evaluated first, and since boolean coefficients are reduced mod 2 inside `Poly.__add__`, the 2 cancels to 0 and the variable disappears. Fixed by reordering:

```python
g.set_phase(v, (g.phase(v) - 2 * (pauli_phase * g.phase(v))) % 2)
```

`pauli_phase * g.phase(v)` runs first, attaching the variable to a fractional coefficient that survives the mod 2 reduction.

Looking forward to your feedback.