### PR TITLE
make `Multigraph.edge` raise `ValueError` on ambiguous parallel mixed edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).
 - The symbolic expression parser (`pyzx.symbolic.parse`) now accepts division, e.g., `theta/2` or `(x + y)/2`. Divisors must be rational (or complex) constants; division by an integer produces an exact `Fraction` coefficient. As a side effect, `^` binds tighter than `*` and `/`. (by @dlyongemallo)
 
+### Changed
+- `Multigraph.edge(s, t)` now raises `ValueError` on ambiguous mixed-type parallel edges or when no matching edge exists, instead of silently returning one; pass `et` to disambiguate. The `et` default is now `None` on `BaseGraph.edge` (`GraphS.edge` and `GraphIG.edge` ignore it). Internal callers were updated to match; as a side effect, `PauliWeb.add_edge` and `PauliWeb.graph_with_errors` now propagate this error rather than silently preferring the `SIMPLE` edge (by @dlyongemallo).
+
 ## [0.10.4] - 2026-07-01
 
 ### Added

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -319,11 +319,41 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         else:
             return max(self.row(v) for v in self.vertices())
 
-    def edge(self, s: VT, t: VT, et: EdgeType=EdgeType.SIMPLE) -> ET:
-        """Returns the name of the first edge with the given source/target and type. Behaviour is undefined if the vertices are not connected."""
+    def edge(self, s: VT, t: VT, et: Optional[EdgeType] = None) -> ET:
+        """Returns the name of an edge between `s` and `t`.
+
+        This default implementation, used by backends with parallel edges that
+        do not provide a specialized edge lookup (e.g., the ``graph_tool``
+        backend), raises `ValueError` if there is no such edge, or if `et` is
+        `None` and parallel edges of differing types make the choice ambiguous;
+        in that case pass `et`, or iterate with :meth:`edges` /
+        :meth:`incident_edges`. If `et` is given, the first edge of that type
+        is returned.
+
+        Note: the `multigraph` backend overrides this with its own
+        implementation, and backends without parallel edges (`GraphS`,
+        `GraphIG`) override it with simpler semantics that do not raise when the
+        edge is absent; see those overrides."""
+        matched: Optional[ET] = None
+        matched_type: Optional[EdgeType] = None
         for e in self.incident_edges(s):
-            if t in self.edge_st(e) and et == self.edge_type(e):
-                return e
+            if t in self.edge_st(e):
+                ety = self.edge_type(e)
+                if et is None:
+                    if matched_type is not None and matched_type != ety:
+                        raise ValueError(
+                            f"edge({s}, {t}) is ambiguous: parallel edges of "
+                            f"multiple types exist. Pass et explicitly, or "
+                            f"use g.edges(s, t) / g.incident_edges(v) to iterate."
+                        )
+                    matched = e
+                    matched_type = ety
+                elif et == ety:
+                    return e
+        if et is None:
+            if matched is None:
+                raise ValueError(f"No edge between {s} and {t}")
+            return matched
         raise ValueError(f"No edge of type {et} between {s} and {t}")
 
     def connected(self,v1: VT, v2: VT) -> bool:

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -20,6 +20,8 @@ except ImportError:
 	print("python-igraph not available")
 	ig = None
 
+from typing import Optional
+
 from .base import BaseGraph, VertexType, EdgeType
 from ..utils import assert_phase_real, normalize_phase
 
@@ -27,6 +29,7 @@ class GraphIG(BaseGraph):
 	"""Implementation of :class:`~graph.base.BaseGraph` using ``python-igraph`` 
 	as its backend"""
 	backend = 'igraph'
+	graph: "ig.Graph"
 	def __init__(self):
 		raise Warning("Python-igraph is currently not fully supported.")
 		BaseGraph.__init__(self)
@@ -80,7 +83,10 @@ class GraphIG(BaseGraph):
 	def edges(self):
 		return range(len(self.graph.es))
 
-	def edge(self, s, t):
+	def edge(self, s, t, et: Optional[EdgeType] = None):
+		"""Return igraph's edge index for the pair ``(s, t)``. ``et`` is accepted
+		for consistency with :meth:`BaseGraph.edge` but ignored, as this backend
+		has no parallel edges of multiple types."""
 		return self.graph.es[s,t][0].index
 	
 	def edge_st(self, edge):

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from fractions import Fraction
-from typing import Generator, Iterable, Any
+from typing import Generator, Iterable, Any, Optional
 
 from .base import BaseGraph
 
