### PR TITLE
add support for division in symbolic expression grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Added
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).
+- The symbolic expression parser (`pyzx.symbolic.parse`) now accepts division, e.g., `theta/2` or `(x + y)/2`. Divisors must be rational (or complex) constants; division by an integer produces an exact `Fraction` coefficient. As a side effect, `^` binds tighter than `*` and `/`. (by @dlyongemallo)
 
 ## [0.10.4] - 2026-07-01
 

--- a/pyzx/symbolic.py
+++ b/pyzx/symbolic.py
@@ -23,8 +23,7 @@ Lark is used to define a parser that can translate a string into a Poly.
 
 from typing import Any, Callable, Mapping, Union, Optional, Dict, List, Tuple, Set
 from lark import Lark, Transformer
-from functools import reduce
-from operator import add, mul
+from lark.exceptions import VisitError
 from fractions import Fraction
 
 
@@ -248,16 +247,20 @@ class Poly:
             other = Poly([(other, Term([]))])
         if len(other.terms) == 0:
             raise ZeroDivisionError("division by zero")
-        quotient = Poly([])
-        while len(self.terms) > 0 and self.degree >= other.degree:
-            leading_term_dividend = sorted(self.terms)[0][1]
-            leading_term_divisor = sorted(other.terms)[0][1]
-            coeff = sorted(self.terms)[0][0] / sorted(other.terms)[0][0]
-            new_term_quotient_vars = [(var, exp - dict(leading_term_divisor.vars).get(var, 0)) for var, exp in leading_term_dividend.vars]
-            new_term_quotient = (coeff, Term(new_term_quotient_vars))
-            quotient.terms.append(new_term_quotient)
-            self -= other * Poly([new_term_quotient])
-        return quotient
+        if len(other.terms) > 1 or other.terms[0][1].vars:
+            raise ValueError(
+                "division by a non-constant polynomial is not supported; "
+                "the divisor must be a rational (or complex) constant")
+        den = other.terms[0][0]
+        if den == 0:
+            raise ZeroDivisionError("division by zero")
+        new_terms = []
+        for num, term in self.terms:
+            # Divide exactly for integer operands so that, e.g., `theta/2`
+            # yields a Fraction coefficient rather than a float.
+            coeff = Fraction(num, den) if isinstance(num, int) and isinstance(den, int) else num / den
+            new_terms.append((coeff, term))
+        return Poly(new_terms)
 
     def __pow__(self, other: int) -> 'Poly':
         if other < 0:
