### PR TITLE
docs: explain measurements, resets, and mixed processes

### DIFF
--- a/demos/AllFeatures.ipynb
+++ b/demos/AllFeatures.ipynb
@@ -3971,6 +3971,138 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id=\"mixed-processes\"></a>\n",
+    "\n",
+    "# Measurements, resets, and mixed processes\n",
+    "\n",
+    "PyZX can represent circuits that are not purely unitary. Measurements, resets, ancilla preparations, post-selections, and simple classical control are kept in the ZX-graph using symbolic Boolean phases, so the classical information is visible after conversion.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyzx.circuit.gates import (\n",
+    "    ConditionalGate,\n",
+    "    InitAncilla,\n",
+    "    Measurement,\n",
+    "    PostSelect,\n",
+    "    ZPhase,\n",
+    ")\n",
+    "from pyzx.symbolic import Poly\n",
+    "from pyzx.simplify import drop_orphan_reset_discards\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A measurement stores its classical result as a symbolic Boolean phase. A reset uses a fresh symbolic variable for the discarded state and then prepares a fresh ``|0>`` state.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mixed_qasm = \"\"\"\n",
+    "OPENQASM 2.0;\n",
+    "include \"qelib1.inc\";\n",
+    "qreg q[1];\n",
+    "creg c[1];\n",
+    "h q[0];\n",
+    "measure q[0] -> c[0];\n",
+    "reset q[0];\n",
+    "\"\"\"\n",
+    "\n",
+    "measured = zx.Circuit.from_qasm(mixed_qasm)\n",
+    "measured_graph = measured.to_graph(elide_initial_resets=False)\n",
+    "\n",
+    "symbolic_phases = sorted({\n",
+    "    str(measured_graph.phase(v))\n",
+    "    for v in measured_graph.vertices()\n",
+    "    if isinstance(measured_graph.phase(v), Poly)\n",
+    "})\n",
+    "symbolic_phases\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Leading resets can be elided when the input is already known to be ``|0>``. The default keeps the discard-and-prepare structure, which is safer for programmatically constructed circuits where the input state may be unknown.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leading_reset = zx.Circuit.from_qasm(\"\"\"\n",
+    "OPENQASM 2.0;\n",
+    "include \"qelib1.inc\";\n",
+    "qreg q[1];\n",
+    "reset q[0];\n",
+    "h q[0];\n",
+    "\"\"\")\n",
+    "\n",
+    "keep_reset = leading_reset.to_graph(elide_initial_resets=False)\n",
+    "elide_reset = leading_reset.to_graph(elide_initial_resets=True)\n",
+    "\n",
+    "(keep_reset.num_vertices(), elide_reset.num_vertices())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If a graph has already been built with non-elided leading resets, ``drop_orphan_reset_discards`` removes only orphaned leading discard chains. Mid-circuit reset discards and still-referenced reset variables are preserved.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cleanup_graph = leading_reset.to_graph(elide_initial_resets=False)\n",
+    "removed = drop_orphan_reset_discards(cleanup_graph)\n",
+    "\n",
+    "(removed, cleanup_graph.num_vertices())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ancilla preparation, post-selection, measurement, and supported classical control can also be combined in a programmatically constructed circuit. Here the conditional gate is a single-qubit ``Z`` rotation controlled by the classical bit ``c[0]``.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "programmatic = zx.Circuit(1, bit_amount=1)\n",
+    "programmatic.add_gate(InitAncilla(1, \"0\"))\n",
+    "programmatic.add_gate(\"CNOT\", 0, 1)\n",
+    "programmatic.add_gate(Measurement(0, result_bit=0))\n",
+    "programmatic.add_gate(ConditionalGate(\"c\", 1, ZPhase(1, 1), 1))\n",
+    "programmatic.add_gate(PostSelect(1, \"0\"))\n",
+    "\n",
+    "programmatic_graph = programmatic.to_graph()\n",
+    "(programmatic_graph.num_vertices(), programmatic_graph.num_edges())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id=\"diagram-io\"></a>\n",
     "# Importing, exporting and editing diagrams\n",
     "PyZX also has its own json format for exporting graphs and interacts with [ZXLive](https://github.com/zxcalc/zxlive) to make manually modifying diagrams easy. First, let's see that we can indeed load diagrams:"

--- a/doc/representations.rst
+++ b/doc/representations.rst
@@ -25,6 +25,87 @@ PyZX also offers a convenience function to construct a circuit out of a string c
 
 To convert a Circuit into a PyZX Graph (i.e. a ZX-diagram), call the method :meth:`~pyzx.circuit.Circuit.to_graph`.
 
