### PR TITLE
Update mypy version to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,13 +38,13 @@ Documentation = "https://pyzx.readthedocs.io/"
 [project.optional-dependencies]
 dev = [
     "matplotlib>=2.2",
-    "mypy~=1.5.1",
+    "mypy~=2.1.0",
     "types-tqdm~=4.66",
 ]
 test = [
     "qiskit~=1.0.0",
     "qiskit_qasm3_import~=0.4.2",
-    "mypy~=1.5.1",
+    "mypy~=2.1.0",
 ]
 docs = [
     "matplotlib>=2.2",

--- a/pyzx/drawing.py
+++ b/pyzx/drawing.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from ipywidgets import Label
 
 def draw(g: Union[BaseGraph[VT,ET], Circuit], labels: bool=False, **kwargs) -> Any:
-    """Draws the given Circuit or Graph. 
+    """Draws the given Circuit or Graph.
     Depending on the value of ``pyzx.settings.drawing_backend``
     either uses matplotlib or d3 to draw."""
 
@@ -154,10 +154,10 @@ def arrange_scalar_diagram(g: BaseGraph[VT,ET]) -> None:
         g.set_qubit(w,0)
 
 def draw_matplotlib(
-        g:      Union[BaseGraph[VT,ET], Circuit], 
-        labels: bool                             =False, 
-        figsize:Tuple[FloatInt,FloatInt]         =(8,2), 
-        h_edge_draw: Literal['blue', 'box']      ='blue', 
+        g:      Union[BaseGraph[VT,ET], Circuit],
+        labels: bool                             =False,
+        figsize:Tuple[FloatInt,FloatInt]         =(8,2),
+        h_edge_draw: Literal['blue', 'box']      ='blue',
         show_scalar: bool                        =False,
         rows: Optional[Tuple[FloatInt,FloatInt]] =None
         ) -> Any: # TODO: Returns a matplotlib figure
@@ -392,8 +392,8 @@ def graph_json(g: BaseGraph[VT, ET],
 
 def draw_d3(
     g: Union[BaseGraph[VT,ET], Circuit],
-    labels:bool=False, 
-    scale:Optional[FloatInt]=None, 
+    labels:bool=False,
+    scale:Optional[FloatInt]=None,
     auto_hbox:Optional[bool]=None,
     show_scalar:bool=False,
     vdata: Optional[List[str]]=None,
@@ -402,7 +402,7 @@ def draw_d3(
     ) -> Any:
     """If auto_layout is checked, will automatically space vertices of graph
     with no regard to qubit/row."""
-    if get_mode() not in ("notebook", "browser"): 
+    if get_mode() not in ("notebook", "browser"):
         raise Exception("This method only works when loaded in a webpage or Jupyter notebook")
 
     if auto_hbox is None:
@@ -463,7 +463,7 @@ showGraph('#graph-output-{id}',
 </script>""".format(colors=json.dumps(settings.colors),
                     library_code=library_code,
                     id = graph_id,
-                    graph = graphj, 
+                    graph = graphj,
                     width=w, height=h, scale=scale, node_size=node_size,
                     hbox = 'true' if auto_hbox else 'false',
                     labels='true' if labels else 'false',
@@ -484,7 +484,7 @@ showGraph('#graph-output-{id}',
 
 def draw_3d(
     g: Union[BaseGraph[VT,ET], Circuit],
-    labels: bool=False, 
+    labels: bool=False,
     pauli_web: Optional[PauliWeb[VT,ET]]=None
     ) -> Any:
 
@@ -719,7 +719,7 @@ def matrix_to_latex(m: np.ndarray) -> str:
     denom = None
     for v in m.flat:
         if abs(v) > epsilon:
-            if best_val is None: 
+            if denom is None:
                 best_val = v
                 denom = Fraction(cmath.phase(v)/math.pi).limit_denominator(512).denominator
             else:

--- a/pyzx/extract.py
+++ b/pyzx/extract.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -30,7 +30,7 @@ from .circuit.gates import Gate, ParityPhase, CNOT, HAD, ZPhase, XPhase, CZ, XCX
 
 from .graph.base import BaseGraph, VT, ET
 
-from typing import List, Optional, Tuple, Dict, Set, Union, Iterator
+from typing import Generic, List, Optional, Tuple, Dict, Set, Union, Iterator
 
 
 def bi_adj(g: BaseGraph[VT,ET], vs:List[VT], ws:List[VT]) -> Mat2:
@@ -39,10 +39,10 @@ def bi_adj(g: BaseGraph[VT,ET], vs:List[VT], ws:List[VT]) -> Mat2:
     return Mat2([[1 if g.connected(v,w) else 0 for v in vs] for w in ws])
 
 def connectivity_from_biadj(
-        g: BaseGraph[VT,ET], 
-        m: Mat2, 
-        left:List[VT], 
-        right: List[VT], 
+        g: BaseGraph[VT,ET],
+        m: Mat2,
+        left:List[VT],
+        right: List[VT],
         edgetype:EdgeType=EdgeType.HADAMARD):
     """Replace the connectivity in ``g`` between the vertices in ``left`` and ``right``
     by the biadjacency matrix ``m``. The edges will be of type ``edgetype``."""
@@ -64,7 +64,7 @@ def streaming_extract(
     return extract_circuit(g, optimize_czs=optimize_czs, optimize_cnots=optimize_cnots, quiet=quiet)
 
 def permutation_as_swaps(perm:Dict[int,int]) -> List[Tuple[int,int]]:
-    """Returns a series of swaps that realises the given permutation. 
+    """Returns a series of swaps that realises the given permutation.
 
     Args:
         perm: A dictionary where both keys and values take values in 0,1,...,n."""
@@ -86,7 +86,7 @@ def permutation_as_swaps(perm:Dict[int,int]) -> List[Tuple[int,int]]:
 
 def column_optimal_swap(m: Mat2) -> Dict[int,int]:
     """Given a matrix m, tries to find a permutation of the columns such that
-    there are as many ones on the diagonal as possible. 
+    there are as many ones on the diagonal as possible.
     This reduces the number of row operations needed to do Gaussian elimination.
     """
     r, c = m.rows(), m.cols()
@@ -95,7 +95,7 @@ def column_optimal_swap(m: Mat2) -> Dict[int,int]:
 
     for i in range(r):
             for j in range(c):
-                if m.data[i][j]: 
+                if m.data[i][j]:
                     connections[i].add(j)
                     connectionsr[j].add(i)
 
@@ -202,7 +202,7 @@ def find_minimal_sums(m: Mat2, reversed_search=False) -> Optional[Tuple[int, ...
 
 def greedy_reduction(m: Mat2) -> Optional[List[Tuple[int, int]]]:
     """Returns a list of tuples (r1,r2) that specify which row should be added to which other row
-    in order to reduce one row of m to only contain a single 1. 
+    in order to reduce one row of m to only contain a single 1.
     Used in :func:`extract_circuit` and :func:`lookahead_extract_base`"""
     indicest = find_minimal_sums(m)
     if indicest is None: return indicest
@@ -354,7 +354,7 @@ def max_overlap(cz_matrix: Mat2) -> Tuple[Tuple[int,int],List[int]]:
     """Given an adjacency matrix of qubit connectivity of a CZ circuit, returns:
     a) the rows which have the maximum inner product
     b) the list of common qubits between these rows.
-    Used in :func:`extract_circuit` to more optimally place CZ gates. 
+    Used in :func:`extract_circuit` to more optimally place CZ gates.
     """
     N = len(cz_matrix.data[0])
 
@@ -832,7 +832,7 @@ def graph_to_swaps(g: BaseGraph[VT, ET], no_swaps: bool = False) -> Circuit:
 
     for q,v in enumerate(outputs): # check for a last layer of Hadamards, and see if swap gates need to be applied.
         inp = list(g.neighbors(v))[0]
-        if inp not in inputs: 
+        if inp not in inputs:
             raise TypeError("Algorithm failed: Graph is not fully reduced")
             return c
         if g.edge_type(g.edge(v,inp)) == EdgeType.HADAMARD:
@@ -910,7 +910,7 @@ def extract_clifford_normal_form(g: BaseGraph[VT,ET]) -> Circuit:
     return c
 
 
-class LookaheadNode:
+class LookaheadNode(Generic[VT, ET]):
     """
     A class for the lookahead extraction.
 

--- a/pyzx/hsimplify.py
+++ b/pyzx/hsimplify.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -148,10 +148,10 @@ had_edge_to_hbox_simp: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(check_h
 hbox_to_had_edge_simp: RewriteSimpSingleVertex = RewriteSimpSingleVertex(check_hadamard, unsafe_replace_hadamard)
 """Converts an h-box connecting the given vertices into a hadamard edge. Can be run automatically on the entire graph."""
 
-hbox_cancel_simp = RewriteSimpSingleVertex(check_hbox_cancel, unsafe_hbox_cancel)
+hbox_cancel_simp: RewriteSimpSingleVertex = RewriteSimpSingleVertex(check_hbox_cancel, unsafe_hbox_cancel)
 """Cancels H-boxes with phase 1 and arity 2 that have a Hadamard edge or an adjacent H-box. Can be run automatically on the entire graph."""
 
-just_hpivot_simp = RewriteSimpGraph(hpivot, simp_hpivot)
+just_hpivot_simp: RewriteSimpGraph = RewriteSimpGraph(hpivot, simp_hpivot)
 """Performs hyper-pivot rewrite. This should only be called through :func:`hpivot_simp`."""
 
 def hpivot_simp(g: BaseGraph[VT,ET]) -> bool:
@@ -177,7 +177,7 @@ def hpivot_simp(g: BaseGraph[VT,ET]) -> bool:
 
 def zh_simp(g: BaseGraph[VT,ET]) -> int:
     """Does a bunch of rewrites to simplify diagrams containing
-    arbitrary Z-spiders, X-spiders and H-boxes. 
+    arbitrary Z-spiders, X-spiders and H-boxes.
     Tries to do as many "non-complicating" rewrites before doing
     rewrites that can make a diagram look more complex."""
     count = 0

--- a/pyzx/scripts/circuit_router.py
+++ b/pyzx/scripts/circuit_router.py
@@ -898,7 +898,7 @@ def batch_map_cnot_circuits(
     dest_folder=None,
     metrics_file=None,
     n_compile=1,
-) -> Dict[Architecture, Dict[ElimMode, Any]]:
+) -> Dict[str, Dict[ElimMode, Any]]:
     modes = make_into_list(modes)
     architectures = make_into_list(architectures)
     populations = make_into_list(populations)
@@ -922,7 +922,7 @@ def batch_map_cnot_circuits(
         os.makedirs(dest_folder, exist_ok=True)
 
     arch_iter = []
-    circuits: Dict[Architecture, Dict[ElimMode, Any]] = {}
+    circuits: Dict[str, Dict[ElimMode, Any]] = {}
     metrics = []
     for architecture in architectures:
         if architecture in dynamic_size_architectures:


### PR DESCRIPTION
Since pyzx no longer supports Python 3.9, we can update the version of mypy dependency we use for type-checking from 1.5.1 to 2.1.0. This provides much improved performance and better type-checking logic.

The upgrade identified a few miscellaneous errors in the codebase, so this PR also fixes those so that tests pass.