@@ -419,16 +422,16 @@ poly_grammar = Lark("""
                | term
     term       : neg_term | pos_term
     neg_term   : "-" pos_term
-    pos_term   : factor (("*" | "⋅")? factor)*
+    pos_term   : factor (mul_factor | div_factor)*
+    mul_factor : ("*" | "⋅")? factor
+    div_factor : "/" factor
     ?factor    : base ("^" exponent)?
-    base       : intf | frac | decimal | pi | pifrac | var | "(" expr ")"
+    base       : intf | decimal | pi | var | "(" expr ")"
     exponent   : intf
     var        : CNAME ("[" INT "]")?
     intf       : INT
     decimal    : DECIMAL
     pi         : "\\pi" | "pi" | "π"
-    frac       : INT "/" INT
-    pifrac     : [INT] pi "/" INT
 
     %import common.INT
     %import common.DECIMAL
@@ -464,7 +467,16 @@ class PolyTransformer(Transformer):
         return -items[0]  # Negate the pos_term
 
     def pos_term(self, items: List[Any]) -> Poly:
-        return reduce(mul, items)
+        result = items[0]
+        for op, operand in items[1:]:
+            result = result / operand if op == "/" else result * operand
+        return result
+
+    def mul_factor(self, items: List[Any]) -> Tuple[str, Poly]:
+        return ("*", items[0])
+
+    def div_factor(self, items: List[Any]) -> Tuple[str, Poly]:
+        return ("/", items[0])
 
     def factor(self, items: List[Any]) -> Poly:
         if len(items) == 1:
@@ -495,17 +507,25 @@ class PolyTransformer(Transformer):
     def decimal(self, items: List[Any]) -> Poly:
         return new_const(Fraction(float(items[0])).limit_denominator())
 
-    def frac(self, items: List[Any]) -> Poly:
-        return new_const(Fraction(int(items[0]), int(items[1])))
-
-    def pifrac(self, items: List[Any]) -> Poly:
-        numerator = int(items[0]) if items[0] else 1
-        return new_const(Fraction(numerator, int(items[2])))
-
 def parse(expr: str, new_var: Callable[[str], Poly]) -> Poly:
     """Parse ``expr`` into a :class:`Poly` using ``new_var`` for variable lookup.
     It converts the string expression into a polynomial.
     Example: parse("x^2 + 3*y + 1/2", new_var) returns Poly([(1, Term([(x,2)])), (3, Term([(y,1)])), (1/2, Term([]))])
     """
     tree = poly_grammar.parse(expr)
-    return PolyTransformer(new_var).transform(tree)
+    for subtree in tree.iter_subtrees_topdown():
+        if subtree.data != "div_factor":
+            continue
+        for descendant in subtree.iter_subtrees_topdown():
+            if descendant.data == "var":
+                raise ValueError(
+                    "divisor must be a rational constant, not a symbolic "
+                    "expression")
+            if descendant.data == "pi":
+                raise ValueError(
+                    "`pi` is a phase marker, not a scalar, and cannot appear "
+                    "in a divisor; divisors must be rational constants")
+    try:
+        return PolyTransformer(new_var).transform(tree)
+    except VisitError as e:
+        raise e.orig_exc from None

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -303,6 +303,29 @@ class TestQASM(unittest.TestCase):
         c2 = p.parse(s2)
         self.assertListEqual(c1.gates, c2.gates)
 
+    def test_custom_gate_with_divided_parameter(self):
+        """A parametrised custom gate whose body divides a parameter."""
+        from pyzx.circuit.qasmparser import QASMParser
+        s1 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        gate halfrot(theta) q {
+            rz(theta/2) q;
+        }
+        qreg q[1];
+        halfrot(pi/2) q[0];
+        """
+        s2 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rz(pi/4) q[0];
+        """
+        p = QASMParser()
+        c1 = p.parse(s1)
+        c2 = p.parse(s2)
+        self.assertListEqual(c1.gates, c2.gates)
+
     def test_custom_gate_parameter_count_mismatch(self):
         """Calling a parametrised custom gate with the wrong arity errors."""
         from pyzx.circuit.qasmparser import QASMParser

--- a/tests/test_symbolic_parsing.py
+++ b/tests/test_symbolic_parsing.py
@@ -276,6 +276,122 @@ class TestSymbolicParsing(unittest.TestCase):
         expected = new_const(2) * ((self.new_var("x") + self.new_var("y")) ** 2)
         self.assertEqual(result, expected)
 
+    def test_division(self):
+        """Test division by a constant, including of symbolic expressions."""
+        # Division of a variable by an integer.
+        result = parse("x/2", self.new_var)
+        expected = self.new_var("x") / 2
+        self.assertEqual(result, expected)
+
+        # Negated variable divided by an integer.
+        result = parse("-x/4", self.new_var)
+        expected = -self.new_var("x") / 4
+        self.assertEqual(result, expected)
+
+        # Division binds at the same level as multiplication, left to right.
+        result = parse("2*x/4", self.new_var)
+        expected = new_const(2) * self.new_var("x") / 4
+        self.assertEqual(result, expected)
+
+        # Division of a parenthesized expression.
+        result = parse("(x + y)/2", self.new_var)
+        expected = (self.new_var("x") + self.new_var("y")) / 2
+        self.assertEqual(result, expected)
+
+        # Division of a power.
+        result = parse("x^2/2", self.new_var)
+        expected = (self.new_var("x") ** 2) / 2
+        self.assertEqual(result, expected)
+
+        # Division by an integer yields an exact Fraction coefficient.
+        result = parse("x/2", self.new_var)
+        self.assertEqual(result.terms[0][0], Fraction(1, 2))
+
+    def test_constant_fractions_remain_exact(self):
+        """Adding general division must not turn `1/2` or `pi/4` into floats."""
+        for expr, expected in [("1/2", Fraction(1, 2)), ("pi/4", Fraction(1, 4)),
+                               ("2*pi/3", Fraction(2, 3)), ("2pi/4", Fraction(1, 2))]:
+            result = parse(expr, self.new_var)
+            self.assertEqual(result, new_const(expected))
+            self.assertIsInstance(result.terms[0][0], Fraction)
+
+    def test_division_by_zero_raises(self):
+        """Division by any constant that evaluates to zero must raise.
+        """
+        from pyzx.symbolic import Poly
+        with self.assertRaises(ZeroDivisionError):
+            self.new_var("x") / 0
+        with self.assertRaises(ZeroDivisionError):
+            self.new_var("x") / new_const(0)
+        with self.assertRaises(ZeroDivisionError):
+            self.new_var("x") / Poly([])
+        with self.assertRaises(ZeroDivisionError):
+            Poly([]) / 0
+        with self.assertRaises(ZeroDivisionError):
+            Poly([]) / new_const(0)
+        for expr in ["x/0", "(x-x)/0", "(1-1)/0", "0/0"]:
+            with self.assertRaises(ZeroDivisionError,
+                                   msg=f"expected {expr!r} to raise"):
+                parse(expr, self.new_var)
+
+    def test_chained_division_is_left_associative(self):
+        """`x/2/3` must parse as `(x/2)/3`, not `x/(2/3)`.
+        """
+        for expr, expected in [
+                ("x/2/3", Fraction(1, 6)),
+                ("x/2/4", Fraction(1, 8)),
+                ("1/2/3", Fraction(1, 6)),
+        ]:
+            result = parse(expr, self.new_var)
+            self.assertEqual(result.terms[0][0], Fraction(expected),
+                             msg=f"{expr!r} coefficient")
+        result = parse("(x+y)/2/3", self.new_var)
+        expected_poly = (self.new_var("x") + self.new_var("y")) / 6
+        self.assertEqual(result, expected_poly)
+
+    def test_division_by_decimal_uses_limit_denominator(self):
+        """Decimal divisors go through `Fraction.limit_denominator`, so `x/2.5`
+        divides by `Fraction(5, 2)` and yields `2/5 x` exactly (not `0.4 x`)."""
+        result = parse("x/2.5", self.new_var)
+        expected = self.new_var("x") / Fraction(5, 2)
+        self.assertEqual(result, expected)
+        self.assertEqual(result.terms[0][0], Fraction(2, 5))
+        self.assertIsInstance(result.terms[0][0], Fraction)
+
+    def test_division_by_non_constant_rejected(self):
+        """Divisors must be constants; the grammar accepts them syntactically
+        but `Poly.__truediv__` and `parse` should refuse to evaluate."""
+        with self.assertRaises(ValueError):
+            self.new_var("x") / self.new_var("y")
+        with self.assertRaises(ValueError):
+            self.new_var("x") / (self.new_var("y") + 1)
+        for expr in ["x/y", "x/(y+1)", "x^2/x", "(x+1)/(x+1)", "x/(2*y)"]:
+            with self.assertRaises(ValueError, msg=f"expected {expr!r} to be rejected"):
+                parse(expr, self.new_var)
+
+    def test_division_by_complex_constant(self):
+        """`Poly.__truediv__` accepts complex divisors (symmetric with `__mul__`,
+        for the `Scalar`-side use case), yielding `complex` coefficients. This
+        path is only reachable via the Python API; the grammar has no complex
+        literal."""
+        x = self.new_var("x")
+        divisor = 2 + 3j
+        result = x / divisor
+        self.assertEqual(len(result.terms), 1)
+        coeff = result.terms[0][0]
+        self.assertIsInstance(coeff, complex)
+        self.assertEqual(coeff, 1 / divisor)
+
+    def test_pi_rejected_in_divisor(self):
+        """`pi` is a phase marker (== 1), and allowing it as a divisor silently results
+        in `x/pi == x`. Reject at parse time."""
+        for expr in ["x/pi", "x/(pi)", "x/pi^2", "x/(2*pi)", "x/(pi+1)", "x/(pi/2)"]:
+            with self.assertRaises(ValueError, msg=f"expected {expr!r} to be rejected"):
+                parse(expr, self.new_var)
+        # Check that `pi` in the dividend or as a multiplicative factor is still fine.
+        self.assertEqual(parse("pi/2", self.new_var), new_const(Fraction(1, 2)))
+        self.assertEqual(parse("pi*x/2", self.new_var), self.new_var("x") / 2)
+
 
 class TestBooleanIdempotency(unittest.TestCase):
 


### PR DESCRIPTION
## Description

Change `pyzx.symbolic.parse` to accept division, e.g., `theta/2`, `2*x/4`, `(x + y)/2`, and `x^2/2`, which binds at the same precedence as multiplication. Also fixed operator precedence so that `^` is higher than `*` and `/`.

`Poly.__truediv__` divides integer operands exactly, so dividing by an integer yields a `Fraction` coefficient. 
    
This change lets parametrised custom gate bodies use expressions like `rz(theta/2)`.

Follow-up to #479.

## Related issue

#220

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.