### PR TITLE
Improve type annotations and fix type errors in `pyzx.circuit` submodule

### DIFF
--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -15,13 +15,12 @@
 # limitations under the License.
 
 import os
-from typing import List, Union, Optional, Iterator, Dict
+from typing import Union, Iterator
 
 import numpy as np
 
-from .gates import (Gate, gate_types, NOT, Y, Z, HAD, XPhase, YPhase, ZPhase, U2, U3, S, T, SX, SWAP, RXX, RZZ, CNOT,
-                    CY, CZ, CHAD, CSX, XCX, CRX, CRY, CRZ, CPhase, CU3, CU, CSWAP, Tofolli, CCZ, ParityPhase, FSim,
-                    Measurement, PhaseGadget, ConditionalGate)
+from .gates import (Gate, gate_types, HAD, XPhase, ZPhase, SWAP, CNOT,
+                    CZ, XCX, Tofolli, CCZ, Measurement, ConditionalGate)
 
 from ..graph.base import BaseGraph
 from ..utils import EdgeType
@@ -42,17 +41,17 @@ class Circuit(object):
     The methods in this class that convert a specification of a circuit into an instance of this class,
     generally do not check whether the specification is well-defined. If a bad input is given,
     the behaviour is undefined."""
-    def __init__(self, qubit_amount: int, name: str = '', bit_amount: Optional[int] = None) -> None:
+    def __init__(self, qubit_amount: int, name: str = '', bit_amount: int | None = None) -> None:
         self.qubits: int        = qubit_amount
         self.bits: int = 0 if bit_amount is None else bit_amount
-        self.gates:  List[Gate] = []
+        self.gates:  list[Gate] = []
         self.name:   str        = name
 
         # If the i-th entry is True, the i-th qubit is initialized to |0>, otherwise the qubit will not be initialized.
-        self._initialize_qubits: Optional[List[bool]] = None
+        self._initialize_qubits: list[bool] | None = None
 
         # If the i-th entry is 1 (0), the i-th measured qubit is postselected to |1> (|0>).
-        self._postselect_qubits: Optional[List[int]] = None
+        self._postselect_qubits: list[int] | None = None
 
     ### BASIC FUNCTIONALITY
 
@@ -75,7 +74,7 @@ class Circuit(object):
         return c
 
 
-    def initialize_qubits(self, initialize_qubits: List[bool]):
+    def initialize_qubits(self, initialize_qubits: list[bool]):
         """
         Args:
             initialize_qubits: A list of booleans of length equal to the number of qubits in the circuit.
@@ -85,7 +84,7 @@ class Circuit(object):
             raise ValueError("Length of initialize_qubits must be equal to the number of qubits in the circuit.")
         self._initialize_qubits = initialize_qubits
 
-    def postselect_qubits(self, postselect_qubits: List[int]):
+    def postselect_qubits(self, postselect_qubits: list[int]):
         """
         Args:
             postselect_qubits: A list of integers indicating for each measured qubits, whether it should be
@@ -163,7 +162,7 @@ class Circuit(object):
         for g in gates.split(" "):
             self.add_gate(g, qubit)
 
-    def add_circuit(self, circ: 'Circuit', mask: Optional[List[int]]=None, bit_mask: Optional[List[int]]=None) -> None:
+    def add_circuit(self, circ: 'Circuit', mask: list[int] | None = None, bit_mask: list[int] | None = None) -> None:
         """Adds the gate of another circuit to this one. If ``mask`` is not given,
         then they must have the same amount of qubits and they are mapped one-to-one.
         If mask is given then it must be a list specifying to which qubits the qubits
@@ -290,10 +289,10 @@ class Circuit(object):
 
     def to_graph(
         self,
-        zh:bool=False,
-        compress_rows:bool=True,
-        backend:Optional[str]=None,
-        elide_initial_resets:bool=False,
+        zh: bool = False,
+        compress_rows: bool = True,
+        backend: str | None = None,
+        elide_initial_resets: bool = False,
     ) -> BaseGraph:
         """Turns the circuit into a ZX-Graph.
         If ``compress_rows`` is set, it tries to put single qubit gates on different qubits,
@@ -454,7 +453,7 @@ class Circuit(object):
             s = """OPENQASM 2.0;\ninclude "qelib1.inc";\n"""
             s += "qreg q[{!s}];\n".format(self.qubits)
         # Collect classical register declarations from measurement and conditional gates.
-        cregs: Dict[str, int] = {}
+        cregs: dict[str, int] = {}
         for g in self.gates:
             if isinstance(g, Measurement):
                 if g.result_symbol is not None and '[' in g.result_symbol:
@@ -549,7 +548,7 @@ class Circuit(object):
                 measurement += 1
             else:
                 other += 1
-        d : Dict[str, Union[str,int]] = dict()
+        d: dict[str, str | int] = {}
         d["name"] = self.name
         d["qubits"] = self.qubits
         d["gates"] = total

--- a/pyzx/circuit/__init__.py
+++ b/pyzx/circuit/__init__.py
@@ -19,18 +19,25 @@ from typing import Union, Iterator
 
 import numpy as np
 
-from .gates import (Gate, gate_types, HAD, XPhase, ZPhase, SWAP, CNOT,
-                    CZ, XCX, Tofolli, CCZ, Measurement, ConditionalGate)
+from .gates import (Gate, gate_types, NOT, Y, Z, HAD, XPhase, YPhase, ZPhase, U2, U3, S, T, SX, SWAP, RXX, RZZ, CNOT,
+                    CY, CZ, CHAD, CSX, XCX, CRX, CRY, CRZ, CPhase, CU3, CU, CSWAP, Tofolli, CCZ, ParityPhase, FSim,
+                    Measurement, PhaseGadget, ConditionalGate)
 
 from ..graph.base import BaseGraph
 from ..utils import EdgeType
 
-CircuitLike = Union['Circuit', Gate]
+__all__ = [
+    'Gate', 'gate_types', 'NOT', 'Y', 'Z', 'HAD', 'XPhase', 'YPhase', 'ZPhase', 'U2', 'U3', 'S', 'T', 'SX', 'SWAP', 'RXX', 'RZZ', 'CNOT',
+    'CY', 'CZ', 'CHAD', 'CSX', 'XCX', 'CRX', 'CRY', 'CRZ', 'CPhase', 'CU3', 'CU', 'CSWAP', 'Tofolli', 'CCZ', 'ParityPhase', 'FSim',
+    'Measurement', 'PhaseGadget', 'ConditionalGate',
+    
+    'Circuit', 'CircuitLike', 'id'
+]
 
 # Note that many of the method of Circuit contain inline imports. These are
 # there to prevent circular imports.
 
-__all__ = ['Circuit', 'id']
+CircuitLike = Union['Circuit', Gate]
 
 class Circuit(object):
     """Class for representing quantum circuits.

--- a/pyzx/circuit/emojiparser.py
+++ b/pyzx/circuit/emojiparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,32 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from . import Circuit
 
-def circuit_to_emoji(c: Circuit, compress_rows:bool=True) -> str:
+def circuit_to_emoji(c: Circuit, compress_rows: bool = True) -> str:
     """Turns the circuit into a ZX-Graph.
     If ``compress_rows`` is set, it tries to put single qubit gates on different qubits,
     on the same row."""
-    strings: List[List[str]] = [list() for _ in range(c.qubits)]
+    strings: list[list[str]] = [list() for _ in range(c.qubits)]
     #for i in range(c.qubits):
     #    strings[i].append(':Wire_lr:')
 
     for gate in c.gates:
         if not compress_rows:
             r = max([len(s) for s in strings])
