### PR TITLE
Fix numeric phases becoming a constant `Poly` after a TikZ round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - Added the "magic cat" decomposition strategy from https://arxiv.org/pdf/2202.09202 (which previously only existed in Quizx). (by @mjsutcliffe99).
 - `settings.strict_phase_types` (default `True`) rejects float phases at `set_phase`/`add_to_phase` rather than letting them flow into the graph and crash downstream rewrite rules. Set to `False` to opt in to automatic conversion to `Fraction` using `settings.float_to_fraction_max_denominator`, accepting the resulting precision loss. Fixes crash in `full_reduce` with non-Clifford spiders (by @dlyongemallo).
 
+### Fixed
+- A numeric phase (e.g. `π/4`) now survives a `to_tikz`/`tikz_to_graph` round trip as a `Fraction` instead of becoming a constant `Poly`. The TikZ phase normaliser emitted numeric fractions in a form that `string_to_phase` could only read through its symbolic fallback, producing a parameter-free `Poly` that compared and printed correctly but raised `Can't convert diagram with parameters to tensor` when passed to `to_tensor`/`to_matrix` (by @gauthamkanagaraj).
+
 ## [0.10.3] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ## [Unreleased]
 
+### Fixed
+- `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
+
 ## [0.10.4] - 2026-07-01
 
 ### Added
 - Added the "magic cat" decomposition strategy from https://arxiv.org/pdf/2202.09202 (which previously only existed in Quizx). (by @mjsutcliffe99).
 - `settings.strict_phase_types` (default `True`) rejects float phases at `set_phase`/`add_to_phase` rather than letting them flow into the graph and crash downstream rewrite rules. Set to `False` to opt in to automatic conversion to `Fraction` using `settings.float_to_fraction_max_denominator`, accepting the resulting precision loss. Fixes crash in `full_reduce` with non-Clifford spiders (by @dlyongemallo).
-
-### Fixed
-- `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
 
 ## [0.10.3] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - `settings.strict_phase_types` (default `True`) rejects float phases at `set_phase`/`add_to_phase` rather than letting them flow into the graph and crash downstream rewrite rules. Set to `False` to opt in to automatic conversion to `Fraction` using `settings.float_to_fraction_max_denominator`, accepting the resulting precision loss. Fixes crash in `full_reduce` with non-Clifford spiders (by @dlyongemallo).
 
 ### Fixed