+Measurements, resets, and mixed processes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PyZX can also import and graph circuits that are not purely unitary, such as
+circuits with measurements, resets, ancilla preparations, post-selections, and
+classical control. These operations are represented in the ZX-graph with
+symbolic Boolean phases, so the classical outcomes remain visible in the graph
+instead of being silently discarded.
+
+The main operations are:
+
+- :class:`~pyzx.circuit.gates.Measurement`: a measurement adds a ``Z(0)``
+  spider on the measured qubit wire and a degree-1 ``X`` leaf whose phase is a
+  Boolean symbol such as ``c[0]``. The symbol records the classical bit that
+  receives the result.
+- :class:`~pyzx.circuit.gates.Reset`: a reset discards the current qubit state
+  and prepares ``|0>``. With the default graph conversion, this is represented
+  by a discard leaf carrying a fresh Boolean symbol such as ``_r0`` and a
+  separate ``X(0)`` preparation leaf.
+- :class:`~pyzx.circuit.gates.InitAncilla` and
+  :class:`~pyzx.circuit.gates.PostSelect`: these add explicit state preparation
+  and post-selection vertices for ``|+>``, ``|->``, ``|0>``, or ``|1>``.
+- :class:`~pyzx.circuit.gates.ConditionalGate`: OpenQASM-style classical
+  control is represented by multiplying supported single-qubit ``Z`` or ``X``
+  rotation phases by a Boolean condition polynomial.
+
+For example, a small OpenQASM circuit with a measurement and a reset can be
+loaded and converted to a graph:
+
+.. code-block:: python
+
+   import pyzx as zx
+
+   circuit = zx.Circuit.from_qasm("""
+   OPENQASM 2.0;
+   include "qelib1.inc";
+   qreg q[1];
+   creg c[1];
+   h q[0];
+   measure q[0] -> c[0];
+   reset q[0];
+   """)
+
+   graph = circuit.to_graph()
+
+The graph contains symbolic phases for the measurement result and for the reset
+discard. You can inspect those symbols directly:
+
+.. code-block:: python
+
+   symbolic_phases = [
+       str(graph.phase(v))
+       for v in graph.vertices()
+       if graph.phase(v) != 0
+   ]
+
+The option ``elide_initial_resets`` controls leading resets on otherwise
+unmodified input wires:
+
+.. code-block:: python
+
+   keep_reset = circuit.to_graph(elide_initial_resets=False)
+   elide_reset = circuit.to_graph(elide_initial_resets=True)
+
+The default, ``False``, preserves the reset's discard-and-prepare structure.
+Use ``True`` when the input is already known to be ``|0>`` (for example, when
+following OpenQASM's implicit all-zero input convention) and the leading reset
+would only repeat that preparation. Mid-circuit resets are still kept, because
+they discard a live state.
+
+If you already built a graph with non-elided leading resets and want to remove
+only the orphaned discard chains, use
+:func:`~pyzx.simplify.drop_orphan_reset_discards`. This cleanup keeps
+mid-circuit resets and any reset variable that is still referenced elsewhere in
+the graph.
+
+Some limitations are intentional. Symbolic phases cannot be converted to a
+numeric tensor or matrix until the classical variables are substituted, and
+classically-controlled graph conversion currently supports single-qubit ``Z``
+and ``X`` rotations rather than arbitrary controlled subcircuits.
+
 
 Importing and exporting ZX-diagrams
 -----------------------------------


### PR DESCRIPTION
Closes #455.

## Summary

This adds documentation for PyZX support around measurements, resets, ancilla preparations, post-selection, and simple classical control:

- adds a new `doc/representations.rst` section explaining the symbolic-Boolean graph representation
- documents `elide_initial_resets` and `drop_orphan_reset_discards`
- extends `demos/AllFeatures.ipynb` with a small mixed-process section
- keeps the notebook examples conservative and runnable against the current public API

## Validation

- `python -m pytest tests/test_init_postselect.py tests/test_qasm.py -q`
  - `100 passed, 12 skipped, 14 subtests passed`
- Executed the newly added AllFeatures notebook cells in isolation with the notebook's normal `import pyzx as zx` setup.
- `git diff --check`

## AI disclosure

I used AI assistance to draft and review the documentation structure and examples. The examples were checked locally against the current codebase before submission.