@@ -288,7 +288,11 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
                         if v1 > v0:
                             yield (v0,v1)
 
-    def edge(self, s: int, t: int, et: EdgeType = EdgeType.SIMPLE) -> tuple[int, int]:
+    def edge(self, s: int, t: int, et: Optional[EdgeType] = None) -> tuple[int, int]:
+        """Return the canonical pair ``(min(s, t), max(s, t))`` whether or not the
+        edge exists; this supports the ``g.add_edge(g.edge(v, w), ...)`` pattern.
+        ``et`` is accepted for consistency with :meth:`BaseGraph.edge` but ignored,
+        as ``GraphS`` has no parallel edges of multiple types."""
         return (s,t) if s < t else (t,s)
     
     def edge_set(self) -> set[tuple[int, int]]:

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -17,7 +17,7 @@
 import itertools
 from collections import Counter
 from fractions import Fraction
-from typing import Iterable, Any, cast
+from typing import Iterable, Any, Optional, cast
 
 from .base import BaseGraph
 
@@ -348,12 +348,30 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     #                    if v1 > v0:
     #                        yield (v0,v1)
 
-    def edge(self, s: int, t: int, et: EdgeType = EdgeType.SIMPLE) -> tuple[int, int, EdgeType]:
+    def edge(self, s: int, t: int, et: Optional[EdgeType] = None) -> tuple[int, int, EdgeType]:
         s, t = (s, t) if s < t else (t, s)
-        e = self.graph[s][t]
-        if e.get_edge_count(et):
-            return (s, t, et)
-        return next(iter(self.edges(s, t)))
+        adj = self.graph.get(s)
+        if adj is None or t not in adj:
+            raise ValueError(f"No edge between {s} and {t}")
+        e = adj[t]
+        if et is not None:
+            if e.get_edge_count(et):
+                return (s, t, et)
+            raise ValueError(f"No edge of type {et} between {s} and {t}")
+        found: Optional[EdgeType] = None
+        for ty in (EdgeType.SIMPLE, EdgeType.HADAMARD, EdgeType.W_IO):
+            if e.get_edge_count(ty):
+                if found is not None:
+                    raise ValueError(
+                        f"edge({s}, {t}) is ambiguous on a multigraph: parallel "
+                        f"edges of multiple types exist (simple={e.s}, "
+                        f"hadamard={e.h}, w_io={e.w_io}). Pass et explicitly, "
+                        f"or use g.edges(s, t) / g.incident_edges(v) to iterate."
+                    )
+                found = ty
+        if found is None:
+            raise ValueError(f"No edge between {s} and {t}")
+        return (s, t, found)
 
 
     def edge_set(self) -> Counter[tuple[int, int, EdgeType]]:

--- a/pyzx/pauliweb.py
+++ b/pyzx/pauliweb.py
@@ -39,28 +39,6 @@ def h_pauli(p: str) -> str:
     else: return 'X'
 
 
