### PR TITLE
add `settings.strict_phase_types` to reject float phases at graph entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Added
 - Added the "magic cat" decomposition strategy from https://arxiv.org/pdf/2202.09202 (which previously only existed in Quizx). (by @mjsutcliffe99).
+- `settings.strict_phase_types` (default `True`) rejects float phases at `set_phase`/`add_to_phase` rather than letting them flow into the graph and crash downstream rewrite rules. Set to `False` to opt in to automatic conversion to `Fraction` using `settings.float_to_fraction_max_denominator`, accepting the resulting precision loss. Fixes crash in `full_reduce` with non-Clifford spiders (by @dlyongemallo).
 
 ## [0.10.3] - 2026-06-01
 

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -357,8 +357,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             else: phase = 0
         self.set_qubit(v, qubit)
         self.set_row(v, row)
-        if phase:
-            self.set_phase(v, phase)
+        self.set_phase(v, phase)
         if ground:
             self.set_ground(v, True)
         if self.track_phases:

--- a/pyzx/graph/graph_ig.py
+++ b/pyzx/graph/graph_ig.py
@@ -21,7 +21,7 @@ except ImportError:
 	ig = None
 
 from .base import BaseGraph, VertexType, EdgeType
-from ..utils import assert_phase_real
+from ..utils import assert_phase_real, normalize_phase
 
 class GraphIG(BaseGraph):
 	"""Implementation of :class:`~graph.base.BaseGraph` using ``python-igraph`` 
@@ -137,7 +137,15 @@ class GraphIG(BaseGraph):
 
 	def set_phase(self, vertex, phase):
 		assert_phase_real(phase)
-		self.graph.vs[vertex]['_a'] = phase % 2
+		self.graph.vs[vertex]['_a'] = normalize_phase(phase) % 2
+
+	def add_to_phase(self, vertex, phase):
+		# Normalize the incoming phase before adding it so the existing exact
+		# phase is not lost to float arithmetic, matching `GraphS` and
+		# `Multigraph`.
+		assert_phase_real(phase)
+		phase = normalize_phase(phase)
+		self.set_phase(vertex, self.phase(vertex) + phase)
 
 	def qubit(self, vertex):
 		return self.graph.vs[vertex]['_q'] or -1

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -19,7 +19,7 @@ from typing import Generator, Iterable, Any
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real
+from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real, normalize_phase
 
 class GraphS(BaseGraph[int, tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
@@ -338,6 +338,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
     
     def set_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
+        phase = normalize_phase(phase)
         try:
             self._phase[vertex] = phase % 2
         except Exception:
@@ -345,6 +346,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
     
     def add_to_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
+        phase = normalize_phase(phase)
         old_phase = self._phase.get(vertex, Fraction(1))
         try:
             self._phase[vertex] = (old_phase + phase) % 2

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -21,7 +21,7 @@ from typing import Iterable, Any, cast
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, set_z_box_label, get_z_box_label, assert_phase_real
+from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, set_z_box_label, get_z_box_label, assert_phase_real, normalize_phase
 
 class Edge:
     """A structure for storing the number of simple and number of Hadamard edges
@@ -423,6 +423,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     
     def set_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
+        phase = normalize_phase(phase)
         try:
             if isinstance(phase, Fraction):
                 self._phase[vertex] = phase % 2
@@ -433,6 +434,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     
     def add_to_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
+        phase = normalize_phase(phase)
         old_phase = self._phase.get(vertex, Fraction(1))
         try:
             if isinstance(old_phase, Fraction) and isinstance(phase, Fraction):

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -16,6 +16,7 @@
 
 import cmath
 import math
+import numbers
 import os
 from argparse import ArgumentTypeError
 from enum import IntEnum
@@ -42,6 +43,38 @@ def assert_phase_real(phase: FractionLike | complex) -> None:
             if isinstance(c, complex) and c.imag != 0:
                 raise TypeError(
                     f"Phase must have real coefficients, got {c}")