-            for s in strings: 
+            for s in strings:
                 s.extend([':W_:']*(r-len(s)))
-        if not hasattr(gate, "to_emoji"): raise TypeError("Gate {} cannot be converted to emoji".format(str(gate)))
         gate.to_emoji(strings)
         if not compress_rows:
             r = max([len(s) for s in strings])
-            for s in strings: 
+            for s in strings:
                 s.extend([':W_:']*(r-len(s)))
 
     r = max([len(s) for s in strings])
-    for s in strings: 
+    for s in strings:
         s.extend([':W_:']*(r-len(s)))
 
     return "\n".join(["".join(s) for s in strings])

--- a/pyzx/circuit/gates.py
+++ b/pyzx/circuit/gates.py
@@ -22,11 +22,14 @@ quantum gates for use in the Circuit class.
 import copy
 import math
 from fractions import Fraction
-from typing import Dict, List, Optional, Type, ClassVar, TypeVar, Generic, Set
+from typing import TYPE_CHECKING, ClassVar, TypeVar, Generic
 
-from ..utils import EdgeType, VertexType, FractionLike, settings
+from ..utils import EdgeType, VertexType, FractionLike, half_phase, settings
 from ..graph.base import BaseGraph, VT, ET
-from ..symbolic import new_var
+from ..symbolic import new_const, new_var, Poly
+
+if TYPE_CHECKING:
+    from . import Circuit
 
 # We need this type variable so that the subclasses of Gate return the correct type for functions like copy()
 Tvar = TypeVar('Tvar', bound='Gate')
@@ -36,10 +39,10 @@ class TargetMapper(Generic[VT]):
     This class is used to map the target parameters of a gate to rows, qubits, and vertices
     when converting them into a graph. Used by :func:`~pyzx.circuit.gates.Gate.to_graph`.
     """
-    _qubits: Dict[int, int]
-    _rows: Dict[int, int]
-    _prev_vs: Dict[int, VT]
-    _labels: Set[int]
+    _qubits: dict[int, int]
+    _rows: dict[int, int]
+    _prev_vs: dict[int, VT]
+    _labels: set[int]
     _max_row: int
 
     def __init__(self):
@@ -49,7 +52,7 @@ class TargetMapper(Generic[VT]):
         self._labels = set()
         self._max_row = 0
 
-    def labels(self) -> Set[int]:
+    def labels(self) -> set[int]:
         """
         Returns the mapped labels.
         """
@@ -169,7 +172,7 @@ class TargetMapper(Generic[VT]):
 
         self._labels.remove(l)
 
-class Gate(object):
+class Gate:
     """Base class for representing quantum gates."""
     name:               ClassVar[str] = "BaseGate"
     qasm_name:          ClassVar[str] = 'undefined'
@@ -180,16 +183,16 @@ class Gate(object):
     index = 0
     def __str__(self) -> str:
         attribs = []
-        if hasattr(self, "control"): attribs.append(str(self.control))
-        if hasattr(self, "target"): attribs.append(str(self.target))
+        if hasattr(self, "control"): attribs.append(str(getattr(self, "control")))
+        if hasattr(self, "target"): attribs.append(str(getattr(self, "target")))
         if self.print_phase:
             if hasattr(self, "phase"):
-                attribs.append("phase={!s}".format(self.phase))
+                attribs.append("phase={!s}".format(getattr(self, "phase")))
             elif hasattr(self, "phases"):
-                attribs.append("phases={}".format(",".join(str(p) for p in self.phases)))
+                attribs.append("phases={}".format(",".join(str(p) for p in getattr(self, "phases"))))
         return "{}{}({})".format(
                         self.name,
-                        ("*" if (hasattr(self,"adjoint") and self.adjoint) else ""),
+                        ("*" if getattr(self, "adjoint", None) else ""),
                         ",".join(attribs))
 
     def __repr__(self) -> str:
@@ -207,19 +210,19 @@ class Gate(object):
         return True
 
     def _max_target(self) -> int:
-        qubits = self.target        # type: ignore # due to ParityPhase
+        qubits = getattr(self, "target")
         if hasattr(self, "control"):
-            qubits = max([qubits, self.control])
+            qubits = max([qubits, getattr(self, "control")])
         return qubits
 
-    def __add__(self, other):
+    def __add__(self: Tvar, other: Tvar) -> 'Circuit':
         from . import Circuit
         c = Circuit(self._max_target()+1)
         c.add_gate(self)
         c += other
         return c
 
-    def __matmul__(self,other):
+    def __matmul__(self: Tvar, other: Tvar) -> 'Circuit':
         from . import Circuit
         c = Circuit(self._max_target()+1)
         c.add_gate(self)
@@ -233,23 +236,23 @@ class Gate(object):
     def to_adjoint(self: Tvar) -> Tvar:
         g = self.copy()
         if hasattr(g, "phase"):
-            g.phase = -g.phase
+            setattr(g, "phase", -getattr(g, "phase"))
         if hasattr(g, "adjoint"):
-            g.adjoint = not g.adjoint
+            setattr(g, "adjoint", not getattr(g, "adjoint"))
         return g
 
     def tcount(self) -> int:
         return 0
 
-    def reposition(self: Tvar, mask: List[int], bit_mask: Optional[List[int]] = None) -> Tvar:
+    def reposition(self: Tvar, mask: list[int], bit_mask: list[int] | None = None) -> Tvar:
         g = self.copy()
         if hasattr(g, "target"):
-            g.target = mask[g.target]
+            setattr(g, "target", mask[getattr(g, "target")])
         if hasattr(g, "control"):
-            g.control = mask[g.control]
+            setattr(g, "control", mask[getattr(g, "control")])
         return g
 
-    def to_basic_gates(self) -> List['Gate']:
+    def to_basic_gates(self) -> list['Gate']:
         return [self]
 
     def to_quipper(self) -> str:
@@ -260,10 +263,10 @@ class Gate(object):
                 raise TypeError("Gate {} doesn't have a Quipper description".format(str(self)))
             return "\n".join(g.to_quipper() for g in bg)
         s = 'QGate["{}"]{}({!s})'.format(n,
-                                         ("*" if (hasattr(self,"adjoint") and self.adjoint) else ""),
-                                         self.target) # type: ignore # due to ParityPhase
+                                         ("*" if getattr(self, "adjoint", None) else ""),
+                                         getattr(self, "target"))
         if hasattr(self, "control"):
-            s += ' with controls=[+{!s}]'.format(self.control)
+            s += ' with controls=[+{!s}]'.format(getattr(self, "control"))
         s += ' with nocontrol'
         return s
 
@@ -274,7 +277,7 @@ class Gate(object):
             if len(bg) == 1:
                 raise TypeError("Gate {} doesn't have a QASM description".format(str(self)))
             return "\n".join(g.to_qasm() for g in bg)
-        if hasattr(self, "adjoint") and self.adjoint:
+        if getattr(self, "adjoint", None):
             n = self.qasm_name_adjoint
 
         args = []
@@ -284,17 +287,17 @@ class Gate(object):
         if self.print_phase:
             if hasattr(self, "phase"):
                 try:
-                    param = "({}*pi)".format(float(self.phase))
+                    param = "({}*pi)".format(float(getattr(self, "phase")))
                 except (TypeError, ValueError):
                     # Symbolic (Poly) phase — emit as-is.
-                    param = "({}*pi)".format(self.phase)
+                    param = "({}*pi)".format(getattr(self, "phase"))
             elif hasattr(self, "phases"):
-                param = "({})".format(",".join("{}*pi".format(float(p)) for p in self.phases))
+                param = "({})".format(",".join("{}*pi".format(float(p)) for p in getattr(self, "phases")))
         return "{}{} {};".format(n, param, ", ".join(args))
 
     def to_qc(self) -> str:
         n = self.qc_name
-        if hasattr(self, "adjoint") and self.adjoint:
+        if getattr(self, "adjoint", None):
             n += "*"
         if n == 'undefined':
             if isinstance(self, (ZPhase, XPhase)):
@@ -314,7 +317,7 @@ class Gate(object):
         #     args.insert(0, phase_to_s(self.phase))
         return "{} {}".format(n, " ".join(args))
 
-    def to_graph(self, g: BaseGraph[VT,ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         """
         Add the converted gate to the graph.
 
