### PR TITLE
fix boundary pivot and gadget pivot matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 ### Changed
 - Refactored the simulation API to make it more formulaic and extensible. Individual decompositions are no longer included as distinct functions inside pyzx.simulate.py but now are provided their own individual files under pyzx.simulation.decompositions and share a common caller function. For example, pyzx.simulate.apply_cat3(g,v) is instead now pyzx.simulation.apply_decomp(Decomp.CAT_3,g,v), etc. (by @mjsutcliffe99).
 - Likewise, decomposition strategies are separated into individual files under pyzx.simulation.strategies and called similarly through e.g. zx.simulation.full_decompose(Strategy.BSS,g). (by @mjsutcliffe99).
+- `pivot_boundary_simp` and `pivot_gadget_simp` are now `RewriteSimpDoubleVertex` instances (previously `RewriteSimpGraph`), so their `is_match` and `apply` methods take two vertices `(v, w)` rather than a `List[VT]`. Whole-graph simplification (calling them as a function or via `simp()`) is unchanged. This is a breaking change for code that relied on the old `apply(graph, vertices)` signature. (by @dlyongemallo)
 
 ### Fixed
 - Multigraph handling of parallel mixed simple/Hadamard edges in tensor contraction, several rewrite rules, and `PauliWeb` (by @dlyongemallo).
 - Reset gate representation changed from ground-based to symbolic boolean paradigm, avoiding paradigm-mixing issues that destroyed measurement phases during simplification of circuits with mid-circuit resets. As a side effect, `graph_to_circuit` now recovers conditional X-type rotations (`NOT`, `XPhase`, `SX`), since X-type vertices on the qubit wire are unambiguous now that measurement outcomes are represented as leaves. `Circuit.to_graph` gains an opt-in `elide_initial_resets` flag (default `False`) that skips the discard chain for a `Reset` on an unmodified input wire, useful for circuits with OpenQASM-style implicit |0⟩ inputs. Each `_rN` reset variable is allocated to the lowest name not already in the graph's variable registry to avoid aliasing user-supplied phases, and `graph_to_circuit` excludes vertices on classical-bit wires (e.g. the `Z`/`X` pair from `DiscardBit`) so hybrid graphs round-trip without extra phantom qubits (by @dlyongemallo).
