### PR TITLE
fix bug in `match_pivot_boundary` which skipped exclusion of grounded neighbours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Added
 - The circuit generation functions in pyzx.generate now accept an additional optional argument, sigma, allowing a CNOT spread based on a Gaussian distribution rather than a uniform distribution for control over how localised the CNOTs should be. (by @mjsutcliffe99).
+- `pyzx.simplify.drop_orphan_reset_discards`: opt-in cleanup pass that removes the disconnected `boundary -- Z(0) -- X(_rN)` components left behind by `Circuit.to_graph(elide_initial_resets=False)` on circuits with leading resets, matching the elided graph with |0⟩ applied to those inputs (by @dlyongemallo).
 
 ### Deprecated
 - Deprecated pyzx.simulate.py as it is starting to get bloated with all the new decompositions and strategies that have been added in recent years. All the functions in this file should still work (with deprecation warnings) but are rerouted to their new homes under the pyzx.simulation folder. (by @mjsutcliffe99).
@@ -18,12 +19,10 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - Refactored the simulation API to make it more formulaic and extensible. Individual decompositions are no longer included as distinct functions inside pyzx.simulate.py but now are provided their own individual files under pyzx.simulation.decompositions and share a common caller function. For example, pyzx.simulate.apply_cat3(g,v) is instead now pyzx.simulation.apply_decomp(Decomp.CAT_3,g,v), etc. (by @mjsutcliffe99).
 - Likewise, decomposition strategies are separated into individual files under pyzx.simulation.strategies and called similarly through e.g. zx.simulation.full_decompose(Strategy.BSS,g). (by @mjsutcliffe99).
 
-### Added
-- `pyzx.simplify.drop_orphan_reset_discards`: opt-in cleanup pass that removes the disconnected `boundary -- Z(0) -- X(_rN)` components left behind by `Circuit.to_graph(elide_initial_resets=False)` on circuits with leading resets, matching the elided graph with |0⟩ applied to those inputs (by @dlyongemallo).
-
 ### Fixed
 - Multigraph handling of parallel mixed simple/Hadamard edges in tensor contraction, several rewrite rules, and `PauliWeb` (by @dlyongemallo).
 - Reset gate representation changed from ground-based to symbolic boolean paradigm, avoiding paradigm-mixing issues that destroyed measurement phases during simplification of circuits with mid-circuit resets. As a side effect, `graph_to_circuit` now recovers conditional X-type rotations (`NOT`, `XPhase`, `SX`), since X-type vertices on the qubit wire are unambiguous now that measurement outcomes are represented as leaves. `Circuit.to_graph` gains an opt-in `elide_initial_resets` flag (default `False`) that skips the discard chain for a `Reset` on an unmodified input wire, useful for circuits with OpenQASM-style implicit |0⟩ inputs. Each `_rN` reset variable is allocated to the lowest name not already in the graph's variable registry to avoid aliasing user-supplied phases, and `graph_to_circuit` excludes vertices on classical-bit wires (e.g. the `Z`/`X` pair from `DiscardBit`) so hybrid graphs round-trip without extra phantom qubits (by @dlyongemallo).
+* `match_pivot_boundary` skipped exclusion of grounded neighbours
 
 ## [0.10.2] - 2026-05-01
 

--- a/pyzx/rewrite_rules/pivot_rule.py
+++ b/pyzx/rewrite_rules/pivot_rule.py
@@ -166,7 +166,7 @@ def match_pivot_boundary(
             if n in consumed_vertices:
                 good_vert = False
                 break
-            if g.is_ground(n) in consumed_vertices:
+            if g.is_ground(n):
                 good_vert = False
                 break
             boundaries: List[VT] = []

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -158,6 +158,25 @@ class TestSimplify(unittest.TestCase):
     def test_pivot_simp(self):
         self.func_test(pivot_simp,prepare=[spider_simp,to_gh,spider_simp])
 
+    def test_match_pivot_boundary_skips_grounded_neighbor(self):
+        """Regression test that ``match_pivot_boundary`` skips a Pauli
+        candidate whose neighbour is grounded."""
+        from pyzx import EdgeType
+        from pyzx.rewrite_rules.pivot_rule import match_pivot_boundary
+        g = Graph()
+        b = g.add_vertex(VertexType.BOUNDARY, qubit=0, row=0)
+        w = g.add_vertex(VertexType.Z, qubit=0, row=1, phase=Fraction(1, 2))
+        v = g.add_vertex(VertexType.Z, qubit=0, row=2, phase=Fraction(1))
+        g.add_edge((b, w), EdgeType.SIMPLE)
+        g.add_edge((w, v), EdgeType.HADAMARD)
+        g.set_inputs([b])
+        g.set_ground(w, True)
+
+        # The only candidate `v` has the grounded `w` as a neighbour.
+        vertex_count_before = len(list(g.vertices()))
+        self.assertEqual(match_pivot_boundary(g), [])
+        self.assertEqual(len(list(g.vertices())), vertex_count_before)
+
     def test_lcomp_simp(self):
         self.func_test(lcomp_simp,prepare=[spider_simp,to_gh,spider_simp])
 


### PR DESCRIPTION
## Description

`match_pivot_boundary` had a typo in the check for grounded neighbours (`consumed_vertices` evidently miscopied from the previous line). This fixes the check.

## Related issue

Fixes a bug that partly contributes to #413.

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.