@@ -325,7 +328,7 @@ class Gate(object):
         raise NotImplementedError("to_graph() must be implemented by each Gate subclass.")
 
     def graph_add_node(self,
-                g: BaseGraph[VT,ET],
+                g: BaseGraph[VT, ET],
                 mapper: TargetMapper[VT],
                 t: VertexType,
                 l: int, r: int,
@@ -336,6 +339,10 @@ class Gate(object):
         g.add_edge((mapper.prev_vertex(l), v), etype)
         mapper.set_prev_vertex(l, v)
         return v
+    
+    def to_emoji(self, strings: list[list[str]]) -> None:
+        raise NotImplementedError(f"Gate {self} cannot be converted to emoji")
+
 
 class ZPhase(Gate):
     name = 'ZPhase'
@@ -346,7 +353,7 @@ class ZPhase(Gate):
         self.target = target
         self.phase = phase
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         self.graph_add_node(g,q_mapper, VertexType.Z, self.target, q_mapper.next_row(self.target), self.phase)
         q_mapper.advance_next_row(self.target)
 
@@ -355,7 +362,7 @@ class ZPhase(Gate):
             return super().to_quipper()
         return 'QRot["exp(-i%Z)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
 
-    def to_emoji(self,strings: List[List[str]]) -> None:
+    def to_emoji(self, strings: list[list[str]]) -> None:
         s = ''
         phase = self.phase % 2
         if phase == Fraction(1,2): s = ':Zp4:'
@@ -371,7 +378,7 @@ class ZPhase(Gate):
     def tcount(self):
         return 1 if self.phase.denominator > 2 else 0
 
-    def split_phases(self) -> List['ZPhase']:
+    def split_phases(self) -> list['ZPhase']:
         if not self.phase: return []
         if self.phase == 1: return [Z(self.target)]
         if self.phase.denominator == 2:
@@ -379,7 +386,7 @@ class ZPhase(Gate):
                 return [S(self.target)]
             else: return [S(self.target, adjoint=True)]
         elif self.phase.denominator == 4:
-            gates: List['ZPhase'] = []
+            gates: list['ZPhase'] = []
             n = self.phase.numerator % 8
             if n == 3 or n == 5:
                 gates.append(Z(self.target))
@@ -431,11 +438,11 @@ class XPhase(Gate):
         self.target = target
         self.phase = phase
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         self.graph_add_node(g, q_mapper, VertexType.X, self.target, q_mapper.next_row(self.target), self.phase)
         q_mapper.advance_next_row(self.target)
 
-    def to_emoji(self,strings: List[List[str]]) -> None:
+    def to_emoji(self, strings: list[list[str]]) -> None:
         s = ''
         phase = self.phase % 2
         if phase == Fraction(1,2): s = ':Xp4:'
@@ -453,7 +460,7 @@ class XPhase(Gate):
             return super().to_quipper()
         return 'QRot["exp(-i%X)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
 
-    def to_basic_gates(self) -> List['Gate']:
+    def to_basic_gates(self) -> list[Gate]:
         # Handle symbolic (Poly) phases - return self unchanged.
         if not isinstance(self.phase, (int, float, Fraction)):
             return [self]
@@ -481,10 +488,10 @@ class XPhase(Gate):
     def tcount(self):
         return 1 if self.phase.denominator > 2 else 0
 
-    def split_phases(self) -> List[Gate]:
+    def split_phases(self) -> list[Gate]:
         if not self.phase: return []
         if self.phase == 1: return [NOT(self.target)]
-        gates: List[Gate] = [HAD(self.target)]
+        gates: list[Gate] = [HAD(self.target)]
         if self.phase.denominator == 2:
             if self.phase.numerator % 4 == 1:
                 gates.append(S(self.target))
@@ -517,12 +524,12 @@ class CSX(Gate):
         self.target = target
         self.control = control
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [HAD(self.target)] + \
                CPhase(self.control,self.target,Fraction(1,2)).to_basic_gates() + \
                [HAD(self.target)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -531,7 +538,7 @@ class YPhase(Gate):
     qasm_name = 'ry'
     quipper_name = 'YPhase'
     print_phase = True
-    def __init__(self, target: int, phase: FractionLike=0) -> None:
+    def __init__(self, target: int, phase: FractionLike = 0) -> None:
         self.target = target
         self.phase = phase
 
@@ -545,7 +552,7 @@ class YPhase(Gate):
     def __str__(self) -> str:
         return 'QRot["exp(-i%Y)",{!s}]({!s})'.format(math.pi*self.phase/2,self.target)
 
-    def to_basic_gates(self) -> List['Gate']:
+    def to_basic_gates(self) -> list[Gate]:
         # Handle symbolic (Poly) phases - use original decomposition.
         if not isinstance(self.phase, (int, float, Fraction)):
             return [ZPhase(self.target, Fraction(1,2)), XPhase(self.target, -self.phase), ZPhase(self.target, -Fraction(1,2))]
@@ -557,7 +564,7 @@ class YPhase(Gate):
             x_phase = Fraction(-self.phase)
         x_phase = x_phase % 2
 
-        gates: List['Gate'] = [ZPhase(self.target, Fraction(1,2))]
+        gates: list[Gate] = [ZPhase(self.target, Fraction(1,2))]
         if x_phase == 0:
             pass  # Identity - skip the XPhase gate.
         elif x_phase == 1:
@@ -567,7 +574,7 @@ class YPhase(Gate):
         gates.append(ZPhase(self.target, -Fraction(1,2)))
         return gates
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -590,12 +597,12 @@ class CY(Gate):
         self.target = target
         self.control = control
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [S(self.target,adjoint=True),
                 CNOT(self.control,self.target),
                 S(self.target)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -608,7 +615,7 @@ class NOT(XPhase):
     def __init__(self, target: int) -> None:
         super().__init__(target, phase = Fraction(1,1))
 
-    def to_basic_gates(self) -> List['Gate']:
+    def to_basic_gates(self) -> list[Gate]:
         return [self]
 
 class HAD(Gate):
@@ -619,13 +626,13 @@ class HAD(Gate):
     def __init__(self, target: int) -> None:
         self.target = target
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         v = g.add_vertex(VertexType.Z, q_mapper.to_qubit(self.target), q_mapper.next_row(self.target))
         g.add_edge((q_mapper.prev_vertex(self.target),v), EdgeType.HADAMARD)
         q_mapper.set_prev_vertex(self.target, v)
         q_mapper.advance_next_row(self.target)
 
-    def to_emoji(self,strings: List[List[str]]) -> None:
+    def to_emoji(self, strings: list[list[str]]) -> None:
         strings[self.target].append(':H_:')
 
 class CNOT(Gate):
@@ -636,7 +643,7 @@ class CNOT(Gate):
     def __init__(self, control: int, target: int) -> None:
         self.target = target
         self.control = control
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         [top, bot] = sorted([self.target, self.control])
         r = max(q_mapper.next_row(r_) for r_ in range(top, bot + 1))
         t = self.graph_add_node(g, q_mapper, VertexType.X, self.target, r)
@@ -646,7 +653,7 @@ class CNOT(Gate):
           q_mapper.set_next_row(r_, r+1)
         g.scalar.add_power(1)
 
-    def to_emoji(self,strings: List[List[str]]) -> None:
+    def to_emoji(self, strings: list[list[str]]) -> None:
         c,t = self.control, self.target
         mi = min([c,t])
         ma = max([c,t])
@@ -679,7 +686,7 @@ class CZ(Gate):
             return True
         return False
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         r = max(q_mapper.next_row(self.target), q_mapper.next_row(self.control))
         t = self.graph_add_node(g, q_mapper, VertexType.Z, self.target, r)
         c = self.graph_add_node(g, q_mapper, VertexType.Z, self.control, r)
@@ -688,7 +695,7 @@ class CZ(Gate):
         q_mapper.set_next_row(self.control, r+1)
         g.scalar.add_power(1)
 
-    def to_emoji(self,strings: List[List[str]]) -> None:
+    def to_emoji(self, strings: list[list[str]]) -> None:
         c,t = self.control, self.target
         strings[t].append(':H_:')
         CNOT(c,t).to_emoji(strings)
@@ -701,7 +708,7 @@ class XCX(CZ):
     qasm_name = 'undefined'
     qc_name = 'undefined'
     quipper_name = 'X'
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         r = max(q_mapper.next_row(self.target), q_mapper.next_row(self.control))
         t = self.graph_add_node(g, q_mapper, VertexType.X, self.target, r)
         c = self.graph_add_node(g, q_mapper, VertexType.X, self.control, r)
@@ -710,7 +717,7 @@ class XCX(CZ):
         q_mapper.set_next_row(self.control, r+1)
         g.scalar.add_power(1)
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [HAD(self.control), CNOT(self.control,self.target), HAD(self.control)]
 
 class SWAP(CZ):
@@ -718,12 +725,12 @@ class SWAP(CZ):
     qasm_name = 'swap'
     qc_name = 'undefined'
     quipper_name = 'undefined'
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         c1 = CNOT(self.control, self.target)
         c2 = CNOT(self.target, self.control)
         return [c1,c2,c1]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -736,12 +743,13 @@ class CRX(Gate):
         self.control = control
         self.phase = phase
 
-    def to_basic_gates(self):
-        return [ZPhase(self.target,Fraction(1,2)),
-                CNOT(self.control,self.target)] + \
-               U3(self.target,-self.phase/2,0,0).to_basic_gates() + \
-               [CNOT(self.control,self.target)] + \
-               U3(self.target,self.phase/2,Fraction(-1,2),0).to_basic_gates()
+    def to_basic_gates(self) -> list[Gate]:
+        phase = half_phase(self.phase)
+        return [ZPhase(self.target, Fraction(1,2)),
+                CNOT(self.control, self.target)] + \
+               U3(self.target, -phase, 0, 0).to_basic_gates() + \
+               [CNOT(self.control, self.target)] + \
+               U3(self.target, phase, Fraction(-1,2), 0).to_basic_gates()
 
     def to_graph(self, g, q_mapper, c_mapper):
         for gate in self.to_basic_gates():
@@ -756,11 +764,12 @@ class CRY(Gate):
         self.control = control
         self.phase = phase
 
-    def to_basic_gates(self):
-        return YPhase(self.target,self.phase/2).to_basic_gates() + \
-               [CNOT(self.control,self.target)] + \
-               YPhase(self.target,-self.phase/2).to_basic_gates() + \
-               [CNOT(self.control,self.target)]
+    def to_basic_gates(self) -> list[Gate]:
+        half_phase = self.phase // 2 if isinstance(self.phase, int) else self.phase / 2
+        return YPhase(self.target, half_phase).to_basic_gates() + \
+               [CNOT(self.control, self.target)] + \
+               YPhase(self.target, -half_phase).to_basic_gates() + \
+               [CNOT(self.control, self.target)]
 
     def to_graph(self, g, q_mapper, c_mapper):
         for gate in self.to_basic_gates():
@@ -775,17 +784,11 @@ class CRZ(Gate):
         self.control = control
         self.phase = phase
 
-    def to_basic_gates(self):
-        phase1 = self.phase / 2
-        phase2 = -self.phase / 2
-        try:
-            phase1 = Fraction(phase1) % 2
-            phase2 = Fraction(phase2) % 2
-        except Exception:
-            pass
-        return [ZPhase(self.target, phase1),
+    def to_basic_gates(self) -> list[Gate]:
+        phase = half_phase(self.phase)
+        return [ZPhase(self.target, phase),
                 CNOT(self.control, self.target),
-                ZPhase(self.target, phase2),
+                ZPhase(self.target, -phase),
                 CNOT(self.control, self.target)]
 
     def to_graph(self, g, q_mapper, c_mapper):
@@ -801,7 +804,7 @@ class RXX(Gate):
         self.control = control
         self.phase = phase
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return U3(self.control,Fraction(1,2),self.phase,0).to_basic_gates() + \
                [HAD(self.target),
                 CNOT(self.control,self.target),
@@ -818,19 +821,13 @@ class CPhase(CRZ):
     name = 'CPhase'
     qasm_name = 'cp'
 
-    def to_basic_gates(self):
-        phase1 = self.phase / 2
-        phase2 = -self.phase / 2
-        try:
-            phase1 = Fraction(phase1) % 2
-            phase2 = Fraction(phase2) % 2
-        except Exception:
-            pass
-        return [ZPhase(self.control, phase1),
+    def to_basic_gates(self) -> list[Gate]:
+        phase = half_phase(self.phase)
+        return [ZPhase(self.control, phase),
                 CNOT(self.control, self.target),
-                ZPhase(self.target, phase2),
+                ZPhase(self.target, -phase),
                 CNOT(self.control, self.target),
-                ZPhase(self.target, phase1)]
+                ZPhase(self.target, phase)]
 
 class CHAD(Gate):
     name = 'CHAD'
@@ -841,7 +838,7 @@ class CHAD(Gate):
         self.target = target
         self.control = control
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         return [HAD(self.target),S(self.target,adjoint=True),
                 CNOT(self.control,self.target),
                 HAD(self.target),T(self.target),
@@ -885,14 +882,14 @@ class ParityPhase(Gate):
         g.targets = [mask[t] for t in g.targets]
         return g
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         if self.as_gadget:
             # Keep as-is so to_graph() can create the phase gadget structure.
             return [self]
-        cnots = [CNOT(self.targets[i],self.targets[i+1]) for i in range(len(self.targets)-1)]
+        cnots: list[Gate] = [CNOT(self.targets[i],self.targets[i+1]) for i in range(len(self.targets)-1)]
         p = ZPhase(self.targets[-1], self.phase)
         return cnots + [p] + list(reversed(cnots))
-
+    
     def to_graph(self, g, q_mapper, c_mapper):
         if self.as_gadget:
             # Create phase gadget structure directly in the graph.
@@ -961,13 +958,13 @@ class FSim(Gate):
         g.target = mask[self.target]
         return g
 
-    def to_basic_gates(self):
+    def to_basic_gates(self) -> list[Gate]:
         # TODO
         #cnots = [CNOT(self.targets[i],self.targets[i+1]) for i in range(len(self.targets)-1)]
         #p = ZPhase(self.targets[-1], self.phase)
         return [self]
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         # TODO: this version assumes theta is always (pi/2)
         r = max(q_mapper.next_row(self.target), q_mapper.next_row(self.control))
         qmin = min(self.target,self.control)
@@ -1086,7 +1083,7 @@ class CCZ(Gate):
                 CNOT(c1,t), T(c2), T(t), CNOT(c1,c2),T(c1),
                 T(c2,adjoint=True),CNOT(c1,c2)]
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         # if basic_gates:
         #     for gate in self.to_basic_gates():
         #         gate.to_graph(g, q_mapper, c_mapper)
@@ -1131,7 +1128,7 @@ class Tofolli(CCZ):
                 CNOT(c1,t), T(c2), T(t), CNOT(c1,c2),T(c1),
                 T(c2,adjoint=True),CNOT(c1,c2), HAD(t)]
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         t = self.target
         HAD(t).to_graph(g, q_mapper, c_mapper)
         CCZ.to_graph(self, g, q_mapper, c_mapper)
@@ -1213,15 +1210,15 @@ class CU3(Gate):
         self.rho = rho
         self.phases = [theta, phi, rho]
 
-    def to_basic_gates(self):
-        return [ZPhase(self.control,phase=(self.rho+self.phi)/2),
-                ZPhase(self.target, phase=(self.rho-self.phi)/2),
-                CNOT(self.control,self.target)] + \
-               U3(self.target,-self.theta/2,0,-(self.phi+self.rho)/2).to_basic_gates() + \
+    def to_basic_gates(self) -> list[Gate]:
+        return [ZPhase(self.control, phase=half_phase(self.rho + self.phi)),
+                ZPhase(self.target, phase=half_phase(self.rho - self.phi)),
+                CNOT(self.control, self.target)] + \
+               U3(self.target, -half_phase(self.theta), 0, -half_phase(self.phi + self.rho)).to_basic_gates() + \
                [CNOT(self.control, self.target)] + \
-               U3(self.target,self.theta/2,self.phi,0).to_basic_gates()
+               U3(self.target, half_phase(self.theta), self.phi, 0).to_basic_gates()
 
-    def to_graph(self, g, q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         for gate in self.to_basic_gates():
             gate.to_graph(g, q_mapper, c_mapper)
 
@@ -1401,17 +1398,24 @@ class ConditionalGate(Gate):
     name = 'ConditionalGate'
 
     def __init__(self, condition_register: str, condition_value: int,
-                 inner_gate: 'Gate', register_size: int) -> None:
+                 inner_gate: 'Gate', register_size: int):
         if condition_value < 0 or condition_value >= (1 << register_size):
             raise ValueError(
                 "Condition value {} is out of range for a {}-bit register "
                 "(must be 0..{})".format(
                     condition_value, register_size, (1 << register_size) - 1))
+        
+        target = getattr(inner_gate, "target", None)
+        if not isinstance(target, int):
+            raise ValueError(
+                f"Expected a single-qubit Z or X rotation, got {inner_gate}."
+            )
+        
         self.condition_register = condition_register
         self.condition_value = condition_value
         self.inner_gate = inner_gate
         self.register_size = register_size
-        self.target = inner_gate.target  # type: ignore
+        self.target = target
 
     def __str__(self) -> str:
         return "if({}=={}) {}".format(
@@ -1433,10 +1437,10 @@ class ConditionalGate(Gate):
             self.condition_register, self.condition_value,
             self.inner_gate.copy(), self.register_size)
 
-    def reposition(self, mask, bit_mask=None):
+    def reposition(self, mask, bit_mask = None):
         g = self.copy()
         g.inner_gate = g.inner_gate.reposition(mask, bit_mask)
-        g.target = g.inner_gate.target  # type: ignore
+        g.target = getattr(g.inner_gate, "target")
         return g
 
     def to_qasm(self) -> str:
@@ -1444,17 +1448,16 @@ class ConditionalGate(Gate):
         return "if({}=={}) {}".format(
             self.condition_register, self.condition_value, inner_qasm)
 
-    def _build_condition_poly(self, g: BaseGraph[VT, ET]) -> 'Poly':  # type: ignore[name-defined]
+    def _build_condition_poly(self, g: BaseGraph[VT, ET]) -> Poly:
         """Build a boolean polynomial representing the register condition.
 
         For ``if (reg == val)`` with an *n*-bit register, the condition is
         the product over all bits *i* of either ``bit_var_i`` (when bit *i*
         of *val* is 1) or ``(1 - bit_var_i)`` (when bit *i* is 0).
         """
-        from ..symbolic import Poly, new_var as sym_new_var, new_const
         result: Poly = new_const(1)
         for i in range(self.register_size):
-            bit_var = sym_new_var(
+            bit_var = new_var(
                 "{}[{}]".format(self.condition_register, i),
                 is_bool=True, registry=g.var_registry)
             if (self.condition_value >> i) & 1:
@@ -1489,15 +1492,15 @@ class ConditionalGate(Gate):
 
 class DiscardBit(Gate):
     name = 'DiscardBit'
-    def __init__(self, target):
+    def __init__(self, target: int):
         self.target = target
 
-    def reposition(self, _mask, bit_mask = None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'DiscardBit':
         g = self.copy()
-        g.target = bit_mask[g.target]
+        g.target = bit_mask[g.target] if bit_mask else g.target
         return g
 
-    def to_graph(self, g, _q_mapper, c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         r = c_mapper.next_row(self.target)
         self.graph_add_node(g,
             c_mapper,
@@ -1511,7 +1514,7 @@ class DiscardBit(Gate):
 
 class Measurement(Gate):
     target: int
-    result_bit: Optional[int]
+    result_bit: int | None
 
     name = 'Measurement'
     quipper_name = 'measure'
@@ -1523,8 +1526,8 @@ class Measurement(Gate):
     def __init__(
         self,
         target: int,
-        result_bit: Optional[int] = None,
-        result_symbol: Optional[str] = None
+        result_bit: int | None = None,
+        result_symbol: str | None = None
     ) -> None:
         self.target = target
         self.result_bit = result_bit
@@ -1550,7 +1553,7 @@ class Measurement(Gate):
         raise TypeError("Measurement on qubit {} has no result destination".format(
             self.target))
 
-    def reposition(self, mask, bit_mask = None):
+    def reposition(self, mask: list[int], bit_mask: list[int] | None = None) -> 'Measurement':
         g = self.copy()
         g.target = mask[self.target]
         if self.result_bit is not None and bit_mask is not None:
@@ -1590,10 +1593,10 @@ class Measurement(Gate):
         g.set_vdata(outcome_v, 'result_symbol', symbol_name)
         q_mapper.set_next_row(self.target, r + 1)
 
-    def to_graph(self, g, q_mapper, _c_mapper):
+    def to_graph(self, g: BaseGraph[VT, ET], q_mapper: TargetMapper[VT], c_mapper: TargetMapper[VT]) -> None:
         self.to_graph_symbolic_boolean(g, q_mapper)
 
-gate_types: Dict[str,Type[Gate]] = {
+gate_types: dict[str, type[Gate]] = {
     "XPhase": XPhase,
     "NOT": NOT,
     "SX": SX,
@@ -1638,7 +1641,7 @@ gate_types: Dict[str,Type[Gate]] = {
     "ConditionalGate": ConditionalGate,
 }
 
-qasm_gate_table: Dict[str, Type[Gate]] = {
+qasm_gate_table: dict[str, type[Gate]] = {
     "x": NOT,
     "y": Y,
     "z": Z,

--- a/pyzx/circuit/graphparser.py
+++ b/pyzx/circuit/graphparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -15,10 +15,9 @@
 # limitations under the License.
 
 import warnings
-from typing import Dict, List, Optional, Union
 
 from . import Circuit
-from .gates import (Gate, InitAncilla, Measurement, Reset, TargetMapper,
+from .gates import (Gate, InitAncilla, Measurement, PostSelect, Reset, TargetMapper,
                      ConditionalGate, ZPhase, XPhase, NOT, Z, S, T, SX)
 from ..utils import EdgeType, VertexType, FloatInt, FractionLike, settings
 from ..graph import Graph
@@ -27,7 +26,7 @@ from ..symbolic import Poly, new_var
 
 def _poly_phase_to_conditional_gate(
     phase: Poly, vertex_type: VertexType, qubit: int
-) -> Optional[ConditionalGate]:
+) -> ConditionalGate | None:
     """Try to convert a symbolic Poly phase into a ConditionalGate.
 
     The polynomial must consist entirely of boolean variables from the
@@ -49,8 +48,8 @@ def _poly_phase_to_conditional_gate(
     import re
     # Collect all boolean variables across all terms.
     bit_pattern = re.compile(r'^(\w+)\[(\d+)\]$')
-    reg_name: Optional[str] = None
-    bit_vars: Dict[int, Var] = {}
+    reg_name: str | None = None
+    bit_vars: dict[int, Var] = {}
     for _coeff, term in phase.terms:
         for var, _exp in term.vars:
             if not var.is_bool:
@@ -75,10 +74,10 @@ def _poly_phase_to_conditional_gate(
             "Conditional gate extraction is O(2^n) in register size; "
             "register '{}' has {} bits ({} evaluations).".format(
                 reg_name, reg_size, 1 << reg_size))
-    cond_value: Optional[int] = None
-    inner_phase_value: Optional[Fraction] = None
+    cond_value: int | None = None
+    inner_phase_value: Fraction | None = None
     for val in range(1 << reg_size):
-        var_map: Dict[Var, Fraction] = {}
+        var_map: dict[Var, Fraction] = {}
         for idx, var in bit_vars.items():
             var_map[var] = Fraction((val >> idx) & 1)
         result = phase.substitute(var_map)
@@ -136,9 +135,9 @@ def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
     rs = g.rows()
     ty = g.types()
     phases = g.phases()
-    rows: Dict[FloatInt,List[VT]] = {}
+    rows: dict[FloatInt, list[VT]] = {}
     # Map (vertex_type, phase) → InitAncilla state string.
-    _reverse_state_map: Dict[tuple, str] = {
+    _reverse_state_map: dict[tuple, str] = {
         (VertexType.Z, 0): '+',
         (VertexType.Z, 1): '-',
         (VertexType.X, 0): '0',
@@ -272,12 +271,12 @@ def graph_to_circuit(g:BaseGraph[VT,ET], split_phases:bool=True) -> Circuit:
 
 def circuit_to_graph(
     c: Circuit,
-    compress_rows:bool=True,
-    backend:Optional[str]=None,
-    initialize_qubits:Optional[List[bool]]=None,
-    postselect_qubits:Optional[List[int]]=None,
-    elide_initial_resets:bool=False,
-) -> BaseGraph[VT, ET]:
+    compress_rows:bool = True,
+    backend: str | None =None,
+    initialize_qubits: list[bool] | None = None,
+    postselect_qubits: list[int] | None = None,
+    elide_initial_resets: bool = False,
+) -> BaseGraph:
     """Turns the circuit into a ZX-Graph.
     If ``compress_rows`` is set, it tries to put single qubit gates on different qubits,
     on the same row.
@@ -302,8 +301,8 @@ def circuit_to_graph(
     measurement-and-discard fragment plus a separate ``X(0)`` |0⟩ prep
     per qubit."""
     g = Graph(backend)
-    q_mapper: TargetMapper[VT] = TargetMapper()
-    c_mapper: TargetMapper[VT] = TargetMapper()
+    q_mapper: TargetMapper = TargetMapper()
+    c_mapper: TargetMapper = TargetMapper()
     inputs = []
     outputs = []
     measure_targets = set()
@@ -344,25 +343,24 @@ def circuit_to_graph(
 
 
     for gate in c.gates:
-        if gate.name == "Measurement":
-            assert isinstance(gate, Measurement)
+        if isinstance(gate, Measurement):
             measure_targets.add(gate.target)
-        if gate.name == 'InitAncilla':
-            l = gate.label # type: ignore
+        if isinstance(gate, InitAncilla):
+            l = gate.label
             if l in q_mapper.labels():
                 raise ValueError("Ancilla label {} already in use".format(str(l)))
-            vtype, phase = gate.get_vertex_info() # type: ignore
+            vtype, phase = gate.get_vertex_info()
             q_mapper.add_label(l, q_mapper.next_row_or_default(l, q_mapper.max_row() - 1))
             v = g.add_vertex(vtype, q_mapper.to_qubit(l), q_mapper.next_row(l), phase)
             q_mapper.set_prev_vertex(l, v)
             q_mapper.advance_next_row(l)
-        elif gate.name == 'Reset':
+        elif isinstance(gate, Reset):
             # Model reset as an implicit measurement with a discarded
             # outcome, followed by fresh |0⟩ preparation. The Z(0)
             # spider + X(_rN) leaf mirrors the measurement pattern.
             # The unused boolean variable gives trace-out semantics:
             # summing over its two values is equivalent to discarding.
-            l = gate.label # type: ignore
+            l = gate.label
             q = q_mapper.to_qubit(l)
             # The qubit is being reused, so clear any pending measurement
             # marker. If the qubit is measured again later without a
@@ -397,8 +395,8 @@ def circuit_to_graph(
             g.set_vdata(state_v, 'outcome_type', 'reset_state')
             q_mapper.set_prev_vertex(l, state_v)
             q_mapper.set_next_row(l, r + 2)
-        elif gate.name == 'PostSelect':
-            l = gate.label # type: ignore
+        elif isinstance(gate, PostSelect):
+            l = gate.label
             if l not in q_mapper.labels():
                 raise ValueError("PostSelect label {} is not in use".format(str(l)))
             q = q_mapper.to_qubit(l)
@@ -406,7 +404,7 @@ def circuit_to_graph(
             u = q_mapper.prev_vertex(l)
             q_mapper.set_next_row(l, r + 1)
             q_mapper.remove_label(l)
-            vtype, phase = gate.get_vertex_info() # type: ignore
+            vtype, phase = gate.get_vertex_info()
             v = g.add_vertex(vtype, q, r, phase)
             g.add_edge((u,v),EdgeType.SIMPLE)
         else:

--- a/pyzx/circuit/graphparser.py
+++ b/pyzx/circuit/graphparser.py
@@ -19,7 +19,7 @@ import warnings
 from . import Circuit
 from .gates import (Gate, InitAncilla, Measurement, PostSelect, Reset, TargetMapper,
                      ConditionalGate, ZPhase, XPhase, NOT, Z, S, T, SX)
-from ..utils import EdgeType, VertexType, FloatInt, FractionLike, settings
+from ..utils import EdgeType, VertexType, FloatInt, settings
 from ..graph import Graph
 from ..graph.base import BaseGraph, VT, ET
 from ..symbolic import Poly, new_var

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -20,7 +20,11 @@ import re
 from fractions import Fraction
 
 from . import Circuit
-from .gates import CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY, CZ, HAD, NOT, RXX, RZZ, S, SWAP, SX, T, U2, U3, Y, Z, CPhase, Gate, Tofolli, XPhase, XPhase, YPhase, YPhase, ZPhase, qasm_gate_table, Measurement, Reset, ConditionalGate
+from .gates import (
+    CCZ, CHAD, CNOT, ConditionalGate, CPhase, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY, CZ,
+    Gate, HAD, Measurement, NOT, Reset, RXX, RZZ, S, SWAP, SX,
+    T, Tofolli, U2, U3, XPhase, Y, YPhase, Z, ZPhase, qasm_gate_table
+)
 from ..symbolic import Var, new_var, parse as parse_symbolic_expr, parse_phase_list
 from ..utils import settings
 

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -18,10 +18,9 @@
 import math
 import re
 from fractions import Fraction
-from typing import List, Dict, Tuple, Optional
 
 from . import Circuit
-from .gates import Gate, qasm_gate_table, Measurement, Reset, ConditionalGate
+from .gates import CCZ, CHAD, CNOT, CRX, CRY, CRZ, CSWAP, CSX, CU, CU3, CY, CZ, HAD, NOT, RXX, RZZ, S, SWAP, SX, T, U2, U3, Y, Z, CPhase, Gate, Tofolli, XPhase, XPhase, YPhase, YPhase, ZPhase, qasm_gate_table, Measurement, Reset, ConditionalGate
 from ..utils import settings
 
 
@@ -29,14 +28,14 @@ class QASMParser(object):
     """Class for parsing QASM source files into circuit descriptions."""
 
     def __init__(self) -> None:
-        self.qasm_version:int = settings.default_qasm_version
-        self.gates: List[Gate] = []
-        self.custom_gates: Dict[str,Circuit] = {}
-        self.registers: Dict[str,Tuple[int,int]] = {}
-        self.cregisters: Dict[str,int] = {}
+        self.qasm_version: int = settings.default_qasm_version
+        self.gates: list[Gate] = []
+        self.custom_gates: dict[str, Circuit] = {}
+        self.registers: dict[str, tuple[int, int]] = {}
+        self.cregisters: dict[str, int] = {}
         self.qubit_count: int = 0
         self.bit_count: int = 0
-        self.circuit: Optional[Circuit] = None
+        self.circuit: Circuit | None = None
 
     def parse(self, s: str, strict:bool=True) -> Circuit:
         self.gates = []
@@ -142,7 +141,7 @@ class QASMParser(object):
         else:
             raise TypeError("Custom gate specification doesn't have any "
                             "arguments: {}".format(data))
-        registers : Dict[str,Tuple[int,int]] = {}
+        registers: dict[str, tuple[int, int]] = {}
         qubit_count = 0
         for a in args.split(","):
             a = a.strip()
@@ -159,7 +158,7 @@ class QASMParser(object):
                 circ.add_gate(g)
         self.custom_gates[name] = circ
 
-    def extract_command_parts(self, c: str) -> Tuple[str,List[Fraction],List[str]]:
+    def extract_command_parts(self, c: str) -> tuple[str, list[Fraction], list[str]]:
         if self.qasm_version == 3:
             # Convert some OpenQASM 3 commands into OpenQASM 2 format.
             c = re.sub(r"^bit\[(\d+)] (\w+)$", r"creg \2[\1]", c)
@@ -179,8 +178,8 @@ class QASMParser(object):
             name = name[:left_bracket]
         return name, phases, args
 
-    def parse_command(self, c: str, registers: Dict[str,Tuple[int,int]]) -> List[Gate]:
-        gates: List[Gate] = []
+    def parse_command(self, c: str, registers: dict[str, tuple[int, int]]) -> list[Gate]:
+        gates: list[Gate] = []
         # Handle `if (creg == val) gate args;` before extract_command_parts,
         # because the parentheses in `if(...)` confuse the phase parser.
         if_match = re.match(r'if\s*\(\s*(\w+)\s*==\s*(\d+)\s*\)\s*(.*)', c)
@@ -278,7 +277,7 @@ class QASMParser(object):
                 regname, valp = a.split("[",1)
                 # Remove the trailing ']' before converting to int
                 val = int(valp[:-1])
-                if regname not in registers: 
+                if regname not in registers:
                     raise TypeError("Invalid register {}".format(regname))
                 qubit_values.append([registers[regname][0]+val])
             else:
@@ -296,49 +295,50 @@ class QASMParser(object):
                     qubit_values[i] = [qubit_values[i][0]]*dim
         for j in range(dim):
             argset = [q[j] for q in qubit_values]
+            gtype = qasm_gate_table.get(name)
             if name in self.custom_gates:
                 circ = self.custom_gates[name]
                 if len(argset) != circ.qubits:
                     raise TypeError("Argument amount does not match gate spec: {}".format(c))
                 for g in circ.gates:
                     gates.append(g.reposition(argset))
-            elif name in ('x', 'y', 'z', 's', 't', 'h', 'sx'):
+            elif gtype in (NOT, Y, Z, HAD):
                 if len(phases) != 0: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](argset[0])  # type: ignore # mypy can't handle Gate subclasses with different number of parameters
+                g = gtype(argset[0])
                 gates.append(g)
-            elif name in ('sdg', 'tdg', 'sxdg'):
+            elif gtype in (S, T, SX):
                 if len(phases) != 0: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](argset[0],adjoint=True)  # type: ignore
+                g = gtype(argset[0], adjoint=(name in ('sdg', 'tdg', 'sxdg')))
                 gates.append(g)
-            elif name in ('rx', 'ry', 'rz', 'p', 'u1'):
+            elif gtype in (XPhase, YPhase, ZPhase):
                 if len(phases) != 1: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](argset[0],phase=phases[0])  # type: ignore
+                g = gtype(argset[0], phase=phases[0])
                 gates.append(g)
-            elif name == 'u2':
+            elif gtype is U2:
                 if len(phases) != 2: raise TypeError("Invalid specification {}".format(c))
-                gates.append(qasm_gate_table[name](argset[0], phases[0], phases[1]))  # type: ignore
-            elif name in ('u3', 'u', 'U'):
+                gates.append(gtype(argset[0], phases[0], phases[1]))
+            elif gtype is U3:
                 if len(phases) != 3: raise TypeError("Invalid specification {}".format(c))
-                gates.append(qasm_gate_table[name](argset[0], phases[0], phases[1], phases[2]))  # type: ignore
-            elif name in ('cx', 'CX', 'cy', 'cz', 'ch', 'csx', 'swap'):
+                gates.append(gtype(argset[0], phases[0], phases[1], phases[2]))
+            elif gtype in (CNOT, CY, CZ, CHAD, CSX, SWAP):
                 if len(phases) != 0: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](control=argset[0],target=argset[1])  # type: ignore
+                g = gtype(control=argset[0],target=argset[1])
                 gates.append(g)
-            elif name in ('crx', 'cry', 'crz', 'cp', 'cphase', 'cu1', 'rxx', 'rzz'):
+            elif gtype in (CRX, CRY, CRZ, CPhase, RXX, RZZ):
                 if len(phases) != 1: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](argset[0],argset[1],phase=phases[0])  # type: ignore
+                g = gtype(argset[0], argset[1], phase=phases[0])
                 gates.append(g)
-            elif name in ('ccx', 'ccz', 'cswap'):
+            elif gtype in (Tofolli, CCZ, CSWAP):
                 if len(phases) != 0: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](ctrl1=argset[0],ctrl2=argset[1],target=argset[2])  # type: ignore
+                g = gtype(ctrl1=argset[0], ctrl2=argset[1], target=argset[2])
                 gates.append(g)
-            elif name == 'cu3':
+            elif gtype is CU3:
                 if len(phases) != 3: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](control=argset[0],target=argset[1],theta=phases[0],phi=phases[1],rho=phases[2])  # type: ignore
+                g = gtype(control=argset[0], target=argset[1], theta=phases[0], phi=phases[1], rho=phases[2])
                 gates.append(g)
-            elif name == 'cu':
+            elif gtype is CU:
                 if len(phases) != 4: raise TypeError("Invalid specification {}".format(c))
-                g = qasm_gate_table[name](control=argset[0],target=argset[1],theta=phases[0],phi=phases[1],rho=phases[2],gamma=phases[3])  # type: ignore
+                g = gtype(control=argset[0], target=argset[1], theta=phases[0], phi=phases[1], rho=phases[2], gamma=phases[3])
                 gates.append(g)
             else:
                 raise TypeError("Invalid specification: {}".format(c))
@@ -374,4 +374,3 @@ def qasm(s: str) -> Circuit:
     """Parses a string representing a program in QASM, and outputs a `Circuit`."""
     p = QASMParser()
     return p.parse(s, strict=False)
-

--- a/pyzx/circuit/qcparser.py
+++ b/pyzx/circuit/qcparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
-
 from . import Circuit
 from .gates import *
 
@@ -24,7 +22,7 @@ def parse_qc(data: str) -> Circuit:
     If a Tofolli gate with more than 2 controls is encountered, ancilla qubits are added.
     Currently up to 5 controls are supported."""
     preamble = data[:data.find("BEGIN")].strip().splitlines()
-    labels: Dict[str,int] = {}
+    labels: dict[str, int] = {}
     for l in preamble:
         if l.startswith('#'): continue
         if l.startswith('.'):
@@ -34,8 +32,8 @@ def parse_qc(data: str) -> Circuit:
         else:
             raise TypeError("Unknown Expression: " + l)
 
-    ancillas: Dict[int,int] = {}
-    gates: List[Gate] = []
+    ancillas: dict[int, int] = {}
+    gates: list[Gate] = []
     qcount = len(labels)
 
     for l in data[data.find("BEGIN")+6:data.find("END")].splitlines():

--- a/pyzx/circuit/qsimparser.py
+++ b/pyzx/circuit/qsimparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 from . import Circuit
 from .gates import *
 from fractions import Fraction
@@ -29,7 +27,7 @@ def parse_qsim(data: str) -> Circuit:
     except ValueError:
         raise ValueError('First line should be qubit count')
 
-    gates: List[Gate] = []
+    gates: list[Gate] = []
 
     for l in lines:
         l = l.strip()

--- a/pyzx/circuit/quipperparser.py
+++ b/pyzx/circuit/quipperparser.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -14,14 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
 import math
 from fractions import Fraction
 
 from . import Circuit
 
-def parse_quipper_block(lines: List[str]) -> Circuit:
+def parse_quipper_block(lines: list[str]) -> Circuit:
     start = lines[0]
     end = lines[-1]
     gates = lines[1:-1]
@@ -55,7 +53,7 @@ def parse_quipper_block(lines: List[str]) -> Circuit:
             elif gate[i+4:i+8] == '-i%X':
                 gtype = "XPhase"
             else:
-                raise TypeError("Unsupported expression: " + gate) 
+                raise TypeError("Unsupported expression: " + gate)
             val = gate[gate.find(',')+1: gate.find(']')]
             try:
                 f = float(val)
@@ -63,7 +61,7 @@ def parse_quipper_block(lines: List[str]) -> Circuit:
                 raise TypeError("Unsupported expression: " + gate)
             phase = Fraction(f/math.pi)
             target = gate[gate.rfind('(')+1:gate.rfind(')')]
-            try: 
+            try:
                 t = int(target)
             except ValueError:
                 raise TypeError("Unsupported expression: "+ gate)
@@ -121,7 +119,7 @@ def quipper_center_block(fname: str) -> Circuit:
     text = f.read()
     f.close()
     i = text.find('Subroutine: "C"')
-    if i == -1: 
+    if i == -1:
         i = text.find('Subroutine: "S"')
         if i == -1: raise Exception("Not a valid format")
         text = text[i:].strip()

--- a/pyzx/circuit/sqasm.py
+++ b/pyzx/circuit/sqasm.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ __all__ = ['sqasm']
 # isolated vertices. n.b. remove_ids already does this, but this might change
 # in the future...
 
-spider_nocheck: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(check_fuse, unsafe_fuse,None, False, False)
+spider_nocheck: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(check_fuse, unsafe_fuse, None, False, False)
 
 # def spider_nocheck(g: BaseGraph, ms: List) -> RewriteOutputType:
 #     etab,rem_v,rem_e,check = spider(g, ms)
@@ -39,7 +39,7 @@ spider_nocheck: RewriteSimpDoubleVertex = RewriteSimpDoubleVertex(check_fuse, un
 remove_ids_nocheck: RewriteSimpSingleVertex = RewriteSimpSingleVertex(check_remove_id, unsafe_remove_id, None, False)
 
 
-def sqasm(s: str, simplify=True) -> BaseGraph:
+def sqasm(s: str, simplify: bool = True) -> BaseGraph:
     p = QASMParser()
     c = p.parse(s, strict=False)
     g = c.to_graph(zh=True)

--- a/pyzx/utils.py
+++ b/pyzx/utils.py
@@ -76,6 +76,8 @@ def normalize_phase(phase: Any) -> FractionLike:
             settings.float_to_fraction_max_denominator)
     return phase
 
+def half_phase(phase: FractionLike) -> FractionLike:
+    return Fraction(phase / 2) if isinstance(phase, int) else phase / 2
 
 class VertexType(IntEnum):
     """Type of a vertex in the graph."""


### PR DESCRIPTION
Adds missing type annotations to the files in `pyzx/circuit/` and fixes a few related problems. Also modernises some of the syntax for Python 3.10 (e.g. using `list` and `dict` instead of `typing.List` and `typing.Dict`) and removes all instances of `#type: ignore`. Function bodies are mostly untouched, with some exceptions to fix type errors:
- A lot of the code in the base `Gate` class used `hasattr` checks and then accessed properties directly, which the type checker doesn't like. This PR replaces these with explicit `getattr` calls so that it's clear we're circumventing the usual behaviour. This is not any safer at runtime, but it at least signals intent and avoids mypy errors (which were previously ignored with broad `#type: ignore`s which could also hide other errors). This code should really be refactored so that subclasses override behaviour instead of relying on `hasattr` in the base class, but this is outside the scope of this PR.
- In some subclass overrides of `Gate.to_basic_gates()`, integer phases could incorrectly become floats because they were being divided by 2. A new utility function `half_phase` is introduced in `pyzx/utils.py` which handles this type error by casting to `Fraction`.
- Some local imports are moved to be global because they were (incorrectly) used in type hints. Doing so does not introduce any cyclic dependencies.
- Rather than identifying gates by their `Gate.name` property, which provides no information to the type-checker, `isinstance` checks are performed. This is also more robust, since the names could have collisions or even be changed by code.

This last bullet point requires #472 to be merged first, as the outdated version of `mypy` currently being used doesn't properly perform the needed type narrowing, so this PR is marked as a draft for now.