### PR TITLE
Document measurements, resets, and mixed processes

### DIFF
--- a/demos/AllFeatures.ipynb
+++ b/demos/AllFeatures.ipynb
@@ -3971,6 +3971,66 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Measurements, resets, and mixed processes\n",
+    "PyZX can import OpenQASM circuits containing measurements and resets. A measurement adds a classical result bit to the circuit model, while a reset is represented as discarding the current qubit state and preparing a fresh `|0>` state.\n",
+    "\n",
+    "When a reset appears at the start of an OpenQASM wire it is often redundant, because OpenQASM `qreg` inputs are already fresh `|0>` states. `Circuit.to_graph(elide_initial_resets=True)` skips only those leading reset fragments; resets after earlier gates or measurements are still kept because they change the mixed process.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mixed_qasm = \"\"\"\n",
+    "OPENQASM 2.0;\n",
+    "include \\\"qelib1.inc\\\";\n",
+    "qreg q[1];\n",
+    "creg c[1];\n",
+    "h q[0];\n",
+    "measure q[0] -> c[0];\n",
+    "reset q[0];\n",
+    "x q[0];\n",
+    "\"\"\"\n",
+    "mixed_circ = zx.Circuit.from_qasm(mixed_qasm)\n",
+    "print(mixed_circ)\n",
+    "print(mixed_circ.gates)\n",
+    "mixed_graph = mixed_circ.to_graph()\n",
+    "print(\"graph inputs:\", len(mixed_graph.inputs()))\n",
+    "print(\"graph outputs:\", len(mixed_graph.outputs()))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a leading reset, compare the default graph with the OpenQASM-style elided graph. The default keeps an explicit discard-and-prepare fragment so programmatically constructed circuits with unknown input states retain reset semantics. The elided form is appropriate when the input is already known to be the OpenQASM `|0>` state.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "leading_reset = zx.Circuit.from_qasm(\"\"\"\n",
+    "OPENQASM 2.0;\n",
+    "include \\\"qelib1.inc\\\";\n",
+    "qreg q[1];\n",
+    "reset q[0];\n",
+    "h q[0];\n",
+    "\"\"\")\n",
+    "keep_reset = leading_reset.to_graph(elide_initial_resets=False)\n",
+    "elide_reset = leading_reset.to_graph(elide_initial_resets=True)\n",
+    "print(\"vertices with explicit leading reset:\", keep_reset.num_vertices())\n",
+    "print(\"vertices with elided leading reset:\", elide_reset.num_vertices())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id=\"diagram-io\"></a>\n",
     "# Importing, exporting and editing diagrams\n",
     "PyZX also has its own json format for exporting graphs and interacts with [ZXLive](https://github.com/zxcalc/zxlive) to make manually modifying diagrams easy. First, let's see that we can indeed load diagrams:"

--- a/doc/representations.rst
+++ b/doc/representations.rst
@@ -25,6 +25,58 @@ PyZX also offers a convenience function to construct a circuit out of a string c
 
 To convert a Circuit into a PyZX Graph (i.e. a ZX-diagram), call the method :meth:`~pyzx.circuit.Circuit.to_graph`.
 
+Measurements, resets, and other mixed processes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PyZX circuits can also represent a useful subset of non-unitary
+OpenQASM instructions. Measurements are parsed as
+:class:`~pyzx.circuit.gates.Measurement` gates, and resets are parsed as
+:class:`~pyzx.circuit.gates.Reset` gates. When converted to a graph, these
+instructions are represented with additional classical or outcome wires rather
+than as ordinary unitary gates.
+
+For example::
+
+	circuit = zx.Circuit.from_qasm("""
+	OPENQASM 2.0;
+	include "qelib1.inc";
+	qreg q[1];
+	creg c[1];
+	h q[0];
+	measure q[0] -> c[0];
+	reset q[0];
+	x q[0];
+	""")
+	graph = circuit.to_graph()
+
+Measurements without post-selection keep the measurement outcome symbolic.
+Internally, PyZX uses boolean symbolic phases for these classical outcomes, so
+later graph manipulations can still keep track of branches of a mixed
+quantum-classical process. This is why graphs containing measurements or
+conditional operations may contain symbolic labels instead of only numeric
+phases.
+
+A reset is modelled as two operations: discard the current qubit state, then
+prepare a fresh ``|0>`` state. The discard outcome is represented by a fresh
+boolean variable named like ``_r0``. If that variable is not fixed to a concrete
+value, tensor extraction treats the graph as symbolic; substitute or
+post-select the variable before using tensor routines that require numeric
+phases.
+
+Leading resets need one extra convention. OpenQASM ``qreg`` declarations imply
+fresh ``|0>`` inputs, so an initial ``reset q[i];`` is redundant in that model.
+Programmatically constructed :class:`~pyzx.circuit.Circuit` objects, however,
+may have unknown input states. For that reason, :meth:`~pyzx.circuit.Circuit.to_graph`
+defaults to keeping the explicit discard-and-prepare fragment. If the inputs
+are known to be fresh ``|0>`` states, pass ``elide_initial_resets=True`` to
+skip those redundant leading reset fragments::
+
+	graph = circuit.to_graph(elide_initial_resets=True)
+
+This flag only applies to resets on otherwise unmodified input wires.
+Mid-circuit resets are still kept, because they discard state produced earlier
+in the computation.
+
 
 Importing and exporting ZX-diagrams
 -----------------------------------


### PR DESCRIPTION
## Summary
- add a documentation section for OpenQASM measurements, resets, symbolic outcome phases, and `elide_initial_resets`
- add an AllFeatures notebook example showing mixed measurement/reset import and the leading-reset elision option

Closes #455.

## Validation
- `.venv/bin/python -m unittest tests.test_qasm.TestQASM.test_reset_single_qubit tests.test_qasm.TestQASM.test_measure_reset_has_output tests.test_qasm.TestQASM.test_elide_initial_resets_toggle`
- `.venv/bin/python` smoke-tested the new notebook example snippets
- `python3 -m json.tool demos/AllFeatures.ipynb`
- `git diff --check`

Note: local validation ran on Python 3.14.5, which produced existing upstream `SyntaxWarning`s for invalid escape sequences in unrelated files.