+
+
+def normalize_phase(phase: Any) -> FractionLike:
+    """Coerce a phase to a supported type (``int``, ``Fraction``, or ``Poly``).
+
+    When ``settings.strict_phase_types`` is ``True`` (the default), a float-valued
+    phase raises ``TypeError`` rather than being silently rounded. Set
+    ``settings.strict_phase_types`` to ``False`` to opt in to automatic
+    conversion to ``Fraction`` using
+    ``settings.float_to_fraction_max_denominator``, accepting the resulting
+    precision loss. Other types are returned unchanged.
+
+    Both built-in ``float`` and non-integer numpy reals such as ``numpy.float32``
+    are treated as float-valued; numpy's ``float64`` already inherits from
+    ``float`` and is caught by the built-in branch.
+    """
+    is_float_like = isinstance(phase, float) or (
+        isinstance(phase, numbers.Real)
+        and not isinstance(phase, (int, Fraction, numbers.Integral))
+    )
+    if is_float_like:
+        if settings.strict_phase_types:
+            raise TypeError(
+                f"Float phase {phase!r} is not accepted by default. Float "
+                "phases would be silently rounded to a nearby fraction; "
+                "if that is acceptable, opt in by setting "
+                "`pyzx.settings.strict_phase_types = False` (the resulting "
+                "fraction uses `pyzx.settings.float_to_fraction_max_denominator`)."
+            )
+        return Fraction(float(phase)).limit_denominator(
+            settings.float_to_fraction_max_denominator)
+    return phase
 
 
 class VertexType(IntEnum):