-* `match_pivot_boundary` skipped exclusion of grounded neighbours
+- The boundary and gadget pivot rules now correctly match the `(P2)` and `(P3)` rules in the paper [arXiv:1903.10477](https://doi.org/10.1103/PhysRevA.102.022406) when applied manually, e.g., from ZXLive (by @dlyongemallo).
 
 ## [0.10.2] - 2026-05-01
 

--- a/pyzx/rewrite.py
+++ b/pyzx/rewrite.py
@@ -177,19 +177,29 @@ class RewriteSimpDoubleVertex(RewriteDoubleVertex[VT, ET]):
     rmv_isolated : bool
         whether to remove isolated vertices after running the applier.
     is_ordered : bool
-        whether to order vertices after running the check.
+        whether the matcher distinguishes the order of its two vertex arguments.
+        If False (the default), `(v1, v2)` and `(v2, v1)` are deduplicated by sorting
+        before being added to the match set. If True, both orderings are kept as
+        distinct matches; use this when the rule is asymmetric in its arguments.
+    simp_override : Optional[Callable[[BaseGraph[VT, ET]], bool]]
+        optional whole-graph routine to run instead of the default per-pair simp loop.
+        Use this when the rule needs to batch-match before any apply (e.g., rules
+        that introduce new vertices which would otherwise interact with later matches).
     """
     simp_match: Optional[Callable[[BaseGraph[VT, ET], VT, VT], bool]]
+    simp_override: Optional[Callable[[BaseGraph[VT, ET]], bool]]
     is_ordered: bool
 
     def __init__(self, is_match: Callable[[BaseGraph[VT, ET], VT, VT], bool],
                  applier: Callable[[BaseGraph[VT, ET], VT, VT], bool],
                  simp_match: Optional[Callable[[BaseGraph[VT, ET], VT, VT], bool]] = None,
                  is_ordered: bool = False,
-                 rmv_isolated: bool = False) -> None:
+                 rmv_isolated: bool = False,
+                 simp_override: Optional[Callable[[BaseGraph[VT, ET]], bool]] = None) -> None:
         super().__init__(is_match, applier, rmv_isolated)
         self.simp_match = simp_match
         self.is_ordered = is_ordered
+        self.simp_override = simp_override
 
     def find_all_matches(self, graph: BaseGraph[VT, ET]) -> Set[Tuple[VT, VT]]:
         all_matches: Set[Tuple[VT, VT]] = set()
@@ -207,12 +217,18 @@ class RewriteSimpDoubleVertex(RewriteDoubleVertex[VT, ET]):
         return all_matches
 
     def simp(self, graph: BaseGraph[VT, ET]) -> bool:
+        applied: bool = False
+        if self.simp_override is not None:
+            applied = self.simp_override(graph)
+            if applied and self.rmv_isolated:
+                graph.remove_isolated_vertices()
+            return applied
+
         if self.simp_match is not None:
             match = self.simp_match
         else:
             match = self.is_match
 
-        applied: bool = False
         while True:
             j = 0
             all_matches = self.find_all_matches(graph)

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -17,16 +17,25 @@
 """
 This module contains the implementation of the pivot rule, and three different matching functions.
 
-The default pivot should be called using simplify.pivot_simp
+The default pivot should be called using simplify.pivot_simp.
 
-Pivot boundary and pivot gadget act on an entire graph and the matchers modify the graph, so these rule should only be run
-using the using simplify.pivot_gadget_simp(g) or simplify.pivot_boundary_simp(g).
+The boundary and gadget pivot variants expose two-vertex is_match/apply interfaces
+(check_pivot_boundary/unsafe_pivot_boundary and check_pivot_gadget/unsafe_pivot_gadget),
+which can be applied manually to a single (v, w) pair, e.g., from ZXLive. Whole-graph
+simplification falls back to the batch matchers pivot_boundary_for_simp and
+pivot_gadget_for_simp because the per-pair appliers gadgetize w in place; running them
+one at a time would let gadget vertices created by an earlier pivot participate in
+later matches.
 """
 
 __all__ = [
         'check_pivot',
+        'check_pivot_boundary',
+        'check_pivot_gadget',
         'pivot',
         'unsafe_pivot',
+        'unsafe_pivot_boundary',
+        'unsafe_pivot_gadget',
         'pivot_boundary_for_simp',
         'pivot_boundary_for_apply',
         'pivot_gadget_for_simp',
@@ -100,6 +109,84 @@ def check_pivot(
 
     return len(b0) + len(b1) <= 1
 
+
+def check_pivot_boundary(
+        g: BaseGraph[VT,ET],
+        v: VT,
+        w: VT
+        ) -> bool:
+    """Checks if a boundary pivot can be applied between an interior Pauli
+    vertex ``v`` and a non-Pauli Z-spider ``w`` with exactly one boundary neighbour.
+
+    :param g: An instance of a ZX-graph.
+    :param v: An interior Pauli vertex.
+    :param w: A non-Pauli Z-spider with exactly one boundary neighbour, adjacent to ``v``.
+    """
+    types = g.types()
+    phases = g.phases()
+    if not (v in g.vertices() and w in g.vertices()): return False
+    if not g.connected(v, w): return False
+
+    if g.edge_type(g.edge(v, w)) != EdgeType.HADAMARD: return False
+
+    if not (types[v] == VertexType.Z and types[w] == VertexType.Z): return False
+
+    if not phase_is_pauli(phases[v]): return False
+    if phase_is_pauli(phases[w]): return False
+    if g.is_ground(v) or g.is_ground(w): return False
+
+    # v's neighbours (including w) must not be grounded, matching match_pivot_boundary.
+    if any(g.is_ground(n) for n in g.neighbors(v)): return False
+
+    # v must be interior (no boundary neighbours).
+    v_boundaries = boundary_list_for_vertex(g, v)
+    if v_boundaries is None or len(v_boundaries) != 0: return False
+
+    # w must have exactly one boundary neighbour.
+    w_boundaries = boundary_list_for_vertex(g, w)
+    if w_boundaries is None or len(w_boundaries) != 1: return False
+
+    return True
+
+
+def check_pivot_gadget(
+        g: BaseGraph[VT,ET],
+        v: VT,
+        w: VT
+        ) -> bool:
+    """Checks if a gadget pivot can be applied between an interior Pauli
+    vertex ``v`` and an interior non-Pauli vertex ``w``.
+
+    :param g: An instance of a ZX-graph.
+    :param v: An interior Pauli vertex.
+    :param w: An interior non-Pauli vertex adjacent to ``v``.
+    """
+    types = g.types()
+    phases = g.phases()
+    if not (v in g.vertices() and w in g.vertices()): return False
+    if not g.connected(v, w): return False
+
+    if g.edge_type(g.edge(v, w)) != EdgeType.HADAMARD: return False
+
+    if not (types[v] == VertexType.Z and types[w] == VertexType.Z): return False
+
+    if not phase_is_pauli(phases[v]): return False
+    if phase_is_pauli(phases[w]): return False
+    if g.is_ground(v) or g.is_ground(w): return False
+
+    # w must not be a phase gadget (leaf vertex).
+    if len(g.neighbors(w)) == 1: return False
+
+    # Both must be interior (no boundary neighbours).
+    v_boundaries = boundary_list_for_vertex(g, v)
+    if v_boundaries is None or len(v_boundaries) != 0: return False
+
+    w_boundaries = boundary_list_for_vertex(g, w)
+    if w_boundaries is None or len(w_boundaries) != 0: return False
+
+    return True
+
+
 ## Pivot Boundary
 
 def pivot_boundary_for_simp(g: BaseGraph[VT,ET]) -> bool:
@@ -129,6 +216,54 @@ def pivot_gadget_for_apply(g: BaseGraph[VT,ET], vertices: List[VT]) -> bool:
     matches = match_pivot_gadget(g, checked_vertices)
     if len(matches) <= 0: return False
     return pivot_NOT_REWORKED(g, matches)
+
+def unsafe_pivot_boundary(
+        g: BaseGraph[VT,ET],
+        v: VT,
+        w: VT
+        ) -> bool:
+    """Perform a boundary pivot by gadgetizing ``w`` and then pivoting on ``(v, w)``."""
+    inputs = g.inputs()
+
+    w_boundaries = boundary_list_for_vertex(g, w)
+    assert w_boundaries is not None and len(w_boundaries) == 1
+    bound = w_boundaries[0]
+
+    if bound in inputs: mod = 0.5
+    else: mod = -0.5
+
+    # g.row() returns -1 for vertices without an explicit row index, rather than raising.
+    w_row = g.row(w) + mod
+    v1 = g.add_vertex(VertexType.Z, -2, w_row, g.phase(w))
+    v2 = g.add_vertex(VertexType.Z, -1, w_row, 0)
+    g.update_phase_index(w, v1)
+    g.set_phase(w, 0)
+    g.add_edges([(w, v2), (v1, v2)], EdgeType.HADAMARD)
+
+    return unsafe_pivot(g, v, w)
+
+
+def unsafe_pivot_gadget(
+        g: BaseGraph[VT,ET],
+        v: VT,
+        w: VT
+        ) -> bool:
+    """Perform a gadget pivot by gadgetizing ``w`` and then pivoting on ``(v, w)``.
+
+    The gadget edge is created as SIMPLE because the pivot's boundary handling
+    toggles the edge type, resulting in the correct HADAMARD gadget edge."""
+    # Mirror the placement and qubit handling done by match_pivot_gadget so that
+    # apply produces the same vertex metadata as the batch simp.
+    v_new = g.add_vertex(VertexType.Z, -2, g.row(v), g.phase(w))
+    g.set_phase(w, 0)
+    g.set_qubit(v, -1)
+    g.update_phase_index(w, v_new)
+    g.add_edge((v_new, w), EdgeType.SIMPLE)
+
+    # Apply pivot treating v_new as a pseudo-boundary of w.
+    match: MatchPivotType[VT] = ((v, w), ([], [v_new]))
+    return pivot_NOT_REWORKED(g, [match])
+
 
 def match_pivot_boundary(
         g: BaseGraph[VT,ET],

--- a/pyzx/simplify.py
+++ b/pyzx/simplify.py
@@ -71,11 +71,15 @@ class Stats(object):
 pivot_simp: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(check_pivot, unsafe_pivot)
 """Performs a pivot rewrite. Can be run automatically on the entire graph."""
 
-pivot_gadget_simp: RewriteSimpGraph = RewriteSimpGraph(pivot_gadget_for_apply, pivot_gadget_for_simp)
-"""Performs pivot rewrite on an interior Pauli vertex and an interior non-Clifford vertex. Should only be run on the entire graph."""
+pivot_gadget_simp: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(
+    check_pivot_gadget, unsafe_pivot_gadget,
+    is_ordered=True, simp_override=pivot_gadget_for_simp)
+"""Performs pivot rewrite on an interior Pauli vertex and an interior non-Pauli vertex."""
 
-pivot_boundary_simp: RewriteSimpGraph = RewriteSimpGraph(pivot_boundary_for_apply, pivot_boundary_for_simp)
-"""Performs pivot rewrite on an interior Pauli vertex and a boundary non-Pauli Clifford vertex. Should only be run on the entire graph."""
+pivot_boundary_simp: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(
+    check_pivot_boundary, unsafe_pivot_boundary,
+    is_ordered=True, simp_override=pivot_boundary_for_simp)
+"""Performs pivot rewrite on an interior Pauli vertex and a non-Pauli Z-spider with exactly one boundary neighbour."""
 
 lcomp_simp: RewriteSimpSingleVertex = RewriteSimpSingleVertex(check_lcomp, unsafe_lcomp)
 """Performs a local complementation rewrite on a given vertex. Can be run automatically on the entire graph."""

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -177,6 +177,184 @@ class TestSimplify(unittest.TestCase):
         self.assertEqual(match_pivot_boundary(g), [])
         self.assertEqual(len(list(g.vertices())), vertex_count_before)
 
+    def _make_boundary_pivot_graph(self):
+        """Build a boundary-pivot configuration: interior Pauli ``v``
+        adjacent to non-Pauli ``w`` with exactly one boundary neighbour."""
+        from pyzx import EdgeType
+        g = Graph()
+        b_in = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        w = g.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1, 4))
+        v = g.add_vertex(VertexType.Z, qubit=0, row=2, phase=Fraction(1))
+        x = g.add_vertex(VertexType.Z, qubit=0, row=3, phase=Fraction(1, 2))
+        b_out = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=4)
+        g.add_edge((b_in, w), EdgeType.SIMPLE)
+        g.add_edge((w, v), EdgeType.HADAMARD)
+        g.add_edge((v, x), EdgeType.HADAMARD)
+        g.add_edge((x, b_out), EdgeType.SIMPLE)
+        g.set_inputs([b_in])
+        g.set_outputs([b_out])
+        return g, v, w
+
+    def _make_gadget_pivot_graph(self):
+        """Build a gadget-pivot configuration matching the example diagram
+        in issue #413: interior Pauli ``v`` adjacent to interior non-Pauli
+        ``w``, each with two boundary-adjacent neighbours plus two shared
+        boundary-adjacent neighbours."""
+        from pyzx import EdgeType
+        g = Graph()
+        v = g.add_vertex(VertexType.Z, qubit=2, row=2, phase=Fraction(1))
+        w = g.add_vertex(VertexType.Z, qubit=3, row=2, phase=Fraction(1, 4))
+
+        # Two boundary-adjacent neighbours of v only (the "a_i" in the issue).
+        a1 = g.add_vertex(VertexType.Z, qubit=0, row=1)
+        ba1 = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        a2 = g.add_vertex(VertexType.Z, qubit=1, row=1)
+        ba2 = g.add_vertex(VertexType.BOUNDARY, qubit=1, row=0)
+        g.add_edge((v, a1), EdgeType.HADAMARD)
+        g.add_edge((a1, ba1), EdgeType.SIMPLE)
+        g.add_edge((v, a2), EdgeType.HADAMARD)
+        g.add_edge((a2, ba2), EdgeType.SIMPLE)
+
+        # Two boundary-adjacent neighbours of w only (the "c_i" in the issue).
+        c1 = g.add_vertex(VertexType.Z, qubit=4, row=3)
+        bc1 = g.add_vertex(VertexType.BOUNDARY, qubit=4, row=4)
+        c2 = g.add_vertex(VertexType.Z, qubit=5, row=3)
+        bc2 = g.add_vertex(VertexType.BOUNDARY, qubit=5, row=4)
+        g.add_edge((w, c1), EdgeType.HADAMARD)
+        g.add_edge((c1, bc1), EdgeType.SIMPLE)
+        g.add_edge((w, c2), EdgeType.HADAMARD)
+        g.add_edge((c2, bc2), EdgeType.SIMPLE)
+
+        # Two shared boundary-adjacent neighbours (the "b_i" in the issue).
+        b1 = g.add_vertex(VertexType.Z, qubit=2, row=3)
+        bb1 = g.add_vertex(VertexType.BOUNDARY, qubit=2, row=4)
+        b2 = g.add_vertex(VertexType.Z, qubit=3, row=3)
+        bb2 = g.add_vertex(VertexType.BOUNDARY, qubit=3, row=4)
+        g.add_edge((v, b1), EdgeType.HADAMARD)
+        g.add_edge((w, b1), EdgeType.HADAMARD)
+        g.add_edge((b1, bb1), EdgeType.SIMPLE)
+        g.add_edge((v, b2), EdgeType.HADAMARD)
+        g.add_edge((w, b2), EdgeType.HADAMARD)
+        g.add_edge((b2, bb2), EdgeType.SIMPLE)
+
+        g.add_edge((v, w), EdgeType.HADAMARD)
+        g.set_inputs([ba1, ba2])
+        g.set_outputs([bb1, bb2, bc1, bc2])
+        return g, v, w
+
+    def test_pivot_boundary_simp_apply(self):
+        """Regression test for issue #413: ``pivot_boundary_simp.apply``
+        matches an interior Pauli vertex paired with a non-Pauli vertex
+        with exactly one boundary neighbour and preserves the tensor.
+        Also exercises the row-index fallback when ``w`` has no explicit
+        row."""
+        g, v, w = self._make_boundary_pivot_graph()
+        self.assertTrue(pivot_boundary_simp.is_match(g, v, w))
+        self.assertFalse(pivot_boundary_simp.is_match(g, w, v))
+
+        t = g.to_tensor()
+        self.assertTrue(pivot_boundary_simp.apply(g, v, w))
+        self.assertTrue(compare_tensors(t, g.to_tensor(), preserve_scalar=True))
+
+        # Graph constructed without an explicit row index for ``w``.
+        g, v, w = self._make_boundary_pivot_graph()
+        del g._rindex[w]
+        self.assertTrue(pivot_boundary_simp.apply(g, v, w))
+
+    def test_pivot_gadget_simp_apply(self):
+        """Regression test for issue #413: ``pivot_gadget_simp.apply``
+        matches an interior Pauli vertex paired with an interior non-Pauli
+        vertex and preserves the tensor. Also exercises the row-index
+        fallback when ``v`` and ``w`` have no explicit rows."""
+        g, v, w = self._make_gadget_pivot_graph()
+        self.assertTrue(pivot_gadget_simp.is_match(g, v, w))
+        self.assertFalse(pivot_gadget_simp.is_match(g, w, v))
+        # The boundary pivot rule should not match this configuration.
+        self.assertFalse(pivot_boundary_simp.is_match(g, v, w))
+
+        t = g.to_tensor()
+        self.assertTrue(pivot_gadget_simp.apply(g, v, w))
+        self.assertTrue(compare_tensors(t, g.to_tensor(), preserve_scalar=True))
+
+        # Graph constructed without explicit row indices for ``v`` and ``w``.
+        g, v, w = self._make_gadget_pivot_graph()
+        del g._rindex[v]
+        del g._rindex[w]
+        self.assertTrue(pivot_gadget_simp.apply(g, v, w))
+
+    def test_pivot_gadget_simp_apply_alignment(self):
+        """Test that ``pivot_gadget_simp.apply`` mirrors the placement and
+        qubit handling done by ``match_pivot_gadget``: the new gadget vertex
+        sits at qubit -2 on the row of the Pauli vertex, and the Pauli vertex
+        is moved to qubit -1."""
+        g, v, w = self._make_gadget_pivot_graph()
+        pauli_row = g.row(v)
+        vertices_before = set(g.vertices())
+        self.assertTrue(pivot_gadget_simp.apply(g, v, w))
+
+        self.assertEqual(g.qubit(v), -1)
+        new_vertices = set(g.vertices()) - vertices_before
+        gadget_vs = [u for u in new_vertices
+                     if g.qubit(u) == -2 and g.row(u) == pauli_row]
+        self.assertEqual(len(gadget_vs), 1)
+
+    def test_pivot_boundary_simp_negative_matches(self):
+        """Test that ``pivot_boundary_simp.is_match`` rejects invalid configurations."""
+        from pyzx import EdgeType
+        g = Graph()
+        b_in = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        w = g.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1, 4))
+        v = g.add_vertex(VertexType.Z, qubit=0, row=2, phase=Fraction(1))
+        b_out = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=3)
+        g.add_edge((b_in, w), EdgeType.SIMPLE)
+        g.add_edge((w, v), EdgeType.HADAMARD)
+        g.add_edge((v, b_out), EdgeType.SIMPLE)
+        g.set_inputs([b_in])
+        g.set_outputs([b_out])
+
+        # v has a boundary neighbour, so the rule should not match.
+        self.assertFalse(pivot_boundary_simp.is_match(g, v, w))
+
+        # Both Pauli; this is a regular pivot match, not a boundary pivot.
+        g2 = Graph()
+        b2 = g2.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        w2 = g2.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1))
+        v2 = g2.add_vertex(VertexType.Z, qubit=0, row=2, phase=Fraction(1))
+        g2.add_edge((b2, w2), EdgeType.SIMPLE)
+        g2.add_edge((w2, v2), EdgeType.HADAMARD)
+        g2.set_inputs([b2])
+        self.assertFalse(pivot_boundary_simp.is_match(g2, v2, w2))
+
+    def test_pivot_gadget_simp_negative_matches(self):
+        """Test that ``pivot_gadget_simp.is_match`` rejects invalid configurations."""
+        from pyzx import EdgeType
+        # w is a phase gadget (degree 1), should not match.
+        g = Graph()
+        v = g.add_vertex(VertexType.Z, qubit=0, row=0, phase=Fraction(1))
+        w = g.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1, 4))
+        n = g.add_vertex(VertexType.Z, qubit=1, row=0)
+        bn = g.add_vertex(VertexType.BOUNDARY, qubit=1, row=1)
+        g.add_edge((v, w), EdgeType.HADAMARD)
+        g.add_edge((v, n), EdgeType.HADAMARD)
+        g.add_edge((n, bn), EdgeType.SIMPLE)
+        g.set_outputs([bn])
+        self.assertFalse(pivot_gadget_simp.is_match(g, v, w))
+
+        # v has a boundary neighbour, so v is not interior.
+        g2 = Graph()
+        b = g2.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        v2 = g2.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1))
+        w2 = g2.add_vertex(VertexType.Z, qubit=0, row=2, phase=Fraction(1, 4))
+        n2 = g2.add_vertex(VertexType.Z, qubit=1, row=2)
+        bn2 = g2.add_vertex(VertexType.BOUNDARY, qubit=1, row=3)
+        g2.add_edge((b, v2), EdgeType.SIMPLE)
+        g2.add_edge((v2, w2), EdgeType.HADAMARD)
+        g2.add_edge((w2, n2), EdgeType.HADAMARD)
+        g2.add_edge((n2, bn2), EdgeType.SIMPLE)
+        g2.set_inputs([b])
+        g2.set_outputs([bn2])
+        self.assertFalse(pivot_gadget_simp.is_match(g2, v2, w2))
+
     def test_lcomp_simp(self):
         self.func_test(lcomp_simp,prepare=[spider_simp,to_gh,spider_simp])
 


### PR DESCRIPTION
## Description

Added `check_pivot_boundary`, `check_pivot_gadget`, `unsafe_pivot_boundary`, and `unsafe_pivot_gadget` functions. Changed `pivot_boundary_simp` and `pivot_gadget_simp` from `RewriteSimpGraph` to `RewriteSimpDoubleVertex` so they expose `is_match` and `find_all_matches`. Overrode `simp()` on both to retain the existing batch-processing behaviour. 

## Related issue

Closes #413. Depends on PR #462

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.