### PR TITLE
Improve type annotations in `pyzx.graph` submodule

### DIFF
--- a/pyzx/altextract.py
+++ b/pyzx/altextract.py
@@ -94,8 +94,9 @@ def alt_extract_circuit(
     qs = g.qubits() # We are assuming that these are objects that update...
     rs = g.rows()   # ...to reflect changes to the graph, so that when...
     # ty = g.types()  # ... g.set_row/g.set_qubit is called, these things update directly to reflect that
+    qubit_count: int = math.ceil(g.qubit_count()) # We take the ceiling because legacy code allows qubit_count to be a float
     phases = g.phases()
-    c = Circuit(g.qubit_count())
+    c = Circuit(qubit_count)
 
     gadgets = {}
     inputs = g.inputs()
@@ -131,7 +132,7 @@ def alt_extract_circuit(
                 g.set_phase(v,0)
 
         # And now on to CZ gates
-        cz_mat = Mat2([[0 for i in range(g.qubit_count())] for j in range(g.qubit_count())])
+        cz_mat = Mat2([[0 for i in range(qubit_count)] for j in range(qubit_count)])
         for v in frontier:
             for w in list(g.neighbors(v)):
                 if w in frontier:
@@ -154,8 +155,8 @@ def alt_extract_circuit(
                 c.add_gate("CNOT",i,j)
                 overlap_data = max_overlap(cz_mat)
 
-        for i in range(g.qubit_count()):
-            for j in range(i+1,g.qubit_count()):
+        for i in range(qubit_count):
+            for j in range(i+1,qubit_count):
                 if cz_mat.data[i][j]==1:
                     c.add_gate("CZ",i,j)
         
@@ -206,11 +207,11 @@ def alt_extract_circuit(
         ops = compute_row_ops(m)
         m1 = ops * m
 
-        cnots = Circuit(g.qubit_count())
-        blocksize = math.ceil(math.log(g.qubit_count(),2)) * 2
+        cnots = Circuit(qubit_count)
+        blocksize = math.ceil(math.log(qubit_count,2)) * 2
         winner = -1
         for bs in range(1,blocksize):
-            cnots1 = Circuit(g.qubit_count())
+            cnots1 = Circuit(qubit_count)
             ops.copy().gauss(full_reduce=True,
                 y=cnots1, blocksize=bs)
             if winner == -1 or len(cnots1.gates) < winner:

--- a/pyzx/editor.py
+++ b/pyzx/editor.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -24,7 +24,7 @@ from typing import Optional, List, Tuple, Set, Dict, Any, Union
 
 import pyperclip # type: ignore # Needed for clipboard actions
 
-from .utils import VertexType
+from .utils import EdgeType, VertexType
 from .utils import settings, get_mode, phase_to_s, FloatInt
 from .drawing import matrix_to_latex
 from .graph import Scalar
@@ -55,25 +55,25 @@ else:
 
 __all__ = ['edit', 'help']
 
-HELP_STRING = """To create an editor, call `e = zx.editor.edit(g)` on a graph g. 
-This will display the editor, and give you access to 
-the underlying Python instance e. Your changes are automatically pushed onto 
+HELP_STRING = """To create an editor, call `e = zx.editor.edit(g)` on a graph g.
+This will display the editor, and give you access to
+the underlying Python instance e. Your changes are automatically pushed onto
 the underlying graph instance g (which can also be accessed as e.graph).
 Adding the optional argument `zx.editor.edit(g,show_matrix=True)` will
 also display the matrix the diagram represents beneath the editor.
 
-Click on edges or vertices to select them. 
+Click on edges or vertices to select them.
 Drag a box or hold shift to select multiple vertices or edges.
 Press delete or backspace to delete the current selection.
 Double-click a vertex to choose its phase.
-Ctrl-click (Command-click for mac users) on empty space to add a new vertex. 
+Ctrl-click (Command-click for mac users) on empty space to add a new vertex.
 The type of the vertex is determined by the box "Vertex type".
-Click this box (or press the hotkey 'x') to change the adding type. 
-Ctrl-drag between two vertices to add an edge between them. 
+Click this box (or press the hotkey 'x') to change the adding type.
+Ctrl-drag between two vertices to add an edge between them.
 The type of edge is determined by the box "Edge type".
 Click this box (or press the hotkey 'e') to change the adding type.
 
-When you have a selection, the buttons below the graph light up to denote that 
+When you have a selection, the buttons below the graph light up to denote that
 a rewrite rule can be applied to some of the vertices or edges in this selection.
 Press Ctrl+C to copy the selection as tikz code onto the clipboard.
 Press Ctrl+V to paste a ZX-diagram on the clipboard (specified as tikz) into the editor.
@@ -119,7 +119,7 @@ def load_js() -> None:
 	display(HTML(text))
 
 def s_to_phase(s: str, t:VertexType=VertexType.Z) -> Fraction:
-	if not s: 
+	if not s:
 		if t!= VertexType.H_BOX: return Fraction(0)
 		else: return Fraction(1)
 	s = s.replace('\u03c0', '')
@@ -171,9 +171,9 @@ class ZXEditorWidget(widgets.DOMWidget):
 	action 		   = Unicode('').tag(sync=True)
 	
 	def __init__(
-			self, 
-			graph: GraphS, 
-			show_matrix:bool=False, 
+			self,
+			graph: GraphS,
+			show_matrix:bool=False,
 			show_scalar:bool=False,
 			*args, **kwargs
 			) -> None:
@@ -244,7 +244,7 @@ class ZXEditorWidget(widgets.DOMWidget):
 			with self.output: print(traceback.format_exc())
 
 	def _apply_operation(self, change):
-		"""called when one of the action buttons is clicked. 
+		"""called when one of the action buttons is clicked.
 		Performs the action on the selection."""
 		try:
 			op = change['new']
@@ -266,7 +266,7 @@ class ZXEditorWidget(widgets.DOMWidget):
 			selection = json.loads(self.graph_selected)
 			selection["nodes"] = [v for v in selection["nodes"] if v["name"] not in rem_verts]
 			selection["links"] = [e for e in selection["links"] if (
-										(e["source"], e["target"]) not in rem_edges 
+										(e["source"], e["target"]) not in rem_edges
 										and e["source"] not in rem_verts
 										and e["target"] not in rem_verts)]
 			self.graph_selected = json.dumps(selection)
@@ -370,33 +370,33 @@ class ZXEditorWidget(widgets.DOMWidget):
 	def graph_from_json(self, js: Dict[str,Any]) -> None:
 		try:
 			scale = self.graph.scale # type: ignore
-			marked: Union[Set[int],Set[Tuple[int,int]]] = self.graph.vertex_set()
+			marked = self.graph.vertex_set()
 			for n in js["nodes"]:
 				v = n["name"]
 				r = float(n["x"])/scale -1
 				q = float(n["y"])/scale -2
-				t = int(n["t"])
-				phase = s_to_phase(n["phase"], t) # type: ignore
+				vt = VertexType(int(n["t"]))
+				phase = s_to_phase(n["phase"], vt) # type: ignore
 				if v not in marked:
 					self.graph.add_vertex_indexed(v)
-				else: 
+				else:
 					marked.remove(v)
 				self.graph.set_position(v, q, r)
 				self.graph.set_phase(v, phase)
-				self.graph.set_type(v, t)
+				self.graph.set_type(v, vt)
 			self.graph.remove_vertices(marked)
-			marked = self.graph.edge_set()
+			marked_edges = self.graph.edge_set()
 			for e in js["links"]:
 				s = int(e["source"])
 				t = int(e["target"])
-				et = int(e["t"])
-				if self.graph.connected(s,t):
-					f = self.graph.edge(s,t)
-					marked.remove(f)
+				et = EdgeType(int(e["t"]))
+				if self.graph.connected(s, t):
+					f = self.graph.edge(s, t)
+					marked_edges.remove(f)
 					self.graph.set_edge_type(f, et)
 				else:
-					self.graph.add_edge((s,t),et) # type: ignore
-			self.graph.remove_edges(marked)
+					self.graph.add_edge((s, t), et) # type: ignore
+			self.graph.remove_edges(marked_edges)
 			if 'scalar' in js:
 				self.graph.scalar = Scalar.from_json(js['scalar'])
 			self._update_matrix()
@@ -424,13 +424,13 @@ class ZXEditorWidget(widgets.DOMWidget):
 _d3_editor_id = 0
 
 def edit(
-		g: GraphS, 
-		scale:Optional[FloatInt]=None, 
+		g: GraphS,
+		scale:Optional[FloatInt]=None,
 		show_matrix:bool=False,
 		show_scalar:bool=False,
 		show_errors:bool=True) -> ZXEditorWidget:
 	"""Start an instance of an ZX-diagram editor on a given graph ``g``.
-	Only usable in a Jupyter Notebook. 
+	Only usable in a Jupyter Notebook.
 	When this function is called it displays a Jupyter Widget that allows
 	you to modify a pyzx Graph instance in the Notebook itself.
 	This function returns an instance of the editor widget, so it should be called like::
@@ -483,8 +483,8 @@ def edit(
 
 	w = ZXEditorWidget(
 					g, show_matrix,show_scalar,
-					graph_json = js, graph_id = str(seq), 
-					graph_width=w, graph_height=h, 
+					graph_json = js, graph_id = str(seq),
+					graph_width=w, graph_height=h,
 					graph_node_size=node_size,
 					graph_buttons = operations_to_js()
 					)

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import math
 import copy
 from fractions import Fraction
-from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Any, Sequence
+from typing import TYPE_CHECKING, Collection, Counter, Generic, Optional, TypeVar, Any, Sequence
 from typing import Mapping, Iterable, Callable, ClassVar, Literal
 from typing_extensions import Self
 
@@ -423,7 +423,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         Should be overloaded if the backend supplies a cheaper version than this."""
         return set(self.vertices())
 
-    def edge_set(self) -> set[ET]:
+    def edge_set(self) -> set[ET] | Counter[ET]:
         """Returns the edges of the graph as a Python set.
         Should be overloaded if the backend supplies a cheaper version than this. Note this ignores parallel edges."""
         return set(self.edges())

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import math
 import copy
 from fractions import Fraction
-from typing import TYPE_CHECKING, Generic, TypeVar, Any, Sequence
+from typing import TYPE_CHECKING, Generic, Optional, TypeVar, Any, Sequence
 from typing import Mapping, Iterable, Callable, ClassVar, Literal
 from typing_extensions import Self
 
@@ -101,7 +101,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
-        self.merge_vdata: Optional[Callable[[VT,VT], None]] = None
+        self.merge_vdata: Callable[[VT, VT], None] | None = None
         self.variable_types: dict[str,bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
         self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
@@ -138,7 +138,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         new vertices added to the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_vertex_indexed(self, v:VT) -> None:
+    def add_vertex_indexed(self, v: VT) -> None:
         """Adds a vertex that is guaranteed to have the chosen index (i.e. 'name').
         If the index isn't available, raises a ValueError.
         This method is used in the editor and ZXLive to support undo,
@@ -319,14 +319,14 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         else:
             return max(self.row(v) for v in self.vertices())
 
-    def edge(self, s:VT, t:VT, et: EdgeType=EdgeType.SIMPLE) -> ET:
+    def edge(self, s: VT, t: VT, et: EdgeType=EdgeType.SIMPLE) -> ET:
         """Returns the name of the first edge with the given source/target and type. Behaviour is undefined if the vertices are not connected."""
         for e in self.incident_edges(s):
             if t in self.edge_st(e) and et == self.edge_type(e):
                 return e
         raise ValueError(f"No edge of type {et} between {s} and {t}")
 
-    def connected(self,v1: VT,v2: VT) -> bool:
+    def connected(self,v1: VT, v2: VT) -> bool:
         """Returns whether vertices v1 and v2 share an edge."""
         for e in self.incident_edges(v1):
             if v2 in self.edge_st(e):
@@ -367,7 +367,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             self.phase_mult[self.max_phase_index] = 1
         return v
 
-    def add_edges(self, edge_pairs: Iterable[tuple[VT,VT]], edgetype:EdgeType=EdgeType.SIMPLE) -> None:
+    def add_edges(self, edge_pairs: Iterable[tuple[VT,VT]], edgetype: EdgeType = EdgeType.SIMPLE) -> None:
         """Adds a list of edges to the graph."""
         for ep in edge_pairs:
             self.add_edge(ep, edgetype)
@@ -393,7 +393,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return len(self.outputs())
 
     def set_position(self, vertex: VT, q: FloatInt, r: FloatInt) -> None:
-        """set both the qubit index and row index of the vertex."""
+        """Set both the qubit index and row index of the vertex."""
         self.set_qubit(vertex, q)
         self.set_row(vertex, r)
 
@@ -487,7 +487,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         g.merge_vdata = self.merge_vdata
         for name in self.var_registry.vars():
             g.var_registry.set_type(name, self.var_registry.get_type(name))
-        mult:int = 1
+        mult: int = 1
         if adjoint:
             mult = -1
 
@@ -540,7 +540,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return self.copy(adjoint=True)
 
 
-    def map_qubits(self, qubit_map:Mapping[int,tuple[float,float]]) -> None:
+    def map_qubits(self, qubit_map: Mapping[int, tuple[float,float]]) -> None:
         for v in self.vertices():
             q = self.qubit(v)
             r = self.row(v)
@@ -790,20 +790,20 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
                 raise TypeError("Unknown output effect " + s)
         self.set_outputs(tuple(new_outputs))
 
-    def to_tensor(self, preserve_scalar:bool=True, strategy:str='naive') -> np.ndarray:
+    def to_tensor(self, preserve_scalar: bool = True, strategy: str = 'naive') -> np.ndarray:
         """Returns a representation of the graph as a tensor using :func:`~pyzx.tensor.tensorfy`"""
         return tensorfy(self, preserve_scalar, strategy)
 
-    def to_matrix(self,preserve_scalar:bool=True, strategy:str='naive') -> np.ndarray:
+    def to_matrix(self, preserve_scalar: bool = True, strategy: str = 'naive') -> np.ndarray:
         """Returns a representation of the graph as a matrix using :func:`~pyzx.tensor.tensorfy`"""
         return tensor_to_matrix(tensorfy(self, preserve_scalar, strategy), self.num_inputs(), self.num_outputs())
 
-    def to_dict(self, include_scalar:bool=True) -> dict[str, Any]:
+    def to_dict(self, include_scalar: bool = True) -> dict[str, Any]:
         """Returns a dictionary representation of the graph, which can then be converted into json."""
         from .jsonparser import graph_to_dict
         return graph_to_dict(self, include_scalar)
 
-    def to_json(self, include_scalar:bool=True) -> str:
+    def to_json(self, include_scalar: bool = True) -> str:
         """Returns a json representation of the graph.
         Convert back into a graph using :meth:`from_json`."""
         from .jsonparser import graph_to_json
@@ -814,7 +814,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         from .jsonparser import to_graphml
         return to_graphml(self)
 
-    def to_tikz(self,draw_scalar:bool=False) -> str:
+    def to_tikz(self,draw_scalar: bool=False) -> str:
         """Returns a Tikz representation of the graph."""
         from ..tikz import to_tikz
         return to_tikz(self,draw_scalar)
@@ -827,7 +827,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return json_to_graph(js)
 
     @classmethod
-    def from_tikz(cls, tikz: str, warn_overlap:bool= True, fuse_overlap:bool = True, ignore_nonzx:bool = False) -> BaseGraph[VT,ET]:
+    def from_tikz(cls, tikz: str, warn_overlap: bool = True, fuse_overlap: bool = True, ignore_nonzx: bool = False) -> BaseGraph[VT,ET]:
         """Converts a tikz diagram into a pyzx Graph.
     The tikz diagram is assumed to be one generated by Tikzit,
     and hence should have a nodelayer and a edgelayer..
@@ -1016,7 +1016,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         self.pack_circuit_rows()
 
-    def translate(self, x:FloatInt, y:FloatInt) -> BaseGraph[VT,ET]:
+    def translate(self, x: FloatInt, y: FloatInt) -> BaseGraph[VT,ET]:
         g = self.copy()
         for v in g.vertices():
             g.set_row(v, g.row(v)+x)
@@ -1025,7 +1025,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
 
 
-    def add_edge_table(self, etab:Mapping[tuple[VT,VT],list[int]]) -> None:
+    def add_edge_table(self, etab: Mapping[tuple[VT,VT], list[int]]) -> None:
         """Takes a dictionary mapping (source,target) --> (#edges, #h-edges) specifying that
         #edges regular edges must be added between source and target and $h-edges Hadamard edges.
         The method selectively adds or removes edges to produce that ZX diagram which would
@@ -1041,7 +1041,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         Used for phase teleportation."""
         self.phase_master = m
 
-    def update_phase_index(self, old:VT, new:VT) -> None:
+    def update_phase_index(self, old: VT, new: VT) -> None:
         """When a phase is moved from a vertex to another vertex,
         we need to tell the phase_teleportation algorithm that this has happened.
         This function does that. Used in some of the rules in `simplify`."""
@@ -1121,7 +1121,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return { key: self.edata(edge, key) for key in self.edata_keys(edge) }
 
     def set_edata_dict(self, edge: ET, d: dict[str, Any]) -> None:
-        """set all edge data for the given edge from a dict, clearing existing data first."""
+        """Set all edge data for the given edge from a dict, clearing existing data first."""
         self.clear_edata(edge)
         for k, v in d.items():
             self.set_edata(edge, k, v)
@@ -1267,7 +1267,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return result
 
     def set_auto_simplify(self, s: bool) -> None:
-        """set whether this graph auto-simplifies parallel edges
+        """Set whether this graph auto-simplifies parallel edges
 
         Simple graphs should always auto-simplify, so this method is a no-op."""
         pass

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -19,8 +19,8 @@ import math
 import copy
 from fractions import Fraction
 from typing import TYPE_CHECKING, Union, Optional, Generic, TypeVar, Any, Sequence
-from typing import List, Dict, Set, Tuple, Mapping, Iterable, Callable, ClassVar, Literal
-from typing_extensions import Literal, GenericMeta, Self# type: ignore # https://github.com/python/mypy/issues/5753
+from typing import Mapping, Iterable, Callable, ClassVar, Literal
+from typing_extensions import Self
 
 import numpy as np
 
@@ -36,13 +36,15 @@ if TYPE_CHECKING:
     from .. import simplify
 
 
-class DocstringMeta(GenericMeta):
+MT = TypeVar("MT", bound="DocstringMeta") # Used for properly typing the metaclass
+
+class DocstringMeta(type):
     """Metaclass that allows docstring 'inheritance'."""
 
-    def __new__(mcls, classname, bases, cls_dict, **kwargs):
-        cls = GenericMeta.__new__(mcls, classname, bases, cls_dict, **kwargs)
-        mro = cls.__mro__[1:]
-        for name, member in cls_dict.items():
+    def __new__(cls: type[MT], classname: str, bases: tuple[type, ...], namespace: dict[str, Any], /, **kwds: Any) -> MT:
+        new_class = super().__new__(cls, classname, bases, namespace, **kwds)
+        mro = new_class.__mro__[1:]
+        for name, member in namespace.items():
             if not getattr(member, '__doc__'):
                 for base in mro:
                     try:
@@ -50,10 +52,10 @@ class DocstringMeta(GenericMeta):
                         break
                     except AttributeError:
                         pass
-        return cls
+        return new_class
 
-def pack_indices(lst: List[FloatInt]) -> Mapping[FloatInt,int]:
-    d: Dict[FloatInt,int] = dict()
+def pack_indices(lst: list[FloatInt]) -> Mapping[FloatInt,int]:
+    d: dict[FloatInt,int] = dict()
     if len(lst) == 0: return d
     list.sort(lst)
     i: int = 0
@@ -70,10 +72,10 @@ VT = TypeVar('VT', bound=int) # The type that is used for representing vertices 
 ET = TypeVar('ET') # The type used for representing edges (e.g. a pair of integers)
 
 
-def upair(v1: VT, v2: VT) -> Tuple[VT, VT]:
+def upair(v1: VT, v2: VT) -> tuple[VT, VT]:
     """Returns the unordered pair associated to the pair of vertices.
     This method takes a pair of vertices and returns them in a canonical order. Use this
-    whenever a pair of vertices is used to reference the location of an undirected edge, 
+    whenever a pair of vertices is used to reference the location of an undirected edge,
     e.g. as a key in an edge table."""
     return (v1, v2) if v1 <= v2 else (v2, v1)
 
@@ -88,19 +90,19 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
     def __init__(self) -> None:
         self.scalar: Scalar = Scalar()
-        # self.inputs: List[VT] = []
-        # self.outputs: List[VT] = []
+        # self.inputs: list[VT] = []
+        # self.outputs: list[VT] = []
         #Data necessary for phase tracking for phase teleportation
         self.track_phases: bool = False
-        self.phase_index : Dict[VT,int] = dict() # {vertex:index tracking its phase for phase teleportation}
+        self.phase_index : dict[VT,int] = dict() # {vertex:index tracking its phase for phase teleportation}
         self.phase_master: Optional['simplify.Simplifier'] = None
-        self.phase_mult: Dict[int,Literal[1,-1]] = dict()
+        self.phase_mult: dict[int,Literal[1,-1]] = dict()
         self.max_phase_index: int = -1
 
         # merge_vdata(v0,v1) is an optional, custom function for merging
         # vdata of v1 into v0 during spider fusion etc.
         self.merge_vdata: Optional[Callable[[VT,VT], None]] = None
-        self.variable_types: Dict[str,bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
+        self.variable_types: dict[str,bool] = dict() # DEPRICATED - mapping of variable names to their type (bool or continuous)
         self.var_registry: VarRegistry = VarRegistry() # registry for variable types
 
     # MANDATORY OVERRIDES {{{
@@ -115,35 +117,35 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """
         raise NotImplementedError()
 
-    def inputs(self) -> Tuple[VT, ...]:
+    def inputs(self) -> tuple[VT, ...]:
         """Gets the inputs of the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def set_inputs(self, inputs: Tuple[VT, ...]):
+    def set_inputs(self, inputs: tuple[VT, ...]) -> None:
         """Sets the inputs of the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def outputs(self) -> Tuple[VT, ...]:
+    def outputs(self) -> tuple[VT, ...]:
         """Gets the outputs of the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def set_outputs(self, outputs: Tuple[VT, ...]):
+    def set_outputs(self, outputs: tuple[VT, ...]) -> None:
         """Sets the outputs of the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_vertices(self, amount: int) -> List[VT]:
+    def add_vertices(self, amount: int) -> list[VT]:
         """Add the given amount of vertices, and return the indices of the
         new vertices added to the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_vertex_indexed(self,v:VT) -> None:
+    def add_vertex_indexed(self, v:VT) -> None:
         """Adds a vertex that is guaranteed to have the chosen index (i.e. 'name').
         If the index isn't available, raises a ValueError.
         This method is used in the editor and ZXLive to support undo,
         which requires vertices to preserve their index."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_edge(self, edge_pair: Tuple[VT,VT], edgetype:EdgeType=EdgeType.SIMPLE) -> ET:
+    def add_edge(self, edge_pair: tuple[VT,VT], edgetype: EdgeType = EdgeType.SIMPLE) -> ET:
         """Adds a single edge of the given type and return its id"""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -151,7 +153,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Removes the list of vertices from the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def remove_edges(self, edges: List[ET]) -> None:
+    def remove_edges(self, edges: list[ET]) -> None:
         """Removes the list of edges from the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -172,7 +174,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         Output type depends on implementation in backend."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def edge_st(self, edge: ET) -> Tuple[VT, VT]:
+    def edge_st(self, edge: ET) -> tuple[VT, VT]:
         """Returns a tuple of source/target of the given edge."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -271,7 +273,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns a boolean indicating if the vertex is connected to a ground."""
         return False
 
-    def grounds(self) -> Set[VT]:
+    def grounds(self) -> set[VT]:
         """Returns the set of vertices connected to a ground."""
         return set(v for v in self.vertices() if self.is_ground(v))
 
@@ -365,7 +367,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             self.phase_mult[self.max_phase_index] = 1
         return v
 
-    def add_edges(self, edge_pairs: Iterable[Tuple[VT,VT]], edgetype:EdgeType=EdgeType.SIMPLE) -> None:
+    def add_edges(self, edge_pairs: Iterable[tuple[VT,VT]], edgetype:EdgeType=EdgeType.SIMPLE) -> None:
         """Adds a list of edges to the graph."""
         for ep in edge_pairs:
             self.add_edge(ep, edgetype)
@@ -390,14 +392,14 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Gets the number of outputs of the graph."""
         return len(self.outputs())
 
-    def set_position(self, vertex: VT, q: FloatInt, r: FloatInt):
-        """Set both the qubit index and row index of the vertex."""
+    def set_position(self, vertex: VT, q: FloatInt, r: FloatInt) -> None:
+        """set both the qubit index and row index of the vertex."""
         self.set_qubit(vertex, q)
         self.set_row(vertex, r)
 
     def neighbors(self, vertex: VT) -> Sequence[VT]:
         """Returns all neighboring vertices of the given vertex."""
-        vs: Set[VT] = set()
+        vs: set[VT] = set()
         for e in self.incident_edges(vertex):
             s,t = self.edge_st(e)
             vs.add(s if t == vertex else t)
@@ -416,12 +418,12 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return self.edge_st(edge)[1]
 
 
-    def vertex_set(self) -> Set[VT]:
+    def vertex_set(self) -> set[VT]:
         """Returns the vertices of the graph as a Python set.
         Should be overloaded if the backend supplies a cheaper version than this."""
         return set(self.vertices())
 
-    def edge_set(self) -> Set[ET]:
+    def edge_set(self) -> set[ET]:
         """Returns the edges of the graph as a Python set.
         Should be overloaded if the backend supplies a cheaper version than this. Note this ignores parallel edges."""
         return set(self.edges())
@@ -447,7 +449,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             Returns a string with some information regarding the degree distribution of the graph.
         """
         s = str(self) + "\n"
-        degrees: Dict[int,int] = {}
+        degrees: dict[int,int] = {}
         for v in self.vertices():
             d = self.vertex_degree(v)
             if d in degrees: degrees[d] += 1
@@ -480,10 +482,10 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             backend = type(self).backend
         g = Graph(backend = backend)
         if isinstance(self, Multigraph) and isinstance(g, Multigraph):
-            g.set_auto_simplify(self._auto_simplify)
+            g.set_auto_simplify(self._auto_simplify) # TODO: this should be moved into the multigraph class
         g.track_phases = self.track_phases
         g.scalar = self.scalar.copy(conjugate=adjoint)
-        g.merge_vdata = self.merge_vdata # type: ignore
+        g.merge_vdata = self.merge_vdata
         for name in self.var_registry.vars():
             g.var_registry.set_type(name, self.var_registry.get_type(name))
         mult:int = 1
@@ -539,7 +541,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return self.copy(adjoint=True)
 
 
-    def map_qubits(self, qubit_map:Mapping[int,Tuple[float,float]]) -> None:
+    def map_qubits(self, qubit_map:Mapping[int,tuple[float,float]]) -> None:
         for v in self.vertices():
             q = self.qubit(v)
             r = self.row(v)
@@ -560,7 +562,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         if len(outputs) != len(inputs):
             raise TypeError("Outputs of first graph must match inputs of second.")
 
-        plugs: List[Tuple[VT,VT,EdgeType]] = []
+        plugs: list[tuple[VT,VT,EdgeType]] = []
         for k in range(len(outputs)):
             o = outputs[k]
             i = inputs[k]
@@ -584,7 +586,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         for v in outputs:
             self.remove_vertex(v)
 
-        vtab : Dict[VT,VT] = dict()
+        vtab : dict[VT,VT] = dict()
         for v in other.vertices():
             if not v in inputs:
                 w = self.add_vertex(other.type(v),
@@ -664,7 +666,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
     def __matmul__(self, other: BaseGraph[VT,ET]) -> BaseGraph[VT,ET]:
         return self.tensor(other)
 
-    def merge(self, other: BaseGraph[VT,ET]) -> Tuple[List[VT],List[ET]]:
+    def merge(self, other: BaseGraph[VT,ET]) -> tuple[list[VT],list[ET]]:
         """Merges this graph with the other graph in-place.
         Returns (list-of-vertices, list-of-edges) corresponding to
         the id's of the vertices and edges of the other graph."""
@@ -691,7 +693,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.rebind_variables_to_registry()
         return (list(vert_map.values()),edges)
 
-    def subgraph_from_vertices(self,verts: List[VT]) -> BaseGraph[VT,ET]:
+    def subgraph_from_vertices(self,verts: list[VT]) -> BaseGraph[VT,ET]:
         """Returns the subgraph consisting of the specified vertices."""
         from .graph import Graph # imported here to prevent circularity
         from .multigraph import Multigraph
@@ -723,7 +725,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             new_e = g.add_edge((vert_map[s], vert_map[t]), self.edge_type(e))
             g.set_edata_dict(new_e, self.edata_dict(e))
 
-        used_var_names: Set[str] = set()
+        used_var_names: set[str] = set()
         for v in verts:
             p = phase[v]
             if isinstance(p, Poly):
@@ -775,7 +777,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         new_outputs = []
         for i,s in enumerate(effect):
             v = outputs[i]
-            if s == '/': 
+            if s == '/':
                 new_outputs.append(v)
                 continue
             if s in ('0', '1'):
@@ -800,7 +802,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns a representation of the graph as a matrix using :func:`~pyzx.tensor.tensorfy`"""
         return tensor_to_matrix(tensorfy(self, preserve_scalar, strategy), self.num_inputs(), self.num_outputs())
 
-    def to_dict(self, include_scalar:bool=True) -> Dict[str, Any]:
+    def to_dict(self, include_scalar:bool=True) -> dict[str, Any]:
         """Returns a dictionary representation of the graph, which can then be converted into json."""
         from .jsonparser import graph_to_dict
         return graph_to_dict(self, include_scalar)
@@ -822,7 +824,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return to_tikz(self,draw_scalar)
 
     @classmethod
-    def from_json(cls, js:Union[str,Dict[str,Any]]) -> BaseGraph[VT,ET]:
+    def from_json(cls, js:Union[str,dict[str,Any]]) -> BaseGraph[VT,ET]:
         """Converts the given .qgraph json string into a Graph.
         Works with the output of :meth:`to_json`."""
         from .jsonparser import json_to_graph
@@ -1027,7 +1029,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
 
 
-    def add_edge_table(self, etab:Mapping[Tuple[VT,VT],List[int]]) -> None:
+    def add_edge_table(self, etab:Mapping[tuple[VT,VT],list[int]]) -> None:
         """Takes a dictionary mapping (source,target) --> (#edges, #h-edges) specifying that
         #edges regular edges must be added between source and target and $h-edges Hadamard edges.
         The method selectively adds or removes edges to produce that ZX diagram which would
@@ -1073,7 +1075,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
     def remove_isolated_vertices(self) -> None:
         """Deletes all vertices and vertex pairs that are not connected to any other vertex."""
-        rem: List[VT] = []
+        rem: list[VT] = []
         for v in self.vertices():
             d = self.vertex_degree(v)
             if d == 0:
@@ -1110,20 +1112,20 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
                         self.scalar.add_node(self.phase(v)+self.phase(w))
         self.remove_vertices(rem)
 
-    def vdata_dict(self, vertex: VT) -> Dict[str, Any]:
+    def vdata_dict(self, vertex: VT) -> dict[str, Any]:
         return { key: self.vdata(vertex, key) for key in self.vdata_keys(vertex) }
 
-    def set_vdata_dict(self, vertex: VT, d: Dict[str, Any]) -> None:
+    def set_vdata_dict(self, vertex: VT, d: dict[str, Any]) -> None:
         self.clear_vdata(vertex)
         for k, v in d.items():
             self.set_vdata(vertex, k, v)
 
-    def edata_dict(self, edge: ET) -> Dict[str, Any]:
+    def edata_dict(self, edge: ET) -> dict[str, Any]:
         """Return a dict of all edge data for the given edge."""
         return { key: self.edata(edge, key) for key in self.edata_keys(edge) }
 
-    def set_edata_dict(self, edge: ET, d: Dict[str, Any]) -> None:
-        """Set all edge data for the given edge from a dict, clearing existing data first."""
+    def set_edata_dict(self, edge: ET, d: dict[str, Any]) -> None:
+        """set all edge data for the given edge from a dict, clearing existing data first."""
         self.clear_edata(edge)
         for k, v in d.items():
             self.set_edata(edge, k, v)
@@ -1196,7 +1198,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             result = copy.deepcopy(self)
 
         # Collect all Var objects from the graph and map to user-provided values.
-        all_vars: Set[Var] = set()
+        all_vars: set[Var] = set()
         for v in result.vertices():
             phase = result.phase(v)
             if isinstance(phase, Poly):
@@ -1207,7 +1209,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
                     all_vars.update(label.free_vars())
         all_vars.update(result.scalar.free_vars())
 
-        var_map: Dict[Var, Union[float, complex, Fraction, Poly]] = {
+        var_map: dict[Var, Union[float, complex, Fraction, Poly]] = {
             var: var_values[var.name] for var in all_vars if var.name in var_values
         }
         if not var_map:
@@ -1215,8 +1217,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         # Precompute all substitutions before mutating, so the graph is not
         # left partially substituted if an error occurs.
-        new_phases: Dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
-        new_labels: Dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
+        new_phases: dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
+        new_labels: dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
         for v in result.vertices():
             phase = result.phase(v)
             if isinstance(phase, Poly):
@@ -1266,7 +1268,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return result
 
     def set_auto_simplify(self, s: bool) -> None:
-        """Set whether this graph auto-simplifies parallel edges
+        """set whether this graph auto-simplifies parallel edges
 
         Simple graphs should always auto-simplify, so this method is a no-op."""
         pass
@@ -1286,7 +1288,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         targets: Iterable[VT],
         edge_type: EdgeType = EdgeType.HADAMARD,
         vertex_type: VertexType = VertexType.Z
-    ) -> Tuple[VT, VT]:
+    ) -> tuple[VT, VT]:
         """Add a phase gadget acting on the given target vertices.
         Returns a tuple (hub, phase_vertex) of the created vertices."""
         target_list = list(targets)
@@ -1304,6 +1306,3 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.add_edge((hub, phase_vertex), EdgeType.HADAMARD)
 
         return (hub, phase_vertex)
-
-
-

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -133,7 +133,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Sets the outputs of the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def add_vertices(self, amount: int) -> list[VT]:
+    def add_vertices(self, amount: int) -> Sequence[VT]:
         """Add the given amount of vertices, and return the indices of the
         new vertices added to the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
@@ -178,7 +178,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns a tuple of source/target of the given edge."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def incident_edges(self, vertex: VT) -> Sequence[ET]:
+    def incident_edges(self, vertex: VT) -> Iterable[ET]:
         """Returns all neighboring edges of the given vertex."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -232,7 +232,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Removes all vdata associated to a vertex"""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
 
-    def vdata_keys(self, vertex: VT) -> Sequence[str]:
+    def vdata_keys(self, vertex: VT) -> Iterable[str]:
         """Returns an iterable of the vertex data key names.
         Used e.g. in making a copy of the graph in a backend-independent way."""
         raise NotImplementedError("Not implemented on backend" + type(self).backend)
@@ -250,7 +250,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Removes all edata associated to an edge"""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def edata_keys(self, edge: ET) -> Sequence[str]:
+    def edata_keys(self, edge: ET) -> Iterable[str]:
         """Returns an iterable of the edge data key names."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
@@ -397,7 +397,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         self.set_qubit(vertex, q)
         self.set_row(vertex, r)
 
-    def neighbors(self, vertex: VT) -> Sequence[VT]:
+    def neighbors(self, vertex: VT) -> Iterable[VT]:
         """Returns all neighboring vertices of the given vertex."""
         vs: set[VT] = set()
         for e in self.incident_edges(vertex):
@@ -407,7 +407,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
     def vertex_degree(self, vertex: VT) -> int:
         """Returns the degree of the given vertex."""
-        return len(self.incident_edges(vertex))
+        return len(list(self.incident_edges(vertex)))
 
     def edge_s(self, edge: ET) -> VT:
         """Returns the source of the given edge."""
@@ -481,8 +481,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         if (backend is None):
             backend = type(self).backend
         g = Graph(backend = backend)
-        if isinstance(self, Multigraph) and isinstance(g, Multigraph):
-            g.set_auto_simplify(self._auto_simplify) # TODO: this should be moved into the multigraph class
+        g.set_auto_simplify(self.get_auto_simplify())
         g.track_phases = self.track_phases
         g.scalar = self.scalar.copy(conjugate=adjoint)
         g.merge_vdata = self.merge_vdata
@@ -566,9 +565,9 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         for k in range(len(outputs)):
             o = outputs[k]
             i = inputs[k]
-            if len(self.neighbors(o)) != 1:
+            if len(list(self.neighbors(o))) != 1:
                 raise ValueError("Bad output vertex: " + str(o))
-            if len(other.neighbors(i)) != 1:
+            if len(list(other.neighbors(i))) != 1:
                 raise ValueError("Bad input vertex: " + str(i))
             no = next(iter(self.neighbors(o)))
             ni = next(iter(other.neighbors(i)))
@@ -696,11 +695,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
     def subgraph_from_vertices(self,verts: list[VT]) -> BaseGraph[VT,ET]:
         """Returns the subgraph consisting of the specified vertices."""
         from .graph import Graph # imported here to prevent circularity
-        from .multigraph import Multigraph
         g = Graph(backend=type(self).backend)
-        if isinstance(self, Multigraph) and isinstance(g, Multigraph):
-            g.set_auto_simplify(self._auto_simplify) # type: ignore
-            # mypy issue https://github.com/python/mypy/issues/16413
+        g.set_auto_simplify(self.get_auto_simplify())
         ty = self.types()
         rs = self.rows()
         qs = self.qubits()

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -1230,7 +1230,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         # with complex coefficients.
         for v, new_phase in new_phases.items():
             try:
-                assert_phase_real(new_phase)  # type: ignore[arg-type]
+                assert_phase_real(new_phase)
             except TypeError:
                 raise TypeError(
                     f"Substitution produced complex phase {new_phase} for "
@@ -1238,7 +1238,10 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         # Apply all substitutions.
         for v, new_phase in new_phases.items():
-            result.set_phase(v, new_phase)  # type: ignore[arg-type]
+            assert not isinstance(new_phase, complex) # assert_phase_real would have raised an error earlier
+            if isinstance(new_phase, float):
+                new_phase = Fraction(new_phase)
+            result.set_phase(v, new_phase)
         for v, new_label in new_labels.items():
             set_z_box_label(result, v, new_label)
         result.scalar = new_scalar

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import math
 import copy
 from fractions import Fraction
-from typing import TYPE_CHECKING, Union, Optional, Generic, TypeVar, Any, Sequence
+from typing import TYPE_CHECKING, Generic, TypeVar, Any, Sequence
 from typing import Mapping, Iterable, Callable, ClassVar, Literal
 from typing_extensions import Self
 
@@ -59,7 +59,7 @@ def pack_indices(lst: list[FloatInt]) -> Mapping[FloatInt,int]:
     if len(lst) == 0: return d
     list.sort(lst)
     i: int = 0
-    x: Optional[FloatInt] = None
+    x: FloatInt | None = None
     for j in range(len(lst)):
         y = lst[j]
         if y != x:
@@ -161,7 +161,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns the amount of vertices in the graph."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def num_edges(self, s: Optional[VT]=None, t: Optional[VT]=None, et: Optional[EdgeType]=None) -> int:
+    def num_edges(self, s: VT | None = None, t: VT | None = None, et: EdgeType | None = None) -> int:
         """Returns the amount of edges in the graph"""
         return len(list(self.edges(s, t)))
 
@@ -169,7 +169,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Iterator over all the vertices."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
 
-    def edges(self, s: Optional[VT]=None, t: Optional[VT]=None) -> Iterable[ET]:
+    def edges(self, s: VT | None = None, t: VT | None = None) -> Iterable[ET]:
         """Iterator that returns all the edges in the graph, or all the edges connecting the pair of vertices.
         Output type depends on implementation in backend."""
         raise NotImplementedError("Not implemented on backend " + type(self).backend)
@@ -334,12 +334,12 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return False
 
     def add_vertex(self,
-                   ty:VertexType=VertexType.BOUNDARY,
-                   qubit:FloatInt=-1,
-                   row:FloatInt=-1,
-                   phase:Optional[FractionLike]=None,
-                   ground:bool=False,
-                   index: Optional[VT] = None
+                   ty: VertexType = VertexType.BOUNDARY,
+                   qubit: FloatInt = -1,
+                   row: FloatInt = -1,
+                   phase: FractionLike | None = None,
+                   ground: bool = False,
+                   index: VT | None = None
                    ) -> VT:
         """Add a single vertex to the graph and return its index.
         The optional parameters allow you to respectively set
@@ -459,7 +459,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             s += "{:d}: {:d}\n".format(d,n)
         return s
 
-    def copy(self, adjoint:bool=False, backend:Optional[str]=None) -> BaseGraph[VT,ET]:
+    def copy(self, adjoint: bool = False, backend: str | None = None) -> BaseGraph[VT,ET]:
         """Create a copy of the graph. If ``adjoint`` is set,
         the adjoint of the graph will be returned (inputs and outputs flipped, phases reversed).
         When ``backend`` is set, a copy of the graph with the given backend is produced.
@@ -820,7 +820,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         return to_tikz(self,draw_scalar)
 
     @classmethod
-    def from_json(cls, js:Union[str,dict[str,Any]]) -> BaseGraph[VT,ET]:
+    def from_json(cls, js: str | dict[str,Any]) -> BaseGraph[VT,ET]:
         """Converts the given .qgraph json string into a Graph.
         Works with the output of :meth:`to_json`."""
         from .jsonparser import json_to_graph
@@ -845,7 +845,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         from ..tikz import tikz_to_graph
         return tikz_to_graph(tikz,warn_overlap, fuse_overlap, ignore_nonzx, cls.backend)
 
-    def save(self, filename: str, fmt: Optional[str] = None) -> None:
+    def save(self, filename: str, fmt: str | None = None) -> None:
         """Saves the graph to a file.
 
         Args:
@@ -878,7 +878,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             f.write(content)
 
     @classmethod
-    def load(cls, filename: str, fmt: Optional[str] = None, **kwargs: Any) -> BaseGraph[VT, ET]:
+    def load(cls, filename: str, fmt: str | None = None, **kwargs: Any) -> BaseGraph[VT, ET]:
         """Loads a graph from a file.
 
         Args:
@@ -1166,7 +1166,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             if isinstance(attr, Poly):
                 attr.rebind_variables_to_registry(self.var_registry)
 
-    def substitute_variables(self, var_values: Mapping[str, Union[float, complex, Fraction, Poly]],
+    def substitute_variables(self, var_values: Mapping[str, float | complex | Fraction | Poly],
                    in_place: bool = False) -> 'BaseGraph[VT, ET]':
         """Substitute values for symbolic variables in all phases and Z-box labels.
 
@@ -1205,7 +1205,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
                     all_vars.update(label.free_vars())
         all_vars.update(result.scalar.free_vars())
 
-        var_map: dict[Var, Union[float, complex, Fraction, Poly]] = {
+        var_map: dict[Var, float | complex | Fraction | Poly] = {
             var: var_values[var.name] for var in all_vars if var.name in var_values
         }
         if not var_map:
@@ -1213,8 +1213,8 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         # Precompute all substitutions before mutating, so the graph is not
         # left partially substituted if an error occurs.
-        new_phases: dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
-        new_labels: dict[VT, Union[int, float, complex, Fraction, Poly]] = {}
+        new_phases: dict[VT, float | complex | Fraction | Poly] = {}
+        new_labels: dict[VT, float | complex | Fraction | Poly] = {}
         for v in result.vertices():
             phase = result.phase(v)
             if isinstance(phase, Poly):

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -20,7 +20,7 @@ import copy
 from fractions import Fraction
 from typing import TYPE_CHECKING, Union, Optional, Generic, TypeVar, Any, Sequence
 from typing import List, Dict, Set, Tuple, Mapping, Iterable, Callable, ClassVar, Literal
-from typing_extensions import Literal, GenericMeta # type: ignore # https://github.com/python/mypy/issues/5753
+from typing_extensions import Literal, GenericMeta, Self# type: ignore # https://github.com/python/mypy/issues/5753
 
 import numpy as np
 
@@ -480,8 +480,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
             backend = type(self).backend
         g = Graph(backend = backend)
         if isinstance(self, Multigraph) and isinstance(g, Multigraph):
-            g.set_auto_simplify(self._auto_simplify) # type: ignore
-            # mypy issue https://github.com/python/mypy/issues/16413
+            g.set_auto_simplify(self._auto_simplify)
         g.track_phases = self.track_phases
         g.scalar = self.scalar.copy(conjugate=adjoint)
         g.merge_vdata = self.merge_vdata # type: ignore
@@ -946,7 +945,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         """Returns the number of inputs of the graph"""
         return self.num_inputs()
 
-    def auto_detect_io(self):
+    def auto_detect_io(self) -> None:
         """Adds every vertex that is of boundary-type to the list of inputs or outputs.
         Whether it is an input or output is determined by looking whether its neighbor
         is further to the right or further to the left of the input.
@@ -1253,7 +1252,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
 
         return result
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self, memo: dict[int, Self]) -> Self:
         """Custom deepcopy implementation to ensure variable registry is properly handled
         while using Python's default deepcopy behavior."""
         cls = self.__class__

--- a/pyzx/graph/base.py
+++ b/pyzx/graph/base.py
@@ -939,7 +939,7 @@ class BaseGraph(Generic[VT, ET], metaclass=DocstringMeta):
         for v in self.vertices():
             self.set_row(v, new_rows[self.row(v)])
 
-    def qubit_count(self) -> int:
+    def qubit_count(self) -> FloatInt:
         """Returns the number of inputs of the graph"""
         return self.num_inputs()
 

--- a/pyzx/graph/diff.py
+++ b/pyzx/graph/diff.py
@@ -60,8 +60,8 @@ class GraphDiff(Generic[VT, ET]):
         new_verts = g2.vertex_set()
         self.removed_verts = list(old_verts - new_verts)
         self.new_verts = list(new_verts - old_verts)
-        old_edges = g1.edge_set()
-        new_edges = g2.edge_set()
+        old_edges = Counter(g1.edge_set())
+        new_edges = Counter(g2.edge_set())
         self.new_edges = []
         self.removed_edges = []
 

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -17,8 +17,6 @@
 from fractions import Fraction
 from typing import Generator, Iterable, Any
 
-from pyzx.symbolic import Poly
-
 from .base import BaseGraph
 
 from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real
@@ -324,48 +322,60 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
 
     def type(self, vertex: int) -> VertexType:
         return self.ty[vertex]
+    
     def types(self) -> dict[int, VertexType]:
         return self.ty
+    
     def set_type(self, vertex: int, t: VertexType) -> None:
         self.ty[vertex] = t
 
-    def phase(self, vertex: int) -> Fraction | int | Poly:
-        return self._phase.get(vertex,Fraction(1))
-    def phases(self) -> dict[int, Fraction | int | Poly]:
+    def phase(self, vertex: int) -> FractionLike:
+        return self._phase.get(vertex, Fraction(1))
+    
+    def phases(self) -> dict[int, FractionLike]:
         return self._phase
-    def set_phase(self, vertex: int, phase: Fraction | int | Poly) -> None:
+    
+    def set_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
         try:
             self._phase[vertex] = phase % 2
         except Exception:
             self._phase[vertex] = phase
-    def add_to_phase(self, vertex: int, phase: Fraction | int | Poly) -> None:
+    
+    def add_to_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
         old_phase = self._phase.get(vertex, Fraction(1))
         try:
             self._phase[vertex] = (old_phase + phase) % 2
         except Exception:
             self._phase[vertex] = old_phase + phase
+    
     def qubit(self, vertex: int) -> FloatInt:
         return self._qindex.get(vertex,-1)
+    
     def qubits(self) -> dict[int, FloatInt]:
         return self._qindex
+    
     def set_qubit(self, vertex: int, q: FloatInt) -> None:
         if q > self._maxq: self._maxq = q
         self._qindex[vertex] = q
 
     def row(self, vertex: int) -> FloatInt:
         return self._rindex.get(vertex, -1)
+    
     def rows(self) -> dict[int, FloatInt]:
         return self._rindex
+    
     def set_row(self, vertex: int, r: FloatInt) -> None:
         if r > self._maxr: self._maxr = r
         self._rindex[vertex] = r
 
     def is_ground(self, vertex: int) -> bool:
         return vertex in self._grounds
+    
     def grounds(self) -> set[int]:
         return self._grounds
+    
     def set_ground(self, vertex: int, flag: bool = True) -> None:
         if flag:
             self._grounds.add(vertex)
@@ -375,8 +385,10 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
     def clear_vdata(self, vertex: int) -> None:
         if vertex in self._vdata:
             del self._vdata[vertex]
+    
     def vdata_keys(self, vertex: int) -> list[str]:
         return list(self._vdata.get(vertex, {}).keys())
+    
     def vdata(self, vertex: int, key: str, default: Any = None) -> Any:
         if vertex in self._vdata:
             return self._vdata[vertex].get(key,default)
@@ -390,13 +402,16 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
 
     def clear_edata(self, edge: tuple[int, int]) -> None:
         self._edata.pop(edge, None)
+    
     def edata_keys(self, edge: tuple[int, int]) -> list[str]:
         return list(self._edata.get(edge, {}).keys())
+    
     def edata(self, edge: tuple[int, int], key: str, default: Any = None) -> Any:
         if edge in self._edata:
             return self._edata[edge].get(key, default)
         else:
             return default
+    
     def set_edata(self, edge: tuple[int, int], key: str, val: Any) -> None:
         if edge in self._edata:
             self._edata[edge][key] = val

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -206,7 +206,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
             except: pass
             self._grounds.discard(v)
             self._vdata.pop(v,None)
-        self._vindex = max(self.vertices(),default=0) + 1
+        self._vindex = max(self.vertices(), default=0) + 1
 
     def remove_vertex(self, vertex: int) -> None:
         self.remove_vertices([vertex])
@@ -243,8 +243,8 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
         else:
             return len(list(self.edges()))
 
-    def vertices(self) -> set[int]:
-        return set(self.graph.keys())
+    def vertices(self) -> Iterable[int]:
+        return self.graph.keys()
 
     def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Generator[int, None, None]:
         """Returns all vertices with index between start and end
@@ -288,11 +288,12 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
                         if v1 > v0:
                             yield (v0,v1)
 
-    def edge(self, s: int, t: int, et: EdgeType=EdgeType.SIMPLE) -> tuple[int, int]:
+    def edge(self, s: int, t: int, et: EdgeType = EdgeType.SIMPLE) -> tuple[int, int]:
         return (s,t) if s < t else (t,s)
     
     def edge_set(self) -> set[tuple[int, int]]:
         return set(self.edges())
+    
     def edge_st(self, edge: tuple[int, int]) -> tuple[int, int]:
         return edge
 
@@ -398,7 +399,7 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
         if vertex in self._vdata:
             self._vdata[vertex][key] = val
         else:
-            self._vdata[vertex] = {key:val}
+            self._vdata[vertex] = {key: val}
 
     def clear_edata(self, edge: tuple[int, int]) -> None:
         self._edata.pop(edge, None)

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from fractions import Fraction
-from typing import Generator, Iterable, Sequence, Tuple, Dict, Set, Any
+from typing import Generator, Iterable, Any
 
 from pyzx.symbolic import Poly
 
@@ -23,7 +23,7 @@ from .base import BaseGraph
 
 from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real
 
-class GraphS(BaseGraph[int,Tuple[int,int]]):
+class GraphS(BaseGraph[int, tuple[int,int]]):
     """Purely Pythonic implementation of :class:`~graph.base.BaseGraph`."""
     backend = 'simple'
 
@@ -31,21 +31,21 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     #can be found in base.BaseGraph
     def __init__(self) -> None:
         BaseGraph.__init__(self)
-        self.graph: Dict[int,Dict[int,EdgeType]]   = dict()
+        self.graph: dict[int,dict[int,EdgeType]]   = dict()
         self._vindex: int                               = 0
         self.nedges: int                                = 0
-        self.ty: Dict[int,VertexType]              = dict()
-        self._phase: Dict[int, FractionLike]            = dict()
-        self._qindex: Dict[int, FloatInt]               = dict()
+        self.ty: dict[int,VertexType]              = dict()
+        self._phase: dict[int, FractionLike]            = dict()
+        self._qindex: dict[int, FloatInt]               = dict()
         self._maxq: FloatInt                            = -1
-        self._rindex: Dict[int, FloatInt]               = dict()
+        self._rindex: dict[int, FloatInt]               = dict()
         self._maxr: FloatInt                            = -1
-        self._grounds: Set[int] = set()
+        self._grounds: set[int] = set()
 
-        self._vdata: Dict[int,Any]                      = dict()
-        self._edata: Dict[Tuple[int,int],Any] = dict()
-        self._inputs: Tuple[int, ...]                   = tuple()
-        self._outputs: Tuple[int, ...]                  = tuple()
+        self._vdata: dict[int,Any]                      = dict()
+        self._edata: dict[tuple[int,int],Any] = dict()
+        self._inputs: tuple[int, ...]                   = tuple()
+        self._outputs: tuple[int, ...]                  = tuple()
 
     def clone(self) -> 'GraphS':
         cpy = GraphS()
@@ -84,22 +84,22 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         else: self._maxq = -1
         return int(self._maxq + 1)
 
-    def inputs(self) -> Tuple[int, ...]:
+    def inputs(self) -> tuple[int, ...]:
         return self._inputs
 
     def num_inputs(self) -> int:
         return len(self._inputs)
 
-    def set_inputs(self, inputs: Tuple[int, ...]) -> None:
+    def set_inputs(self, inputs: tuple[int, ...]) -> None:
         self._inputs = inputs
 
-    def outputs(self) -> Tuple[int, ...]:
+    def outputs(self) -> tuple[int, ...]:
         return self._outputs
 
     def num_outputs(self) -> int:
         return len(self._outputs)
 
-    def set_outputs(self, outputs: Tuple[int, ...]) -> None:
+    def set_outputs(self, outputs: tuple[int, ...]) -> None:
         self._outputs = outputs
 
     def add_vertices(self, amount: int) -> list[int]:
@@ -213,7 +213,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
     def remove_vertex(self, vertex: int) -> None:
         self.remove_vertices([vertex])
     
-    def remove_edges(self, edges: Sequence[tuple[int, int]]) -> None:
+    def remove_edges(self, edges: Iterable[tuple[int, int]]) -> None:
         for s,t in edges:
             if s == t:
                 continue

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 from fractions import Fraction
-from typing import Optional, Tuple, Dict, Set, Any
+from typing import Generator, Iterable, Sequence, Tuple, Dict, Set, Any
+
+from pyzx.symbolic import Poly
 
 from .base import BaseGraph
 
@@ -69,42 +71,46 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         cpy.max_phase_index = self.max_phase_index
         return cpy
 
-    def vindex(self): return self._vindex
-    def depth(self):
+    def vindex(self) -> int:
+        return self._vindex
+    
+    def depth(self) -> int:
         if self._rindex: self._maxr = max(self._rindex.values())
         else: self._maxr = -1
-        return self._maxr
-    def qubit_count(self):
+        return int(self._maxr)
+    
+    def qubit_count(self) -> int:
         if self._qindex: self._maxq = max(self._qindex.values())
         else: self._maxq = -1
-        return self._maxq + 1
+        return int(self._maxq + 1)
 
-    def inputs(self):
+    def inputs(self) -> Tuple[int, ...]:
         return self._inputs
 
-    def num_inputs(self):
+    def num_inputs(self) -> int:
         return len(self._inputs)
 
-    def set_inputs(self, inputs):
+    def set_inputs(self, inputs: Tuple[int, ...]) -> None:
         self._inputs = inputs
 
-    def outputs(self):
+    def outputs(self) -> Tuple[int, ...]:
         return self._outputs
 
-    def num_outputs(self):
+    def num_outputs(self) -> int:
         return len(self._outputs)
 
-    def set_outputs(self, outputs):
+    def set_outputs(self, outputs: Tuple[int, ...]) -> None:
         self._outputs = outputs
 
-    def add_vertices(self, amount):
+    def add_vertices(self, amount: int) -> list[int]:
         for i in range(self._vindex, self._vindex + amount):
             self.graph[i] = dict()
             self.ty[i] = VertexType.BOUNDARY
             self._phase[i] = 0
         self._vindex += amount
-        return range(self._vindex - amount, self._vindex)
-    def add_vertex_indexed(self, v):
+        return list(range(self._vindex - amount, self._vindex))
+    
+    def add_vertex_indexed(self, v: int) -> None:
         """Adds a vertex that is guaranteed to have the chosen index (i.e. 'name').
         If the index isn't available, raises a ValueError.
         This method is used in the editor to support undo, which requires vertices
@@ -115,13 +121,13 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         self.ty[v] = VertexType.BOUNDARY
         self._phase[v] = 0
 
-    def add_edges(self, edge_pairs, edgetype=EdgeType.SIMPLE):
+    def add_edges(self, edge_pairs: Iterable[tuple[int, int]], edgetype: EdgeType = EdgeType.SIMPLE) -> None:
         for s,t in edge_pairs:
             self.nedges += 1
             self.graph[s][t] = edgetype
             self.graph[t][s] = edgetype
     
-    def add_edge(self, edge_pair, edgetype=EdgeType.SIMPLE):
+    def add_edge(self, edge_pair: tuple[int, int], edgetype: EdgeType = EdgeType.SIMPLE) -> tuple[int, int]:
         s,t = edge_pair
         t1 = self.ty[s]
         t2 = self.ty[t]
@@ -176,7 +182,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
 
         return edge_pair
 
-    def remove_vertices(self, vertices):
+    def remove_vertices(self, vertices: Iterable[int]) -> None:
         for v in vertices:
             vs = list(self.graph[v])
             # remove all edges
@@ -204,10 +210,10 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             self._vdata.pop(v,None)
         self._vindex = max(self.vertices(),default=0) + 1
 
-    def remove_vertex(self, vertex):
+    def remove_vertex(self, vertex: int) -> None:
         self.remove_vertices([vertex])
-
-    def remove_edges(self, edges):
+    
+    def remove_edges(self, edges: Sequence[tuple[int, int]]) -> None:
         for s,t in edges:
             if s == t:
                 continue
@@ -216,13 +222,13 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             del self.graph[t][s]
             self._edata.pop((s, t), None)
 
-    def remove_edge(self, edge):
+    def remove_edge(self, edge: tuple[int, int]) -> None:
         self.remove_edges([edge])
 
-    def num_vertices(self):
+    def num_vertices(self) -> int:
         return len(self.graph)
 
-    def num_edges(self, s=None, t=None, et=None):
+    def num_edges(self, s: int | None = None, t: int | None = None, et: EdgeType | None = None) -> int:
         if s is not None and t is not None:
             if self.connected(s, t):
                 if et is not None:
@@ -239,10 +245,10 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
         else:
             return len(list(self.edges()))
 
-    def vertices(self):
-        return self.graph.keys()
+    def vertices(self) -> set[int]:
+        return set(self.graph.keys())
 
-    def vertices_in_range(self, start, end):
+    def vertices_in_range(self, start: FloatInt, end: FloatInt) -> Generator[int, None, None]:
         """Returns all vertices with index between start and end
         that only have neighbours whose indices are between start and end"""
         for v in self.graph.keys():
@@ -250,7 +256,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
             if all(start<v2<end for v2 in self.graph[v]):
                 yield v
 
-    def edges(self, s=None, t=None):
+    def edges(self, s: int | None = None, t: int | None = None) -> Generator[tuple[int, int], None, None]:
         if s is not None and t is not None:
             if self.connected(s, t):
                 yield (s,t) if s < t else (t,s)
@@ -262,7 +268,7 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
                 for v1 in adj:
                     if v1 > v0: yield (v0,v1)
 
-    def edges_in_range(self, start, end, safe=False):
+    def edges_in_range(self, start: FloatInt, end: FloatInt, safe: bool = False) -> Generator[tuple[int, int], None, None]:
         """like self.edges, but only returns edges that belong to vertices
         that are only directly connected to other vertices with
         index between start and end.
@@ -284,113 +290,114 @@ class GraphS(BaseGraph[int,Tuple[int,int]]):
                         if v1 > v0:
                             yield (v0,v1)
 
-    def edge(self, s, t):
+    def edge(self, s: int, t: int, et: EdgeType=EdgeType.SIMPLE) -> tuple[int, int]:
         return (s,t) if s < t else (t,s)
-    def edge_set(self):
+    
+    def edge_set(self) -> set[tuple[int, int]]:
         return set(self.edges())
-    def edge_st(self, edge):
+    def edge_st(self, edge: tuple[int, int]) -> tuple[int, int]:
         return edge
 
-    def neighbors(self, vertex):
-        return self.graph[vertex].keys()
+    def neighbors(self, vertex: int) -> list[int]:
+        return list(self.graph[vertex].keys())
 
-    def vertex_degree(self, vertex):
+    def vertex_degree(self, vertex: int) -> int:
         return len(self.graph[vertex])
 
-    def incident_edges(self, vertex):
+    def incident_edges(self, vertex: int) -> list[tuple[int, int]]:
         return [(vertex, v1) if v1 > vertex else (v1, vertex) for v1 in self.graph[vertex]]
 
-    def connected(self,v1,v2):
+    def connected(self, v1: int, v2: int) -> bool:
         return v2 in self.graph[v1]
 
-    def edge_type(self, e):
+    def edge_type(self, e: tuple[int, int]) -> EdgeType:
         v1,v2 = e
         try:
             return self.graph[v1][v2]
         except KeyError:
-            return 0
+            return EdgeType(0)
 
-    def set_edge_type(self, e, t):
+    def set_edge_type(self, e: tuple[int, int], t: EdgeType) -> None:
         v1,v2 = e
         self.graph[v1][v2] = t
         self.graph[v2][v1] = t
 
-    def type(self, vertex):
+    def type(self, vertex: int) -> VertexType:
         return self.ty[vertex]
-    def types(self):
+    def types(self) -> dict[int, VertexType]:
         return self.ty
-    def set_type(self, vertex, t):
+    def set_type(self, vertex: int, t: VertexType) -> None:
         self.ty[vertex] = t
 
-    def phase(self, vertex):
+    def phase(self, vertex: int) -> Fraction | int | Poly:
         return self._phase.get(vertex,Fraction(1))
-    def phases(self):
+    def phases(self) -> dict[int, Fraction | int | Poly]:
         return self._phase
-    def set_phase(self, vertex, phase):
+    def set_phase(self, vertex: int, phase: Fraction | int | Poly) -> None:
         assert_phase_real(phase)
         try:
             self._phase[vertex] = phase % 2
         except Exception:
             self._phase[vertex] = phase
-    def add_to_phase(self, vertex, phase):
+    def add_to_phase(self, vertex: int, phase: Fraction | int | Poly) -> None:
         assert_phase_real(phase)
         old_phase = self._phase.get(vertex, Fraction(1))
         try:
             self._phase[vertex] = (old_phase + phase) % 2
         except Exception:
             self._phase[vertex] = old_phase + phase
-    def qubit(self, vertex):
+    def qubit(self, vertex: int) -> FloatInt:
         return self._qindex.get(vertex,-1)
-    def qubits(self):
+    def qubits(self) -> dict[int, FloatInt]:
         return self._qindex
-    def set_qubit(self, vertex, q):
+    def set_qubit(self, vertex: int, q: FloatInt) -> None:
         if q > self._maxq: self._maxq = q
         self._qindex[vertex] = q
 
-    def row(self, vertex):
+    def row(self, vertex: int) -> FloatInt:
         return self._rindex.get(vertex, -1)
-    def rows(self):
+    def rows(self) -> dict[int, FloatInt]:
         return self._rindex
-    def set_row(self, vertex, r):
+    def set_row(self, vertex: int, r: FloatInt) -> None:
         if r > self._maxr: self._maxr = r
         self._rindex[vertex] = r
 
-    def is_ground(self, vertex):
+    def is_ground(self, vertex: int) -> bool:
         return vertex in self._grounds
-    def grounds(self):
+    def grounds(self) -> set[int]:
         return self._grounds
-    def set_ground(self, vertex, flag=True):
+    def set_ground(self, vertex: int, flag: bool = True) -> None:
         if flag:
             self._grounds.add(vertex)
         else:
             self._grounds.discard(vertex)
 
-    def clear_vdata(self, vertex):
+    def clear_vdata(self, vertex: int) -> None:
         if vertex in self._vdata:
             del self._vdata[vertex]
-    def vdata_keys(self, vertex):
-        return self._vdata.get(vertex, {}).keys()
-    def vdata(self, vertex, key, default=None):
+    def vdata_keys(self, vertex: int) -> list[str]:
+        return list(self._vdata.get(vertex, {}).keys())
+    def vdata(self, vertex: int, key: str, default: Any = None) -> Any:
         if vertex in self._vdata:
             return self._vdata[vertex].get(key,default)
         else:
             return default
-    def set_vdata(self, vertex, key, val):
+    def set_vdata(self, vertex: int, key: str, val: Any) -> None:
         if vertex in self._vdata:
             self._vdata[vertex][key] = val
         else:
             self._vdata[vertex] = {key:val}
 
-    def clear_edata(self, edge):
+    def clear_edata(self, edge: tuple[int, int]) -> None:
         self._edata.pop(edge, None)
-    def edata_keys(self, edge):
-        return self._edata.get(edge, {}).keys()
-    def edata(self, edge, key, default=None):
+    def edata_keys(self, edge: tuple[int, int]) -> list[str]:
+        return list(self._edata.get(edge, {}).keys())
+    def edata(self, edge: tuple[int, int], key: str, default: Any = None) -> Any:
         if edge in self._edata:
             return self._edata[edge].get(key, default)
         else:
             return default
-    def set_edata(self, edge, key, val):
+    def set_edata(self, edge: tuple[int, int], key: str, val: Any) -> None:
         if edge in self._edata:
             self._edata[edge][key] = val
         else:

--- a/pyzx/graph/graph_s.py
+++ b/pyzx/graph/graph_s.py
@@ -77,10 +77,10 @@ class GraphS(BaseGraph[int, tuple[int,int]]):
         else: self._maxr = -1
         return int(self._maxr)
     
-    def qubit_count(self) -> int:
+    def qubit_count(self) -> FloatInt:
         if self._qindex: self._maxq = max(self._qindex.values())
         else: self._maxq = -1
-        return int(self._maxq + 1)
+        return self._maxq + 1
 
     def inputs(self) -> tuple[int, ...]:
         return self._inputs

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -21,23 +21,21 @@ import re
 import ast
 import warnings
 from fractions import Fraction
-from typing import List, Dict, Tuple, Any, Optional, Callable, Union, TYPE_CHECKING
+from typing import Any, Union, TYPE_CHECKING
 from typing_extensions import deprecated
 
 from pyzx.graph.multigraph import Multigraph
 
-from ..utils import FractionLike, EdgeType, VertexType, phase_to_s
+from ..utils import EdgeType, VertexType, phase_to_s
 from .graph import Graph
 from .scalar import Scalar
 from .base import BaseGraph, VT, ET
-from ..simplify import id_simp
 from ..symbolic import parse, Poly, new_var, VarRegistry
 if TYPE_CHECKING:
     from .diff import GraphDiff
-    from .multigraph import Multigraph
 
 
-def string_to_phase(string: str, g: Optional[Union[BaseGraph,'GraphDiff']] = None) -> Union[Fraction, Poly]:
+def string_to_phase(string: str, g: Union[BaseGraph, 'GraphDiff', None] = None) -> Fraction | Poly:
     if not string:
         return Fraction(0)
     try:
@@ -68,7 +66,7 @@ def string_to_phase(string: str, g: Optional[Union[BaseGraph,'GraphDiff']] = Non
             raise ValueError(e)
 
 @deprecated("json_to_graph_old is deprecated, use json_to_graph or dict_to_graph instead")
-def json_to_graph_old(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) -> BaseGraph:
+def json_to_graph_old(js: str | dict[str, Any], backend: str | None = None) -> BaseGraph:
     """Deprecated: Use :func:`json_to_graph` or :func:`dict_to_graph` instead.
 
     Converts the json representation of a .qgraph Quantomatic graph into
@@ -80,8 +78,8 @@ def json_to_graph_old(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) 
     g = Graph(backend)
     g.variable_types = j.get('variable_types',{})
 
-    names: Dict[str, Any] = {} # TODO: Any = VT
-    hadamards: Dict[str, List[Any]] = {}
+    names: dict[str, Any] = {} # TODO: Any = VT
+    hadamards: dict[str, list[Any]] = {}
     for name,attr in j.get('node_vertices',{}).items():
         if ('data' in attr and 'type' in attr['data'] and attr['data']['type'] == "hadamard"
             and 'is_edge' in attr['data'] and attr['data']['is_edge'] == 'true'):
@@ -142,7 +140,7 @@ def json_to_graph_old(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) 
     g.set_inputs(tuple(sorted(inputs.keys(),key=lambda v:inputs[v])))
     g.set_outputs(tuple(sorted(outputs.keys(),key=lambda v:outputs[v])))
 
-    edges: Dict[Any, List[int]] = {} # TODO: Any = ET
+    edges: dict[Any, list[int]] = {} # TODO: Any = ET
     for edge in j.get('undir_edges',{}).values():
         n1, n2 = edge['src'], edge['tgt']
         if n1 in hadamards and n2 in hadamards: #Both
@@ -180,7 +178,7 @@ def json_to_graph_old(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) 
 
     return g
 
-def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, Any]:
+def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[str, Any]:
     """Converts a PyZX graph into Python dict for JSON output.
     If include_scalar is set to True (the default), then this includes the value
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
@@ -190,14 +188,14 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
         "variable_types": g.var_registry.types, # Potential source of error: this dictionary is mutable
     }
     if hasattr(g,'name'):
-        d['name'] = g.name
+        d['name'] = getattr(g, 'name')
     if include_scalar:
         d["scalar"] = g.scalar.to_dict()
     d['inputs'] = g.inputs()
     d['outputs'] = g.outputs()
     # Convert tuple keys to strings for JSON compatibility, replacing EdgeType with its integer value
     # This only applies to edata in Multigraph. For other classes, it returns str(k)
-    def edata_key_to_str(k):
+    def edata_key_to_str(k: Any) -> str:
         if isinstance(k, tuple) and len(k) == 3 and hasattr(k[2], 'value'):
             return str((k[0], k[1], k[2].value))
         return str(k)
@@ -230,7 +228,7 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
             d_v['is_ground'] = True
         verts.append(d_v)
 
-    edges: List[Tuple[VT,VT,EdgeType]] = []
+    edges: list[tuple[VT, VT, EdgeType]] = []
     if g.backend == 'multigraph':
         for e in g.edges():
             edges.append(e)  # type: ignore  # We know what we are doing, for multigraphs this has the right type.
@@ -246,16 +244,16 @@ def graph_to_dict(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, A
 
 
 @deprecated("graph_to_dict_old is deprecated, use graph_to_dict instead")
-def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[str, Any]:
+def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> dict[str, Any]:
     """Deprecated: Use :func:`graph_to_dict` instead.
 
     Converts a PyZX graph into Python dict for JSON output that is compatible with the Quantomatic format.
     If include_scalar is set to True (the default), then this includes the value
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
-    node_vs: Dict[str, Dict[str, Any]] = {}
-    wire_vs: Dict[str, Dict[str, Any]] = {}
-    edges: Dict[str, Dict[str, str]] = {}
-    names: Dict[VT, str] = {}
+    node_vs: dict[str, dict[str, Any]] = {}
+    wire_vs: dict[str, dict[str, Any]] = {}
+    edges: dict[str, dict[str, str]] = {}
+    names: dict[VT, str] = {}
     freenamesv = ["v"+str(i) for i in range(g.num_vertices()+g.num_edges())]
     freenamesb = ["b"+str(i) for i in range(g.num_vertices())]
     inputs = g.inputs()
@@ -344,7 +342,7 @@ def graph_to_dict_old(g: BaseGraph[VT,ET], include_scalar: bool=True) -> Dict[st
         else:
             raise TypeError("Edge of type 0")
 
-    d: Dict[str,Any] = {
+    d: dict[str,Any] = {
         "wire_vertices": wire_vs,
         "node_vertices": node_vs,
         "undir_edges": edges,
@@ -361,10 +359,10 @@ def graph_to_json(g: BaseGraph[VT,ET], include_scalar: bool=True) -> str:
     of g.scalar with the json, which will also be loaded by the ``from_json`` method."""
     return json.dumps(graph_to_dict(g, include_scalar))
 
-def dict_to_graph(d: Dict[str,Any], backend: Optional[str]=None) -> BaseGraph:
+def dict_to_graph(d: dict[str, Any], backend: str | None = None) -> BaseGraph:
     """Converts a Python dict representation a graph produced by `graph_to_dict` into
     a pyzx Graph.
-    If backend is given, it will be used as the backend for the graph, 
+    If backend is given, it will be used as the backend for the graph,
     otherwise the backend will be read from the dict description."""
     if not 'version' in d:
         # Version is not specified in dictionary, will try to parse it as an older format.
@@ -422,7 +420,7 @@ def dict_to_graph(d: Dict[str,Any], backend: Optional[str]=None) -> BaseGraph:
 
     return g
 
-def json_to_graph(js: Union[str,Dict[str,Any]], backend:Optional[str]=None) -> BaseGraph:
+def json_to_graph(js: str | dict[str, Any], backend: str | None = None) -> BaseGraph:
     """Converts the json representation of a pyzx graph (as a string or dict) into
     a `Graph`. If JSON is given as a string, parse it first."""
     if isinstance(js, str):
@@ -476,5 +474,3 @@ def to_graphml(g: BaseGraph[VT,ET]) -> str:
 """
 
     return gml
-
-

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -357,7 +357,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
 
 
     def edge_set(self) -> Counter[tuple[int, int, EdgeType]]:
-        return Counter(self.edges()) #TODO: this function is not a valid override
+        return Counter(self.edges())
 
     def edge_st(self, edge: tuple[int, int, EdgeType]) -> tuple[int, int]:
         return (edge[0], edge[1])

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -356,7 +356,7 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
         return next(iter(self.edges(s, t)))
 
 
-    def edge_set(self) -> set[tuple[int, int, EdgeType]]:
+    def edge_set(self) -> Counter[tuple[int, int, EdgeType]]:
         return Counter(self.edges()) #TODO: this function is not a valid override
 
     def edge_st(self, edge: tuple[int, int, EdgeType]) -> tuple[int, int]:

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -17,11 +17,11 @@
 import itertools
 from collections import Counter
 from fractions import Fraction
-from typing import Tuple, Dict, Set, Union, Any
+from typing import Iterable, Any
 
 from .base import BaseGraph
 
-from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, vertex_is_z_like, set_z_box_label, get_z_box_label, assert_phase_real
+from ..utils import VertexType, EdgeType, FractionLike, FloatInt, vertex_is_zx_like, set_z_box_label, get_z_box_label, assert_phase_real
 
 class Edge:
     """A structure for storing the number of simple and number of Hadamard edges
@@ -35,7 +35,7 @@ class Edge:
         self.h = h
         self.w_io = w_io
 
-    def add(self, s: int=0, h: int=0, w_io: int=0):
+    def add(self, s: int = 0, h: int = 0, w_io: int = 0) -> None:
         self.s += s
         self.h += h
         self.w_io += w_io
@@ -46,7 +46,7 @@ class Edge:
         if self.w_io == 1 and self.s + self.h > 0:
             raise ValueError('Cannot have W-IO edge and other edges')
 
-    def remove(self, s: int=0, h: int=0, w_io: int=0):
+    def remove(self, s: int = 0, h: int = 0, w_io: int = 0) -> None:
         self.add(s=-s, h=-h, w_io=-w_io)
 
     def is_empty(self) -> bool:
@@ -57,7 +57,8 @@ class Edge:
         elif ty == EdgeType.HADAMARD: return self.h
         else: return self.w_io
 
-class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
+
+class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
     """Purely Pythonic multigraph implementation of :class:`~graph.base.BaseGraph`."""
     backend = 'multigraph'
 
@@ -65,23 +66,24 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
     #can be found in base.BaseGraph
     def __init__(self) -> None:
         BaseGraph.__init__(self)
-        self.graph: Dict[int,Dict[int,Edge]]   = dict()
+        self.graph: dict[int,dict[int,Edge]]   = dict()
         self._auto_simplify: bool                       = True
         self._vindex: int                               = 0
         self.nedges: int                                = 0
-        self.ty: Dict[int,VertexType]                   = dict()
-        self._phase: Dict[int, FractionLike]            = dict()
-        self._qindex: Dict[int, FloatInt]               = dict()
+        self.ty: dict[int,VertexType]                   = dict()
+        self._phase: dict[int, FractionLike]            = dict()
+        self._qindex: dict[int, FloatInt]               = dict()
         self._maxq: FloatInt                            = -1
-        self._rindex: Dict[int, FloatInt]               = dict()
+        self._rindex: dict[int, FloatInt]               = dict()
         self._maxr: FloatInt                            = -1
-        self._grounds: Set[int]                         = set()
+        self._grounds: set[int]                         = set()
 
-        self._vdata: Dict[int,Any]                      = dict()
-        self._edata: Dict[Tuple[int,int,EdgeType], Dict[str, Any]] = dict()
-        self._inputs: Tuple[int, ...]                   = tuple()
-        self._outputs: Tuple[int, ...]                  = tuple()
-
+        self._vdata: dict[int,Any]                      = dict()
+        self._edata: dict[tuple[int, int, EdgeType], dict[str, Any]] = dict()
+        self._inputs: tuple[int, ...]                   = tuple()
+        self._outputs: tuple[int, ...]                  = tuple()
+    
+    
     def clone(self) -> 'Multigraph':
         cpy = Multigraph()
         for v, d in self.graph.items():
@@ -107,52 +109,56 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
         cpy.max_phase_index = self.max_phase_index
         return cpy
 
-    def set_auto_simplify(self, s: bool):
+    def set_auto_simplify(self, s: bool) -> None:
         """Automatically remove parallel edges as edges are added"""
         self._auto_simplify = s
 
-    def get_auto_simplify(self):
+    def get_auto_simplify(self) -> bool:
         return self._auto_simplify
 
-    def multigraph(self):
+    def multigraph(self) -> bool:
         return False
 
-    def vindex(self): return self._vindex
-    def depth(self):
+    def vindex(self) -> int:
+        return self._vindex
+    
+    def depth(self) -> float:
         if self._rindex: self._maxr = max(self._rindex.values())
         else: self._maxr = -1
         return self._maxr
-    def qubit_count(self):
+    
+    def qubit_count(self) -> int:
         if self._qindex: self._maxq = max(self._qindex.values())
         else: self._maxq = -1
-        return self._maxq + 1
+        return int(self._maxq + 1)
 
-    def inputs(self):
+    def inputs(self) -> tuple[int, ...]:
         return self._inputs
 
-    def num_inputs(self):
+    def num_inputs(self) -> int:
         return len(self._inputs)
 
-    def set_inputs(self, inputs):
+    def set_inputs(self, inputs: tuple[int, ...]) -> None:
         self._inputs = inputs
 
-    def outputs(self):
+    def outputs(self) -> tuple[int, ...]:
         return self._outputs
 
-    def num_outputs(self):
+    def num_outputs(self) -> int:
         return len(self._outputs)
 
-    def set_outputs(self, outputs):
+    def set_outputs(self, outputs: tuple[int, ...]) -> None:
         self._outputs = outputs
 
-    def add_vertices(self, amount):
+    def add_vertices(self, amount: int) -> range:
         for i in range(self._vindex, self._vindex + amount):
             self.graph[i] = dict()
             self.ty[i] = VertexType.BOUNDARY
             self._phase[i] = 0
         self._vindex += amount
         return range(self._vindex - amount, self._vindex)
-    def add_vertex_indexed(self, v):
+    
+    def add_vertex_indexed(self, v: int) -> None:
         """Adds a vertex that is guaranteed to have the chosen index (i.e. 'name').
         If the index isn't available, raises a ValueError.
         This method is used in the editor to support undo, which requires vertices
@@ -163,10 +169,10 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
         self.ty[v] = VertexType.BOUNDARY
         self._phase[v] = 0
 
-    def add_edges(self, edge_pairs, edgetype=EdgeType.SIMPLE):
+    def add_edges(self, edge_pairs: Iterable[tuple[int, int]], edgetype: EdgeType = EdgeType.SIMPLE) -> None:
         for ep in edge_pairs: self.add_edge(ep, edgetype)
 
-    def add_edge(self, edge_pair, edgetype=EdgeType.SIMPLE):
+    def add_edge(self, edge_pair: tuple[int, int], edgetype: EdgeType = EdgeType.SIMPLE) -> tuple[int, int, EdgeType]:
         self.nedges += 1
         s,t = edge_pair
         if not t in self.graph[s]:
@@ -219,7 +225,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
 
         return (s,t, edgetype) if s <= t else (t,s,edgetype)
 
-    def remove_vertices(self, vertices):
+    def remove_vertices(self, vertices: Iterable[int]) -> None:
         for v in vertices:
             vs = list(self.graph[v])
             # remove all edges
@@ -249,14 +255,14 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             self._vdata.pop(v,None)
         self._vindex = max(self.vertices(),default=0) + 1
 
-    def remove_vertex(self, vertex):
+    def remove_vertex(self, vertex: int) -> None:
         self.remove_vertices([vertex])
 
-    def remove_edges(self, edges):
+    def remove_edges(self, edges: Iterable[tuple[int, int, EdgeType]]) -> None:
         for e in edges:
             self.remove_edge(e)
 
-    def remove_edge(self, edge):
+    def remove_edge(self, edge: tuple[int, int, EdgeType]) -> None:
         s,t,ty = edge
         e = self.graph[s][t]
         if ty == EdgeType.SIMPLE: e.remove(s=1)
@@ -270,14 +276,14 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
 
         self.nedges -= 1
 
-    def num_vertices(self):
+    def num_vertices(self) -> int:
         return len(self.graph)
 
-    def num_edges(self, s=None, t=None, et=None):
-        if s != None or t != None:
-            if et == None:
+    def num_edges(self, s: int | None = None, t: int | None = None, et: EdgeType | None = None) -> int:
+        if s is not None and t is not None:
+            if et is None:
                 return len(list(self.edges(s, t)))
-            if not t in self.graph[s]:
+            if t not in self.graph[s]:
                 return 0
             if et == EdgeType.SIMPLE:
                 return self.graph[s][t].s
@@ -287,13 +293,15 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
                 return self.graph[s][t].w_io
             else:
                 raise ValueError("Unkown EdgeType: %s" % repr(et))
+        elif s is not None:
+            return self.vertex_degree(s)
         else:
             return self.nedges
 
-    def vertices(self):
+    def vertices(self) -> Iterable[int]:
         return self.graph.keys()
 
-    def vertices_in_range(self, start, end):
+    def vertices_in_range(self, start: int, end: int) -> Iterable[int]:
         """Returns all vertices with index between start and end
         that only have neighbours whose indices are between start and end"""
         for v in self.graph.keys():
@@ -301,7 +309,7 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             if all(start<v2<end for v2 in self.graph[v]):
                 yield v
 
-    def edges(self, s=None, t=None):
+    def edges(self, s: int | None = None, t: int | None = None) -> Iterable[tuple[int, int, EdgeType]]:
         if s == None:
             for v0,adj in self.graph.items():
                 for v1, e in adj.items():
@@ -340,39 +348,39 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
     #                    if v1 > v0:
     #                        yield (v0,v1)
 
-    def edge(self, s, t, et: EdgeType=EdgeType.SIMPLE):
+    def edge(self, s: int, t: int, et: EdgeType = EdgeType.SIMPLE) -> tuple[int, int, EdgeType]:
         s, t = (s, t) if s < t else (t, s)
         e = self.graph[s][t]
         if e.get_edge_count(et):
             return (s, t, et)
-        return next(self.edges(s, t))
+        return next(iter(self.edges(s, t)))
 
 
-    def edge_set(self):
-        return Counter(self.edges())
+    def edge_set(self) -> set[tuple[int, int, EdgeType]]:
+        return Counter(self.edges()) #TODO: this function is not a valid override
 
-    def edge_st(self, edge):
+    def edge_st(self, edge: tuple[int, int, EdgeType]) -> tuple[int, int]:
         return (edge[0], edge[1])
 
-    def neighbors(self, vertex):
+    def neighbors(self, vertex: int) -> Iterable[int]:
         return self.graph[vertex].keys()
 
-    def vertex_degree(self, vertex):
+    def vertex_degree(self, vertex: int) -> int:
         d = 0
         for e in self.graph[vertex].values():
             for ty in EdgeType:
                 d += e.get_edge_count(ty)
         return d
 
-    def incident_edges(self, vertex):
+    def incident_edges(self, vertex: int) -> Iterable[tuple[int, int, EdgeType]]:
         return list(itertools.chain.from_iterable(
             self.edges(vertex, v1) for v1 in self.graph[vertex]
         ))
 
-    def connected(self,v1,v2):
+    def connected(self, v1: int, v2: int) -> bool:
         return v2 in self.graph[v1]
 
-    def edge_type(self, e):
+    def edge_type(self, e: tuple[int, int, EdgeType]) -> EdgeType:
         if len(e) == 2:
             edges = list(self.edges(e[0],e[1]))
             if len(edges) == 0:
@@ -386,30 +394,34 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
             e = edges[0]
         return e[2]
 
-    def set_edge_type(self, edge, t):
-        v1,v2,ty = edge
+    def set_edge_type(self, e: tuple[int, int, EdgeType], t: EdgeType) -> None:
+        v1,v2,ty = e
         if ty != t:
-            e = self.graph[v1][v2]
+            edge = self.graph[v1][v2]
             # decrement the old type and increment the new type
-            if ty == EdgeType.SIMPLE: e.add(s=-1)
-            elif ty == EdgeType.HADAMARD: e.add(h=-1)
-            else: e.add(w_io=-1)
-            if t == EdgeType.SIMPLE: e.add(s=1)
-            elif t == EdgeType.HADAMARD: e.add(h=1)
-            else: e.add(w_io=1)
+            if ty == EdgeType.SIMPLE: edge.add(s=-1)
+            elif ty == EdgeType.HADAMARD: edge.add(h=-1)
+            else: edge.add(w_io=-1)
+            if t == EdgeType.SIMPLE: edge.add(s=1)
+            elif t == EdgeType.HADAMARD: edge.add(h=1)
+            else: edge.add(w_io=1)
 
-    def type(self, vertex):
+    def type(self, vertex: int) -> VertexType:
         return self.ty[vertex]
-    def types(self):
+    
+    def types(self) -> dict[int, VertexType]:
         return self.ty
-    def set_type(self, vertex, t):
+    
+    def set_type(self, vertex: int, t: VertexType) -> None:
         self.ty[vertex] = t
 
-    def phase(self, vertex):
-        return self._phase.get(vertex,Fraction(1))
-    def phases(self):
+    def phase(self, vertex: int) -> FractionLike:
+        return self._phase.get(vertex, Fraction(1))
+    
+    def phases(self) -> dict[int, FractionLike]:
         return self._phase
-    def set_phase(self, vertex, phase):
+    
+    def set_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
         try:
             if isinstance(phase, Fraction):
@@ -418,7 +430,8 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
                 self._phase[vertex] = phase
         except Exception:
             self._phase[vertex] = phase
-    def add_to_phase(self, vertex, phase):
+    
+    def add_to_phase(self, vertex: int, phase: FractionLike) -> None:
         assert_phase_real(phase)
         old_phase = self._phase.get(vertex, Fraction(1))
         try:
@@ -428,74 +441,84 @@ class Multigraph(BaseGraph[int,Tuple[int,int,EdgeType]]):
                 self._phase[vertex] = old_phase + phase
         except Exception:
             self._phase[vertex] = old_phase + phase
-    def qubit(self, vertex):
+    
+    def qubit(self, vertex: int) -> FloatInt:
         return self._qindex.get(vertex,-1)
-    def qubits(self):
+    
+    def qubits(self) -> dict[int, FloatInt]:
         return self._qindex
-    def set_qubit(self, vertex, q):
+    
+    def set_qubit(self, vertex: int, q: FloatInt) -> None:
         if q > self._maxq: self._maxq = q
         self._qindex[vertex] = q
 
-    def row(self, vertex):
+    def row(self, vertex: int) -> FloatInt:
         return self._rindex.get(vertex, -1)
-    def rows(self):
+    
+    def rows(self) -> dict[int, FloatInt]:
         return self._rindex
-    def set_row(self, vertex, r):
+    
+    def set_row(self, vertex: int, r: FloatInt) -> None:
         if r > self._maxr: self._maxr = r
         self._rindex[vertex] = r
 
-    def is_ground(self, vertex):
+    def is_ground(self, vertex: int) -> bool:
         return vertex in self._grounds
-    def grounds(self):
+    
+    def grounds(self) -> set[int]:
         return self._grounds
-    def set_ground(self, vertex, flag=True):
+    
+    def set_ground(self, vertex: int, flag: bool = True) -> None:
         if flag:
             self._grounds.add(vertex)
         else:
             self._grounds.discard(vertex)
 
-    def clear_vdata(self, vertex):
+    def clear_vdata(self, vertex: int) -> None:
         if vertex in self._vdata:
             del self._vdata[vertex]
-    def vdata_keys(self, vertex):
+    
+    def vdata_keys(self, vertex: int) -> Iterable[str]:
         return self._vdata.get(vertex, {}).keys()
-    def vdata(self, vertex, key, default=None):
+    
+    def vdata(self, vertex: int, key: str, default: Any = None) -> Any:
         if vertex in self._vdata:
-            return self._vdata[vertex].get(key,default)
+            return self._vdata[vertex].get(key, default)
         else:
             return default
-    def set_vdata(self, vertex, key, val):
+    
+    def set_vdata(self, vertex: int, key: str, val: Any) -> None:
         if vertex in self._vdata:
             self._vdata[vertex][key] = val
         else:
-            self._vdata[vertex] = {key:val}
+            self._vdata[vertex] = {key: val}
 
-    def clear_edata(self, edge):
+    def clear_edata(self, edge: tuple[int, int, EdgeType]) -> Any:
         self._edata.pop(edge, None)
 
-    def edata_keys(self, edge):
+    def edata_keys(self, edge: tuple[int, int, EdgeType]) -> Iterable[str]:
         return self._edata.get(edge, {}).keys()
 
-    def edata(self, edge, key, default=None):
+    def edata(self, edge: tuple[int, int, EdgeType], key: str, default: Any = None) -> Any:
         return self._edata.get(edge, {}).get(key, default)
 
-    def set_edata(self, edge, key, val):
+    def set_edata(self, edge: tuple[int, int, EdgeType], key: str, val: Any) -> None:
         if edge in self._edata:
             self._edata[edge][key] = val
         else:
             self._edata[edge] = {key: val}
 
-    def edata_dict(self, edge):
+    def edata_dict(self, edge: tuple[int, int, EdgeType]) -> dict[str, Any]:
         return dict(self._edata.get(edge, {}))
 
-    def set_edata_dict(self, edge, d):
+    def set_edata_dict(self, edge: tuple[int, int, EdgeType], d: dict[str, Any]) -> None:
         self.clear_edata(edge)
         if d:
             self._edata[edge] = dict(d)
 
     @classmethod
-    def from_json(cls, js:Union[str,Dict[str,Any]]) -> 'Multigraph':
+    def from_json(cls, js: str | dict[str, Any]) -> 'Multigraph':
         """Converts the given .qgraph json string into a Multigraph.
         Works with the output of :meth:`to_json`."""
         from .jsonparser import json_to_graph
-        return json_to_graph(js,backend='multigraph') # type:ignore
+        return json_to_graph(js, backend='multigraph')

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -127,10 +127,10 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
         else: self._maxr = -1
         return self._maxr
     
-    def qubit_count(self) -> int:
+    def qubit_count(self) -> FloatInt:
         if self._qindex: self._maxq = max(self._qindex.values())
         else: self._maxq = -1
-        return int(self._maxq + 1)
+        return self._maxq + 1
 
     def inputs(self) -> tuple[int, ...]:
         return self._inputs

--- a/pyzx/graph/multigraph.py
+++ b/pyzx/graph/multigraph.py
@@ -17,7 +17,7 @@
 import itertools
 from collections import Counter
 from fractions import Fraction
-from typing import Iterable, Any
+from typing import Iterable, Any, cast
 
 from .base import BaseGraph
 
@@ -310,14 +310,14 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
                 yield v
 
     def edges(self, s: int | None = None, t: int | None = None) -> Iterable[tuple[int, int, EdgeType]]:
-        if s == None:
+        if s is None:
             for v0,adj in self.graph.items():
                 for v1, e in adj.items():
                     if v1 >= v0:
                         for _ in range(e.s): yield (v0, v1, EdgeType.SIMPLE)
                         for _ in range(e.h): yield (v0, v1, EdgeType.HADAMARD)
                         for _ in range(e.w_io): yield (v0, v1, EdgeType.W_IO)
-        elif t != None:
+        elif t is not None:
             s, t = (s, t) if s < t else (t, s)
             if t not in self.graph[s]:
                 return
@@ -521,4 +521,4 @@ class Multigraph(BaseGraph[int, tuple[int,int,EdgeType]]):
         """Converts the given .qgraph json string into a Multigraph.
         Works with the output of :meth:`to_json`."""
         from .jsonparser import json_to_graph
-        return json_to_graph(js, backend='multigraph')
+        return cast(Multigraph, json_to_graph(js, backend='multigraph'))

--- a/pyzx/pauliweb.py
+++ b/pyzx/pauliweb.py
@@ -234,7 +234,7 @@ def compute_pauli_webs(g: BaseGraph[VT,ET], backwards:bool=True, debug:Optional[
             color_edge[v] = (s,t)
         
     for b in g1.inputs() + g1.outputs():
-        e = g1.incident_edges(b)[0]
+        e = next(iter(g1.incident_edges(b)))
         v = next(iter(g1.neighbors(b)))
         vt = g1.type(v)
         et = g1.edge_type(e)

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -211,10 +211,10 @@ def match_pivot_gadget(
     """Like :func:`check_pivot`, but except for pairings of
     Pauli vertices, it looks for a pair of an interior Pauli vertex and an
     interior non-Clifford vertex in order to gadgetize the non-Clifford vertex."""
-    if vertices is not None: candidates_set = {g.edge(vertices[0], vertices[1])}
+    if vertices is not None: candidates_set = Counter([g.edge(vertices[0], vertices[1])])
 
-    else: candidates_set = g.edge_set()
-    candidates = list(Counter(candidates_set).elements())
+    else: candidates_set = Counter(g.edge_set())
+    candidates = list(candidates_set.elements())
     types = g.types()
     phases = g.phases()
     rs = g.rows()

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -160,7 +160,7 @@ def match_pivot_boundary(
             if types[n] != VertexType.Z:
                 good_vert = False
                 break
-            if len(g.neighbors(n)) == 1: # v is a phase gadget
+            if len(list(g.neighbors(n))) == 1: # v is a phase gadget
                 good_vert = False
                 break
             if n in consumed_vertices:

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -50,13 +50,13 @@ GOOGLE_SYCAMORE = "google_sycamore"
 IBM_ROCHESTER = "ibm_rochester"
 DENSITY = "dynamic_density"
 
-architectures = [SQUARE, CIRCLE, FULLY_CONNECTED, LINE, DENSITY, IBM_QX4, IBM_QX2, IBM_QX3, 
-                IBM_QX5, IBM_Q20_TOKYO, RIGETTI_8Q_AGAVE, RIGETTI_16Q_ASPEN, RIGETTI_19Q_ACORN, 
-                REC_ARCH, SYCAMORE_LIKE, IBMQ_POUGHKEEPSIE, IBMQ_BOEBLINGEN, IBMQ_SINGAPORE, 
+architectures = [SQUARE, CIRCLE, FULLY_CONNECTED, LINE, DENSITY, IBM_QX4, IBM_QX2, IBM_QX3,
+                IBM_QX5, IBM_Q20_TOKYO, RIGETTI_8Q_AGAVE, RIGETTI_16Q_ASPEN, RIGETTI_19Q_ACORN,
+                REC_ARCH, SYCAMORE_LIKE, IBMQ_POUGHKEEPSIE, IBMQ_BOEBLINGEN, IBMQ_SINGAPORE,
                 GOOGLE_SYCAMORE, IBM_ROCHESTER] # List of available architectures
 dynamic_size_architectures = [FULLY_CONNECTED, LINE, CIRCLE, SQUARE, DENSITY]
-hamiltonian_path_architectures = [FULLY_CONNECTED, LINE, CIRCLE, SQUARE, IBM_QX4, IBM_QX2, IBM_QX3, 
-                IBM_QX5, IBM_Q20_TOKYO, RIGETTI_8Q_AGAVE, RIGETTI_16Q_ASPEN, 
+hamiltonian_path_architectures = [FULLY_CONNECTED, LINE, CIRCLE, SQUARE, IBM_QX4, IBM_QX2, IBM_QX3,
+                IBM_QX5, IBM_Q20_TOKYO, RIGETTI_8Q_AGAVE, RIGETTI_16Q_ASPEN,
                 IBMQ_POUGHKEEPSIE]
 
 class Architecture():
@@ -68,7 +68,7 @@ class Architecture():
         """
         Class that represents the architecture of the qubits to be taken into account when routing.
 
-        :param coupling_graph: a PyZX Graph representing the architecture, optional 
+        :param coupling_graph: a PyZX Graph representing the architecture, optional
         :param coupling_matrix: a 2D numpy array representing the adjacency of the qubits, from which the Graph is created, optional
         :param backend: The PyZX Graph backend to be used when creating it from the adjacency matrix, optional
         :param reduce_order: A list of integers representing the order in which the qubits should be scanned for some operations (e.g. steiner tree reduction), optional
@@ -184,7 +184,7 @@ class Architecture():
         Converts a list of vertices, representing a subgraph, to a sorted tuple.
         
         :param subgraph: A list of vertex location within the subgraph
-        :return: A sorted tuple of the given subgraph vertices 
+        :return: A sorted tuple of the given subgraph vertices
         """
         return tuple(sorted(subgraph))
 
@@ -244,7 +244,7 @@ class Architecture():
         :param vertices: An optional list of vertex locations within the graph, default None
         :return: A corresponding list showcasing which vertices are articulation points
         """
-        # algorithm from https://courses.cs.washington.edu/courses/cse421/04su/slides/artic.pdf and https://www.geeksforgeeks.org/articulation-points-or-cut-vertices-in-a-graph/ 
+        # algorithm from https://courses.cs.washington.edu/courses/cse421/04su/slides/artic.pdf and https://www.geeksforgeeks.org/articulation-points-or-cut-vertices-in-a-graph/
         if vertices is None:
             vertices = self.vertices
         number_of_nodes = len(vertices)
@@ -382,23 +382,23 @@ class Architecture():
         """
         if qubits_to_use is None:
             nodes = self.vertices
-        else: 
+        else:
             nodes = [self.qubit2vertex(n) for n in qubits_to_use]
         start = self.qubit2vertex(start_qubit)
         end = self.qubit2vertex(end_qubit)
 
-        queue = [(start, [start])] 
+        queue = [(start, [start])]
         visited = [start]
   
-        while queue != []: 
+        while queue != []:
             
-            node, path = queue.pop() 
+            node, path = queue.pop()
             if node == end:
                 return path
             edges = [edge for edge in self.graph.edges() if node in edge]
             neighbors = [n for edge in edges for n in edge if n != node and n in nodes]
-            for new_node in neighbors: 
-                if new_node not in visited: 
+            for new_node in neighbors:
+                if new_node not in visited:
                     queue.append((new_node, path + [new_node]))
                     visited.append(new_node)
         return None
@@ -410,7 +410,7 @@ class Architecture():
 
         :param start_qubit: The index of the root qubit to be used
         :param qubits_to_use: The indices of the other qubits that should be present in the steiner tree
-        :param upper: Whether to consider only the nodes 
+        :param upper: Whether to consider only the nodes
             the steiner tree is used for creating an upper triangular matrix or a full reduction.
         :yields: First yields all edges from the tree top-to-bottom, finished with None, then yields all edges from the tree bottom-up, finished with None.
         """
@@ -468,7 +468,7 @@ class Architecture():
             
         # Compute all the edges of the steiner tree in BFS order, starting from the root
         visited = {root}
-        queue = [root] 
+        queue = [root]
         generated_edges: List[Tuple[int,int]] = []
         
         while queue != []:
@@ -563,7 +563,7 @@ class Architecture():
         Returns a list of tuples (i, arity) where i is the index of each node and arity is the number of neighbors,
         sorted by decreasing arity.
         """
-        arities = [(i, len(self.graph.neighbors(v))) for i,v in enumerate(self.vertices)]
+        arities = [(i, len(list(self.graph.neighbors(v)))) for i,v in enumerate(self.vertices)]
         arities.sort(key=lambda p: p[1], reverse=True)
         return arities
 
@@ -588,7 +588,7 @@ def connect_vertices_in_line(vertices: List[int]) -> List[Tuple[int, int]]:
 
 def connect_vertices_as_grid(width: int, height: int, vertices: List[int]) -> List[Tuple[int,int]]:
     """
-    Connects vertices into a grid, with layout specified by width and height, vertices length much be equal to width * height. 
+    Connects vertices into a grid, with layout specified by width and height, vertices length much be equal to width * height.
     
     :param width: Width of the grid, number of columns
     :param height: Height of the grid, number of rows

--- a/pyzx/simulation/common.py
+++ b/pyzx/simulation/common.py
@@ -64,7 +64,7 @@ class SumGraph(object):
     def inner_product_with_random_state(self) -> complex:
         """All the graphs should be Clifford states with same amount of outputs.
         We compose them with a random equatorial Clifford effect,
-        and we calculate the resulting inner product. 
+        and we calculate the resulting inner product.
         Used in the norm estimation algorithm of
         https://arxiv.org/pdf/1808.00128.pdf"""
         terms = self.graphs
@@ -88,7 +88,7 @@ class SumGraph(object):
             g.set_outputs(())
             g.add_edges([(vs[i1],vs[i2]) for (i1,i2) in connections],EdgeType.HADAMARD)
             g.scalar.add_power(len(connections))
-            # Now that we have composed g with a right sort of effect, 
+            # Now that we have composed g with a right sort of effect,
             # we need to calculate the value of the resulting inner product.
             # Since the diagram is a scalar, full_reduce() will completely annihilate it.
             simplify.full_reduce(g)
@@ -129,14 +129,14 @@ class SumGraph(object):
             terms.append(g)
         return SumGraph(terms)
 
-    def sample(self, 
-        qubits: List[int], 
-        post_selected:Optional[Dict[int,str]]=None, 
-        amount:int=10, 
-        epsilon:float=0.05, 
+    def sample(self,
+        qubits: List[int],
+        post_selected:Optional[Dict[int,str]]=None,
+        amount:int=10,
+        epsilon:float=0.05,
         quiet:bool=True) -> List[List[Tuple[int,int]]]:
         """Implements the weak simulation algorithm of https://arxiv.org/pdf/1808.00128.pdf.
-        ``qubits`` should be a list of qubit numbers from which measurement outcomes in the 
+        ``qubits`` should be a list of qubit numbers from which measurement outcomes in the
         computational basis are to be sampled. ``post_selected`` should be in the format of
         :method:`post_select`. ``amount`` dictates the amount of samples to be taken.
         ``epsilon`` is the error used in the norm estimation.
@@ -153,7 +153,7 @@ class SumGraph(object):
                 qubit_map[q] -= sum(1 for v in post_selected if v<q)
         norm = gsum.estimate_norm(epsilon)
         if not quiet: print("Estimated original norm:", norm)
-        if norm < 0.01 and not quiet: 
+        if norm < 0.01 and not quiet:
             print("Norm very close to zero. Possibly post-selected to zero probability event?")
         probs : Dict[str,float] = {}
         outputs = []
@@ -193,7 +193,7 @@ class SumGraph(object):
         return outputs
     
 def calculate_path_sum(g: BaseGraph[VT,ET]) -> complex:
-    """Input should be a fully reduced scalar graph-like Clifford+T ZX-diagram. 
+    """Input should be a fully reduced scalar graph-like Clifford+T ZX-diagram.
     Calculates the scalar it represents."""
     if g.num_vertices() < 2: return g.to_tensor().flatten()[0]
     phases = g.phases()
@@ -355,7 +355,7 @@ def check_catn(g: BaseGraph[VT, ET], vertex: VT, n: int) -> bool:
         raise ValueError(f'The cat {n} decomposition function can only be '
                          + 'applied to a phaseless or pi-phase spider, but '
                          + f'specified vertex has phase {phase}')
-    neighbors = g.neighbors(vertex)
+    neighbors = list(g.neighbors(vertex))
     if len(neighbors) != n:
         raise ValueError(f'The cat {n} decomposition acts on a degree {n} '
                          + 'spider, but specified vertex has degree '

--- a/pyzx/simulation/decompositions/cut_vertex.py
+++ b/pyzx/simulation/decompositions/cut_vertex.py
@@ -21,7 +21,7 @@ def decompose(g:BaseGraph[VT,ET], v:VT) -> SumGraph:
     g0.remove_vertex(v)
     g1.remove_vertex(v)
 
-    n = len(g.neighbors(v))
+    n = len(list(g.neighbors(v)))
     g0.scalar.add_power(-n)
     g1.scalar.add_power(-n)
     g1.scalar.add_phase(g.phase(v)) # account for e^(i*pi*alpha) on right branch

--- a/pyzx/tikz.py
+++ b/pyzx/tikz.py
@@ -178,8 +178,8 @@ def to_tikz(g: BaseGraph[VT,ET], draw_scalar:bool=False) -> str:
 def to_tikz_sequence(graphs:List[BaseGraph], draw_scalar:bool=False, maxwidth:FloatInt=10) -> str:
     """Given a list of ZX-graphs, outputs a single tikz diagram with the graphs presented in a grid.
     ``maxwidth`` is the maximum width of the diagram, before a graph is put on a new row in the tikz diagram."""
-    xoffset = -maxwidth
-    yoffset = -10
+    xoffset: FloatInt = -maxwidth
+    yoffset: FloatInt = -10
     idoffset = 0
     total_verts, total_edges = [],[]
     for g in graphs:

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -28,7 +28,7 @@ from .symbolic import Poly
 FloatInt = Union[float,int]
 FractionLike = Union[Fraction,int,Poly]
 
-def assert_phase_real(phase: FractionLike) -> None:
+def assert_phase_real(phase: FractionLike | complex) -> None:
     """Raise a TypeError if ``phase`` contains complex coefficients.
 
     Phases represent multiples of pi and must be real-valued.  Complex


### PR DESCRIPTION
Smaller-scoped version of #444 targeting just the graph classes.

This PR is part of an effort to introduce type annotations on all functions across the library and enable the mypy setting to enforce it on all future contributions. I also updated some annotations to slightly more modern syntax since the lowest supported python version has now been raised to 3.10.

For the most part, I avoided touching the bodies of functions, but there's a few areas where I slightly modified things in order to fix type errors (e.g., adding `list(...)` at call sites, or removing hardcoded references to the `Multigraph` implementation inside `BaseGraph`). There are still some areas where code that should be generic instead relies heavily on specific implementations in a non-typesafe manner, and the currently recommended `Graph()` function is, but fixing these larger issues seems to require a larger refactor which is outside the scope of this PR.

I did not touch `graph_gt.py` or `graph_ig.py` since they are marked as deprecated, but if it's worth also typing these then I can do that in this PR too.

There is one unresolved issue I would like to seek feedback on: currently, `BaseGraph` defines a `edge_set` function which returns a `set[ET]`, but `Multigraph` overrides this to return a `Counter[ET]` instead, which is not a compatible type at all. The solutions to this are either to change what `Multigraph.edge_set` returns (which would be a breaking change) or make `BaseGraph.edge_set` have a uselessly generic type annotations. I didn't want to presume which solution would be better here.