-- A numeric phase (e.g. `π/4`) now survives a `to_tikz`/`tikz_to_graph` round trip as a `Fraction` instead of becoming a constant `Poly`. The TikZ phase normaliser emitted numeric fractions in a form that `string_to_phase` could only read through its symbolic fallback, producing a parameter-free `Poly` that compared and printed correctly but raised `Can't convert diagram with parameters to tensor` when passed to `to_tensor`/`to_matrix` (by @gauthamkanagaraj).
+- `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
 
 ## [0.10.3] - 2026-06-01
 

--- a/pyzx/graph/jsonparser.py
+++ b/pyzx/graph/jsonparser.py
@@ -28,7 +28,7 @@ from pyzx.graph.multigraph import Multigraph
 
 from ..utils import EdgeType, VertexType, phase_to_s
 from .graph import Graph
-from .scalar import Scalar
+from .scalar import Scalar, simplify_poly
 from .base import BaseGraph, VT, ET
 from ..symbolic import parse, Poly, new_var, VarRegistry
 if TYPE_CHECKING:
@@ -61,9 +61,16 @@ def string_to_phase(string: str, g: Union[BaseGraph, 'GraphDiff', None] = None) 
                 return new_var(name, is_bool=False)
             return new_var(name, is_bool=g.var_registry.get_type(name, False), registry=g.var_registry)
         try:
-            return parse(string, _new_var)
+            poly = parse(string, _new_var)
         except Exception as e:
             raise ValueError(e)
+        # A numeric expression that misses the fast path above, like "(1)*1/4", parses
+        # to a Poly without variables. Unwrap it so that numeric phases always get a
+        # numeric type. See issue #471.
+        value = simplify_poly(poly)
+        if isinstance(value, (int, Fraction)):
+            return Fraction(value)
+        return poly
 
 @deprecated("json_to_graph_old is deprecated, use json_to_graph or dict_to_graph instead")
 def json_to_graph_old(js: str | dict[str, Any], backend: str | None = None) -> BaseGraph:

--- a/pyzx/tikz.py
+++ b/pyzx/tikz.py
@@ -267,6 +267,14 @@ def _extract_braced_group(s: str, start: int) -> Tuple[Optional[str], int]:
     return None, start
 
 
+def _is_numeric_phase_expr(expr: str) -> bool:
+    """True if a normalised factor is a plain numeric multiple of pi (e.g. 'pi', '3*pi', '3').
+
+    Only these round-trip to a Fraction via string_to_phase's fast path; others stay symbolic (#471).
+    """
+    return re.fullmatch(r"-?(\d+\*?)?(pi|π)|-?\d+", expr) is not None
+
+
 def _normalise_tikzit_phase_expr(expr: str) -> Optional[str]:
     """Convert simple Tikzit LaTeX syntax into the expression syntax accepted by string_to_phase."""
     expr = expr.strip()
@@ -288,13 +296,19 @@ def _normalise_tikzit_phase_expr(expr: str) -> Optional[str]:
             return None
         if not re.fullmatch(r"-?\d+", normalised_denominator):
             return None
-        normalised_fraction = f"({normalised_numerator})*1/{normalised_denominator}"
-        suffix = rest[final_index:].strip()
-        if not suffix:
-            return normalised_fraction
-        normalised_suffix = _normalise_tikzit_phase_expr(suffix)
-        if normalised_suffix is None:
+        if int(normalised_denominator) == 0:
             return None
+        suffix = rest[final_index:].strip()
+        normalised_suffix = _normalise_tikzit_phase_expr(suffix) if suffix else None
+        if suffix and normalised_suffix is None:
+            return None
+        # A plain numeric fraction takes the fast path and returns a Fraction; anything else
+        # keeps the symbolic "(num)*1/den" form and parses to a Poly (see _is_numeric_phase_expr).
+        if _is_numeric_phase_expr(normalised_numerator) and normalised_suffix is None:
+            return f"{normalised_numerator}/{normalised_denominator}"
+        normalised_fraction = f"({normalised_numerator})*1/{normalised_denominator}"
+        if normalised_suffix is None:
+            return normalised_fraction
         return f"({normalised_fraction})*{normalised_suffix}"
 
     tokens: List[str] = []

--- a/pyzx/tikz.py
+++ b/pyzx/tikz.py
@@ -267,14 +267,6 @@ def _extract_braced_group(s: str, start: int) -> Tuple[Optional[str], int]:
     return None, start
 
 
-def _is_numeric_phase_expr(expr: str) -> bool:
-    """True if a normalised factor is a plain numeric multiple of pi (e.g. 'pi', '3*pi', '3').
-
-    Only these round-trip to a Fraction via string_to_phase's fast path; others stay symbolic (#471).
-    """
-    return re.fullmatch(r"-?(\d+\*?)?(pi|π)|-?\d+", expr) is not None
-
-
 def _normalise_tikzit_phase_expr(expr: str) -> Optional[str]:
     """Convert simple Tikzit LaTeX syntax into the expression syntax accepted by string_to_phase."""
     expr = expr.strip()
@@ -296,19 +288,13 @@ def _normalise_tikzit_phase_expr(expr: str) -> Optional[str]:
             return None
         if not re.fullmatch(r"-?\d+", normalised_denominator):
             return None
-        if int(normalised_denominator) == 0:
-            return None
-        suffix = rest[final_index:].strip()
-        normalised_suffix = _normalise_tikzit_phase_expr(suffix) if suffix else None
-        if suffix and normalised_suffix is None:
-            return None
-        # A plain numeric fraction takes the fast path and returns a Fraction; anything else
-        # keeps the symbolic "(num)*1/den" form and parses to a Poly (see _is_numeric_phase_expr).
-        if _is_numeric_phase_expr(normalised_numerator) and normalised_suffix is None:
-            return f"{normalised_numerator}/{normalised_denominator}"
         normalised_fraction = f"({normalised_numerator})*1/{normalised_denominator}"
-        if normalised_suffix is None:
+        suffix = rest[final_index:].strip()
+        if not suffix:
             return normalised_fraction
+        normalised_suffix = _normalise_tikzit_phase_expr(suffix)
+        if normalised_suffix is None:
+            return None
         return f"({normalised_fraction})*{normalised_suffix}"
 
     tokens: List[str] = []

--- a/tests/test_jsonparser.py
+++ b/tests/test_jsonparser.py
@@ -24,8 +24,9 @@ if __name__ == '__main__':
     sys.path.append('.')
 
 from pyzx.graph import Graph
+from pyzx.graph.diff import GraphDiff
 from pyzx.graph.scalar import Scalar
-from pyzx.graph.jsonparser import graph_to_dict, dict_to_graph
+from pyzx.graph.jsonparser import graph_to_dict, dict_to_graph, string_to_phase
 from pyzx.utils import EdgeType, VertexType, set_h_box_label, get_h_box_label, hbox_has_complex_label
 from pyzx.symbolic import Poly, new_var
 
@@ -440,6 +441,63 @@ class TestGraphIO(unittest.TestCase):
         self.assertTrue(hbox_has_complex_label(g2, v3_new))
         self.assertEqual(get_h_box_label(g2, v2_new), 1j)
         self.assertEqual(get_h_box_label(g2, v3_new), 2.5+1.3j)
+
+class TestStringToPhase(unittest.TestCase):
+
+    def test_numeric_expression_parses_to_fraction(self):
+        """Numeric strings that miss the fast path return a Fraction, not a constant Poly (issue #471)."""
+        for s, expected in [("(1)*1/4", Fraction(1, 4)),
+                            ("(3*pi)*1/4", Fraction(3, 4)),
+                            ("(-3)*1/2", Fraction(-3, 2)),
+                            ("1/2+1/4", Fraction(3, 4))]:
+            with self.subTest(s=s):
+                phase = string_to_phase(s)
+                self.assertEqual(phase, expected)
+                self.assertIsInstance(phase, Fraction)
+
+    def test_symbolic_expression_parses_to_poly(self):
+        g = Graph()
+        phase = string_to_phase("alpha + 1/2", g)
+        self.assertIsInstance(phase, Poly)
+        self.assertEqual(len(phase.free_vars()), 1)
+
+    def test_cancelling_symbolic_expression_parses_to_fraction(self):
+        g = Graph()
+        phase = string_to_phase("alpha - alpha", g)
+        self.assertEqual(phase, 0)
+        self.assertIsInstance(phase, Fraction)
+
+    def test_parsed_numeric_phase_works_as_dict_key(self):
+        """Phases are used as dict keys (e.g. in Scalar.from_json), so equal phases must hash equally."""
+        d = {string_to_phase("(1)*1/4"): 1}
+        self.assertIn(Fraction(1, 4), d)
+
+    def test_numeric_phase_as_scalar_dict_key(self):
+        """Phases are used as dict keys in Scalar.sum_of_phases, so a numeric phase
+        parsed from JSON must hash equally to the Fraction it denotes (issue #471)."""
+        scalar = Scalar.from_json(json.dumps(
+            {"power2": 0, "phase": "(1)*1/4", "sum_of_phases": {"(1)*3/4": 2}}))
+        self.assertIsInstance(scalar.phase, Fraction)
+        self.assertEqual(scalar.phase, Fraction(1, 4))
+        self.assertEqual(scalar.sum_of_phases.get(Fraction(3, 4)), 2)
+
+    def test_graph_diff_phases_round_trip(self):
+        """GraphDiff.from_json also parses phases with string_to_phase; numeric
+        phases must come back as Fraction and symbolic ones as Poly."""
+        g1 = Graph()
+        v1 = g1.add_vertex(VertexType.Z, 0, 0)
+        v2 = g1.add_vertex(VertexType.X, 0, 1)
+        g2 = g1.clone()
+        g2.set_phase(v1, Fraction(3, 4))
+        g2.set_phase(v2, new_var('alpha', is_bool=False, registry=g2.var_registry) + Fraction(1, 2))
+        diff = GraphDiff.from_json(GraphDiff(g1, g2).to_json())
+        self.assertIsInstance(diff.changed_phases[v1], Fraction)
+        self.assertEqual(diff.changed_phases[v1], Fraction(3, 4))
+        self.assertIsInstance(diff.changed_phases[v2], Poly)
+        applied = diff.apply_diff(g1.clone())
+        self.assertEqual(applied.phase(v1), Fraction(3, 4))
+        self.assertEqual(applied.phase(v2), g2.phase(v2))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_tikz.py
+++ b/tests/test_tikz.py
@@ -209,17 +209,23 @@ class TestTikzErrorHandling(unittest.TestCase):
         self.assertEqual(str(g.phase(v)), "1/2⋅alpha")
 
     def test_latex_fraction_numeric_phase_label(self):
-        """Numeric LaTeX fractions take the string_to_phase path after normalisation."""
-        tikz = r'''\begin{tikzpicture}
+        """Numeric LaTeX fractions parse back to a Fraction, not a constant Poly (issue #471)."""
+        for label, expected in [(r"\frac{\pi}{4}", Fraction(1, 4)),
+                                (r"\frac{3\pi}{4}", Fraction(3, 4)),
+                                (r"\frac{\pi}{2}", Fraction(1, 2)),
+                                (r"\frac{2\pi}{3}", Fraction(2, 3))]:
+            with self.subTest(label=label):
+                tikz = r'''\begin{tikzpicture}
 \begin{pgfonlayer}{nodelayer}
-\node [style=green dot] (0) at (0, 0) {$\frac{\pi}{4}$};
+\node [style=green dot] (0) at (0, 0) {$%s$};
 \end{pgfonlayer}
 \begin{pgfonlayer}{edgelayer}
 \end{pgfonlayer}
-\end{tikzpicture}'''
-        g = tikz_to_graph(tikz, warn_overlap=False)
-        v = list(g.vertices())[0]
-        self.assertEqual(g.phase(v), Fraction(1, 4))
+\end{tikzpicture}''' % label
+                g = tikz_to_graph(tikz, warn_overlap=False)
+                v = list(g.vertices())[0]
+                self.assertEqual(g.phase(v), expected)
+                self.assertIsInstance(g.phase(v), Fraction)
 
     def test_latex_fraction_pi_suffix_phase_label(self):
         """The normaliser also handles fraction forms with a trailing pi."""
@@ -233,6 +239,48 @@ class TestTikzErrorHandling(unittest.TestCase):
         g = tikz_to_graph(tikz, warn_overlap=False)
         v = list(g.vertices())[0]
         self.assertEqual(g.phase(v), Fraction(3, 2))
+
+    def test_tikz_round_trip_preserves_numeric_phase_type(self):
+        """A numeric phase survives a to_tikz/tikz_to_graph round trip as a Fraction, not a Poly (issue #471)."""
+        g = Graph()
+        v = g.add_vertex(VertexType.Z, 0, 0)
+        g.set_phase(v, Fraction(1, 4))
+        g2 = tikz_to_graph(to_tikz(g), warn_overlap=False)
+        w = next(u for u in g2.vertices() if g2.type(u) == VertexType.Z)
+        self.assertEqual(g2.phase(w), Fraction(1, 4))
+        self.assertIsInstance(g2.phase(w), Fraction)
+
+    def test_malformed_numeric_fraction_not_silently_accepted(self):
+        """A malformed numerator (empty or trailing operator) is rejected, not read as 1/den (issue #471)."""
+        for label in [r"\frac{}{4}", r"\frac{\pi*}{4}"]:
+            with self.subTest(label=label):
+                tikz = r'''\begin{tikzpicture}
+\begin{pgfonlayer}{nodelayer}
+\node [style=z spider] (0) at (0, 0) {$%s$};
+\end{pgfonlayer}
+\begin{pgfonlayer}{edgelayer}
+\end{pgfonlayer}
+\end{tikzpicture}''' % label
+                with self.assertRaises(ValueError):
+                    tikz_to_graph(tikz, warn_overlap=False)
+                g = tikz_to_graph(tikz, warn_overlap=False, ignore_invalid_phases=True)
+                v = list(g.vertices())[0]
+                self.assertEqual(g.phase(v), 0)
+
+    def test_zero_denominator_fraction_does_not_crash(self):
+        """A zero denominator is rejected cleanly (ValueError or fallback), not an uncaught error (issue #471)."""
+        tikz = r'''\begin{tikzpicture}
+\begin{pgfonlayer}{nodelayer}
+\node [style=z spider] (0) at (0, 0) {$\frac{\pi}{0}$};
+\end{pgfonlayer}
+\begin{pgfonlayer}{edgelayer}
+\end{pgfonlayer}
+\end{tikzpicture}'''
+        with self.assertRaises(ValueError):
+            tikz_to_graph(tikz, warn_overlap=False)
+        g = tikz_to_graph(tikz, warn_overlap=False, ignore_invalid_phases=True)
+        v = list(g.vertices())[0]
+        self.assertEqual(g.phase(v), 0)
 
     def test_latex_symbolic_hbox_phase_label(self):
         """H-box labels use the normalised phase parser when not complex."""

--- a/tests/test_tikz.py
+++ b/tests/test_tikz.py
@@ -239,6 +239,7 @@ class TestTikzErrorHandling(unittest.TestCase):
         g = tikz_to_graph(tikz, warn_overlap=False)
         v = list(g.vertices())[0]
         self.assertEqual(g.phase(v), Fraction(3, 2))
+        self.assertIsInstance(g.phase(v), Fraction)
 
     def test_tikz_round_trip_preserves_numeric_phase_type(self):
         """A numeric phase survives a to_tikz/tikz_to_graph round trip as a Fraction, not a Poly (issue #471)."""


### PR DESCRIPTION
## Description

A numeric spider phase (e.g. π/4) written out with `to_tikz` and read back with `tikz_to_graph` came back as a constant `Poly` instead of a `Fraction`. The value was correct and compared/printed as expected, so it was easy to miss, but a parameter-free `Poly` still counts as having parameters, so the round tripped graph raised `Can't convert diagram with parameters to tensor` when passed to `to_tensor`/`to_matrix`.

The TikZ phase normaliser emits numeric fractions as `(num)*1/den`, a form `string_to_phase` only parses through its symbolic fallback (yielding a `Poly`). Rather than special-casing this in the TikZ importer, the fix moves upstream of every caller. After parsing, `string_to_phase` now collapses a variable free parse result to a numeric value using the existing `Scalar.simplify_poly` helper, returning a Fraction for a numeric result and leaving genuinely symbolic phases as a Poly. Symbolic phases are unchanged and still produce a `Poly`.

Regression tests round trip a numeric phase and assert a `Fraction` result, including through the phase-keyed dicts in `Scalar.from_json` (equal phases must hash equally as dict keys). The existing symbolic and suffixed round-trip tests are retained.

## Related issue

Fixes #471

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation. (N/A - bugfix, no new feature)
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.