-def _resolve_edge(g: BaseGraph[VT, ET], s: VT, t: VT) -> ET:
-    """Resolve a single edge between `s` and `t` for PauliWeb's per-pair semantics.
-
-    PauliWeb labels edges by ordered vertex pair, which has no canonical answer
-    on multigraphs with mixed parallel edges. We prefer the SIMPLE edge when
-    both types exist; otherwise we return whatever edge is there.
-    """
-    fallback: Optional[ET] = None
-    for e in g.edges(s, t):
-        if g.edge_type(e) == EdgeType.SIMPLE:
-            return e
-        fallback = e
-    if fallback is not None:
-        return fallback
-    raise ValueError(f"No edge between {s} and {t}")
-
-
-def _resolve_edge_type(g: BaseGraph[VT, ET], s: VT, t: VT) -> EdgeType:
-    """Like :func:`_resolve_edge` but returns the resolved edge type."""
-    return g.edge_type(_resolve_edge(g, s, t))
-
-
 class PauliWeb(Generic[VT, ET]):
     """A Pauli web
     
@@ -115,7 +93,12 @@ class PauliWeb(Generic[VT, ET]):
     
     def add_edge(self, v_pair: Tuple[VT, VT], pauli: str):
         s, t = v_pair
-        et = _resolve_edge_type(self.g, s, t)
+        # Reject missing edges up front: on backends like ``GraphS`` that
+        # return a canonical pair regardless of existence, ``edge``/``edge_type``
+        # would otherwise silently label a non-existent edge.
+        if not self.g.connected(s, t):
+            raise ValueError(f"No edge between {s} and {t}")
+        et = self.g.edge_type(self.g.edge(s, t))
         self.add_half_edge((s,t), pauli)
         self.add_half_edge((t,s), pauli if et == EdgeType.SIMPLE else h_pauli(pauli))
     
@@ -153,8 +136,13 @@ class PauliWeb(Generic[VT, ET]):
         for s,t in edges:
             p0 = self.es.get((s,t), 'I')
             p1 = self.es.get((t,s), 'I')
-            
-            e = _resolve_edge(g, s, t)
+
+            # Fail clearly if the web references an edge the graph lacks: on
+            # ``GraphS``, ``edge`` returns a canonical pair even when absent, so
+            # ``remove_edge`` would otherwise raise an opaque ``KeyError``.
+            if not g.connected(s, t):
+                raise ValueError(f"No edge between {s} and {t}")
+            e = g.edge(s, t)
             et = g.edge_type(e)
             g.remove_edge(e)
             

--- a/pyzx/rewrite_rules/add_identity_rule.py
+++ b/pyzx/rewrite_rules/add_identity_rule.py
@@ -68,9 +68,9 @@ def add_Z_identity( g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
 def unsafe_add_Z_identity(g: BaseGraph[VT,ET], v:VT, w:VT) -> bool:
     """Adds a Z spider to the edge given by the input vertices.
 