@@ -131,16 +164,18 @@ def phase_fraction_to_s(a: FractionLike, t:VertexType=VertexType.Z, limit_denomi
     return simstr + ns + '\u03c0' + ds
 
 def phase_is_clifford(phase: FractionLike):
+    if isinstance(phase, Poly):
+        return phase.is_clifford
     if isinstance(phase, (Fraction, int)):
         return phase in [Fraction(i, 2) for i in range(4)]
-    else:
-        return phase.is_clifford
+    raise TypeError(f"phase must be FractionLike, got {type(phase).__name__}")
 
 def phase_is_pauli(phase: FractionLike):
+    if isinstance(phase, Poly):
+        return phase.is_pauli
     if isinstance(phase, (Fraction, int)):
         return phase in (0, 1)
-    else:
-        return phase.is_pauli
+    raise TypeError(f"phase must be FractionLike, got {type(phase).__name__}")
 
 tikz_classes = {
     'boundary': 'none',
@@ -205,6 +240,10 @@ class Settings(object): # namespace class
     # Maximum denominator when converting floats to fractions (e.g., for phase values).
     # Higher values preserve more precision but may produce larger fractions.
     float_to_fraction_max_denominator: int = 2**20
+    # When True, reject float phases at `set_phase`/`add_to_phase` rather than
+    # silently rounding them to a nearby fraction. Set to False to opt in to
+    # automatic conversion using `float_to_fraction_max_denominator`.
+    strict_phase_types: bool = True
     drawing_auto_hbox: bool = False
     javascript_location: str = "" # Path to javascript files of pyzx
     d3_load_string: str = ""

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -62,7 +62,7 @@ class TestExtract(unittest.TestCase):
     def test_extract_not_graph_like(self):
         c = Circuit(1)
         c.add_gate("HAD", 0)
-        c.add_gate("ZPhase", 0, phase=1/4)
+        c.add_gate("ZPhase", 0, phase=Fraction(1, 4))
 
         g = c.to_graph()
 

--- a/tests/test_quimb.py
+++ b/tests/test_quimb.py
@@ -18,6 +18,7 @@
 import unittest
 import sys
 import warnings
+from fractions import Fraction
 from types import ModuleType
 from typing import Optional
 
@@ -105,8 +106,8 @@ class TestMapping(unittest.TestCase):
         # connected by a simple edge.
         g = Graph()
         x = g.add_vertex(VertexType.BOUNDARY)
-        v = g.add_vertex(VertexType.Z, phase = 1. / 6.)
-        w = g.add_vertex(VertexType.Z, phase = 1. / 3.)
+        v = g.add_vertex(VertexType.Z, phase = Fraction(1, 6))
+        w = g.add_vertex(VertexType.Z, phase = Fraction(1, 3))
         y = g.add_vertex(VertexType.BOUNDARY)
 
         g.add_edge(g.edge(x, v), edgetype = EdgeType.SIMPLE)
@@ -123,8 +124,8 @@ class TestMapping(unittest.TestCase):
 
     def test_scalar(self):
         g = Graph()
-        x = g.add_vertex(VertexType.Z, row = 0, phase = 1 / 2)
-        y = g.add_vertex(VertexType.Z, row = 1, phase = 1 / 4)
+        x = g.add_vertex(VertexType.Z, row = 0, phase = Fraction(1, 2))
+        y = g.add_vertex(VertexType.Z, row = 1, phase = Fraction(1, 4))
         g.add_edge(g.edge(x, y), edgetype = EdgeType.SIMPLE)
 
         full_reduce(g)
@@ -135,8 +136,6 @@ class TestMapping(unittest.TestCase):
     def test_sum_of_phases_scalar(self):
         # Regression test for issue #373: two non-Clifford Z-spiders connected
         # by Hadamard edge populate sum_of_phases when removed.
-        from fractions import Fraction
-
         g = Graph()
         v1 = g.add_vertex(VertexType.Z, phase=Fraction(1, 8))
         v2 = g.add_vertex(VertexType.Z, phase=Fraction(3, 8))

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -410,9 +410,9 @@ class TestSimplify(unittest.TestCase):
         """Test that checks whether a scalar is correctly removed from a graph using full_reduce.
         """
 
-        from pyzx import Graph, full_reduce 
+        from pyzx import Graph, full_reduce
         g = Graph()
-        g.add_vertex(ty=VertexType.Z, phase=0.5)
+        g.add_vertex(ty=VertexType.Z, phase=Fraction(1, 2))
         g.add_vertex(ty=VertexType.Z, phase=1)
         g.add_edge((0, 1))
 
@@ -422,9 +422,46 @@ class TestSimplify(unittest.TestCase):
         g1.add_vertex(ty=VertexType.Z, phase=1)
 
         full_reduce(g1)
-        
+
         self.assertTrue(g.num_vertices() == 0)
         self.assertTrue(g1.num_vertices() == 0)
+
+    def test_float_phase_rejected_under_strict(self):
+        """Regression test for issue #457.
+
+        Under the default ``settings.strict_phase_types = True``, a float
+        phase must be rejected at the graph entry point with a clear
+        ``TypeError`` rather than crashing deep inside a rewrite rule.
+        """
+        from pyzx import settings
+        self.assertTrue(settings.strict_phase_types)
+        for value in (0.0, 0.5, 0.124312):
+            with self.subTest(value=value):
+                g = Graph()
+                with self.assertRaises(TypeError) as cm:
+                    g.add_vertex(VertexType.Z, phase=value)
+                self.assertIn("strict_phase_types", str(cm.exception))
+
+    def test_float_phase_opt_in_conversion(self):
+        """Opting out of strict phase types coerces floats to ``Fraction``.
+
+        ``full_reduce`` then runs to completion without crashing, and the
+        surviving non-Clifford spider carries the converted phase.
+        """
+        from pyzx import settings
+        c = Circuit(1)
+        c.add_gate("ZPhase", 0, phase=0.124312)
+        settings.strict_phase_types = False
+        try:
+            g = c.to_graph()
+            full_reduce(g)
+        finally:
+            settings.strict_phase_types = True
+        zs = [v for v in g.vertices() if g.type(v) == VertexType.Z]
+        self.assertEqual(len(zs), 1)
+        phase = g.phase(zs[0])
+        self.assertIsInstance(phase, Fraction)
+        self.assertAlmostEqual(float(phase), 0.124312)
 
 
     def test_to_clifford_normal_form_graph(self):


### PR DESCRIPTION
## Description

The library implicitly accepts float phases, which only worked by accident in many code paths. `full_reduce` crashed with `AttributeError` on a spider carrying a float phase because rewrite rules assumed `FractionLike`. 

Floats reaching `set_phase`/`add_to_phase` are now rejected with a `TypeError` by default, surfacing a clear error at the entry point instead of crashing deep inside a rewrite rule. 

Setting `pyzx.settings.strict_phase_types = False` opts in to automatic conversion via `settings.float_to_fraction_max_denominator`.

## Related issue

#457

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.