-    Assumes there is a unique edge type between `v` and `w`; on a multigraph
-    with mixed parallel edges, callers must pre-disambiguate (e.g. by gating
-    on :func:`check_edge`)."""
+    Requires a unique edge type between `v` and `w`; raises ``ValueError`` on
+    multigraphs with mixed parallel edges (the rule has no canonical edge to
+    act on in that case). Callers can pre-disambiguate via :func:`check_edge`."""
     etab = {}
 
     e = g.edge(v, w)

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -89,7 +89,10 @@ def check_pivot(
     if not (v in g.vertices() and w in g.vertices()): return False
     if not g.connected(v, w): return False
 
-    if g.edge_type(g.edge(v, w)) != EdgeType.HADAMARD: return False
+    # Pivot acts on a HADAMARD edge; reject if any SIMPLE parallel exists
+    # alongside or if no HADAMARD edge is present.
+    if g.num_edges(v, w, EdgeType.SIMPLE) > 0: return False
+    if g.num_edges(v, w, EdgeType.HADAMARD) == 0: return False
 
     if not (types[v] == VertexType.Z and types[w] == VertexType.Z): return False
 

--- a/pyzx/rewrite_rules/self_loops_rule.py
+++ b/pyzx/rewrite_rules/self_loops_rule.py
@@ -71,8 +71,10 @@ def unsafe_remove_self_loop(g: BaseGraph[VT, ET], v: VT) -> bool:
     ns = g.num_edges(v, v, EdgeType.SIMPLE)
     nh = g.num_edges(v, v, EdgeType.HADAMARD)
 
-    rem_edges.extend([g.edge(v, v, EdgeType.SIMPLE)] * ns)
-    rem_edges.extend([g.edge(v, v, EdgeType.HADAMARD)] * nh)
+    if ns > 0:
+        rem_edges.extend([g.edge(v, v, EdgeType.SIMPLE)] * ns)
+    if nh > 0:
+        rem_edges.extend([g.edge(v, v, EdgeType.HADAMARD)] * nh)
     g.scalar.add_power(-nh)
 
     if nh % 2 == 1:  # A Hadamard self-loop gives a phase of pi

--- a/tests/test_add_identity_rule.py
+++ b/tests/test_add_identity_rule.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
 
 from pyzx.graph.multigraph import Multigraph
 from pyzx.utils import EdgeType, VertexType
-from pyzx.rewrite_rules.add_identity_rule import check_edge, add_Z_identity
+from pyzx.rewrite_rules.add_identity_rule import check_edge, add_Z_identity, unsafe_add_Z_identity
 
 
 class TestAddIdentityRule(unittest.TestCase):
@@ -62,6 +62,19 @@ class TestAddIdentityRule(unittest.TestCase):
         verts_before = g.num_vertices()
         self.assertFalse(add_Z_identity(g, v1, v2))
         self.assertEqual(g.num_vertices(), verts_before)
+
+    def test_unsafe_add_Z_identity_raises_on_ambiguous(self):
+        """``unsafe_add_Z_identity`` must refuse mixed parallels rather than
+        silently picking an edge; callers that bypass ``check_edge`` should
+        see a clear ``ValueError`` instead of a wrong rewrite."""
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        with self.assertRaises(ValueError):
+            unsafe_add_Z_identity(g, v1, v2)
 
     def test_check_edge_rejects_w_io(self):
         """check_edge rejects vertex pairs joined by W_IO edges, since the rule

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -95,6 +95,103 @@ class TestGraphBasicMethods(unittest.TestCase):
         self.assertEqual(g.phases()[0], 1)
         self.assertEqual(g.phases()[1], 1)
 
+    def test_multigraph_edge_strict_on_parallel_mixed(self):
+        """Multigraph.edge(s, t) without an explicit type must raise when
+        parallel edges of multiple types exist between s and t. Specifying
+        the type explicitly returns that edge."""
+        from pyzx.graph.multigraph import Multigraph
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+
+        with self.assertRaises(ValueError):
+            g.edge(v1, v2)
+
+        e_s = g.edge(v1, v2, EdgeType.SIMPLE)
+        self.assertEqual(g.edge_type(e_s), EdgeType.SIMPLE)
+        e_h = g.edge(v1, v2, EdgeType.HADAMARD)
+        self.assertEqual(g.edge_type(e_h), EdgeType.HADAMARD)
+
+    def test_multigraph_edge_unique_returns_single_edge(self):
+        """Multigraph.edge(s, t) without an explicit type returns the unique
+        edge when only one type is present between s and t."""
+        from pyzx.graph.multigraph import Multigraph
+        g = Multigraph()
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        e = g.edge(v1, v2)
+        self.assertEqual(g.edge_type(e), EdgeType.HADAMARD)
+
+    def test_multigraph_edge_missing_raises(self):
+        """Multigraph.edge raises ValueError (not KeyError) when called on
+        endpoints with no edge between them, including when one endpoint is
+        not a vertex of the graph at all."""
+        from pyzx.graph.multigraph import Multigraph
+        g = Multigraph()
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        with self.assertRaises(ValueError):
+            g.edge(v1, v2, EdgeType.HADAMARD)
+        with self.assertRaises(ValueError):
+            g.edge(v1, 999)
+        with self.assertRaises(ValueError):
+            g.edge(999, v1)
+
+    def test_unsafe_hopf_with_mixed_parallels(self):
+        """``unsafe_hopf`` cancels the type appropriate for the spider colours
+        even when the ``Multigraph`` carries parallel edges of both types: a
+        Z-Z pair with two HADAMARDs (Hopf-cancelling) plus a stray SIMPLE
+        loses both HADAMARDs and keeps the SIMPLE."""
+        from pyzx.graph.multigraph import Multigraph
+        from pyzx.rewrite_rules.hopf_rule import unsafe_hopf
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        self.assertTrue(unsafe_hopf(g, v1, v2))
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.HADAMARD), 0)
+        self.assertEqual(g.num_edges(v1, v2, EdgeType.SIMPLE), 1)
+
+    def test_check_pivot_rejects_mixed_parallels(self):
+        """``check_pivot`` rejects a vertex pair that has a SIMPLE parallel
+        alongside a HADAMARD edge, since pivot is only defined on a clean
+        Hadamard edge."""
+        from pyzx.graph.multigraph import Multigraph
+        from pyzx.rewrite_rules.pivot_rule import check_pivot
+        g = Multigraph()
+        g.set_auto_simplify(False)
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.HADAMARD)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        self.assertFalse(check_pivot(g, v1, v2))
+
+    def test_graph_s_edge_signature_and_canonical_pair(self):
+        """``GraphS.edge`` accepts the optional ``et`` argument added on
+        :meth:`BaseGraph.edge` (so backend-agnostic callers that pass an edge
+        type do not raise ``TypeError``), but ``GraphS`` does not consult
+        ``et``: the canonical ``(min(s, t), max(s, t))`` pair is returned
+        regardless of whether an edge already exists, supporting the
+        documented ``g.add_edge(g.edge(v, w), edgetype=...)`` pattern."""
+        g = Graph()
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        # The canonical pair is returned before any edge exists.
+        self.assertEqual(g.edge(v1, v2), (v1, v2))
+        self.assertEqual(g.edge(v2, v1), (v1, v2))
+        # The optional ``et`` argument is accepted but does not change the result.
+        self.assertEqual(g.edge(v1, v2, EdgeType.HADAMARD), (v1, v2))
+        g.add_edge(g.edge(v1, v2), edgetype=EdgeType.HADAMARD)
+        self.assertEqual(g.edge_type(g.edge(v1, v2)), EdgeType.HADAMARD)
+
     def test_set_attributes(self):
         g = Graph()
         v = g.add_vertex()

--- a/tests/test_pauliweb.py
+++ b/tests/test_pauliweb.py
@@ -22,6 +22,7 @@ if __name__ == '__main__':
     sys.path.append('..')
     sys.path.append('.')
 
+from pyzx.graph import Graph
 from pyzx.graph.multigraph import Multigraph
 from pyzx.pauliweb import PauliWeb
 from pyzx.utils import EdgeType, VertexType
@@ -29,9 +30,10 @@ from pyzx.utils import EdgeType, VertexType
 
 class TestPauliWeb(unittest.TestCase):
 
-    def test_add_edge_multigraph_mixed_parallels_uses_simple(self):
-        """On a multigraph with mixed parallel edges, PauliWeb.add_edge falls
-        back to the SIMPLE edge for its per-pair labelling."""
+    def test_add_edge_multigraph_mixed_parallels_raises(self):
+        """``PauliWeb.add_edge`` labels edges by ordered vertex pair, which
+        cannot distinguish mixed parallel edge types, so it must refuse to
+        guess and raise ``ValueError`` instead of silently picking one."""
         g = Multigraph()
         g.set_auto_simplify(False)
         v1 = g.add_vertex(VertexType.Z, 0, 0)
@@ -39,10 +41,35 @@ class TestPauliWeb(unittest.TestCase):
         g.add_edge((v1, v2), EdgeType.SIMPLE)
         g.add_edge((v1, v2), EdgeType.HADAMARD)
         pw = PauliWeb(g)
+        with self.assertRaises(ValueError):
+            pw.add_edge((v1, v2), 'X')
+
+    def test_add_edge_missing_edge_raises(self):
+        """``PauliWeb.add_edge`` must reject a disconnected vertex pair. On the
+        simple backend ``edge``/``edge_type`` return a canonical pair and type
+        even when no edge exists, so without an explicit check the web would
+        silently label a non-existent edge."""
+        g = Graph()
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        pw = PauliWeb(g)
+        with self.assertRaises(ValueError):
+            pw.add_edge((v1, v2), 'X')
+
+    def test_graph_with_errors_missing_edge_raises(self):
+        """``graph_with_errors`` must raise a clear ``ValueError`` (not an
+        opaque ``KeyError`` from ``remove_edge``) when the web references an
+        edge that the underlying graph no longer contains."""
+        g = Graph()
+        v1 = g.add_vertex(VertexType.Z, 0, 0)
+        v2 = g.add_vertex(VertexType.Z, 0, 1)
+        g.add_edge((v1, v2), EdgeType.SIMPLE)
+        pw = PauliWeb(g)
         pw.add_edge((v1, v2), 'X')
-        # Treated as a SIMPLE edge: both half-edges carry the same Pauli.
-        self.assertEqual(pw[(v1, v2)], 'X')
-        self.assertEqual(pw[(v2, v1)], 'X')
+        # Drop the edge the web references, so rebuilding the graph must fail.
+        g.remove_edge(g.edge(v1, v2))
+        with self.assertRaises(ValueError):
+            pw.graph_with_errors()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

## Description

Previously, when a `Multigraph` has both a simple and Hadamard edge between two vertices, some operations would silently return incorrect results by conflating the edges. This change makes `Multigraph` complain loudly when this happens, and forces the caller to be more specific about the expected edge type.

## Related issue

#439

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.