### PR TITLE
route QASM parser gate phase arguments through symbolic grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Fixed
 - `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
+- `Circuit.from_qasm` routes through the symbolic grammar and accepts parenthesised subexpressions in gate phase arguments, e.g., `rz((pi/2 + pi/4)) q[0];` or `u3(pi, (a+b)/2, c) q[0];` (by @dlyongemallo).
 
 ### Added
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -22,7 +22,7 @@ from typing import List, Dict, Tuple, Optional, Union
 
 from . import Circuit
 from .gates import Gate, qasm_gate_table, Measurement, Reset, ConditionalGate
-from ..symbolic import Var, new_var, parse as parse_symbolic_expr
+from ..symbolic import Var, new_var, parse as parse_symbolic_expr, parse_phase_list
 from ..utils import settings
 
 
@@ -191,18 +191,21 @@ class QASMParser(object):
             c = re.sub(r"^bit\[(\d+)] (\w+)$", r"creg \2[\1]", c)
             c = re.sub(r"^qubit\[(\d+)] (\w+)$", r"qreg \2[\1]", c)
             c = re.sub(r"^(\w+)\[(\d+)] = measure (\w+)\[(\d+)]$", r"measure \3[\4] -> \1[\2]", c)
-        right_bracket = c.find(")")
-        name, rest = c.split(" ", 1) if right_bracket == -1\
-            else [c[:right_bracket+1], c[right_bracket+1:]]
+        left_bracket = c.find('(')
+        phases: List[Fraction] = []
+        if left_bracket == -1:
+            name, rest = (c.split(" ", 1) + [""])[:2]
+        else:
+            # Delegate paren matching and top-level comma splitting to the symbolic grammar.
+            try:
+                vals, offset = parse_phase_list(c[left_bracket:])
+            except Exception as exc:
+                raise TypeError(
+                    "Invalid phase list in {}: {}".format(c, exc)) from exc
+            phases = [self.parse_phase_arg(v) for v in vals if v]
+            name = c[:left_bracket]
+            rest = c[left_bracket + offset:].lstrip()
         args = [s.strip() for s in rest.split(",") if s.strip()]
-        left_bracket = name.find('(')
-        phases = []
-        if left_bracket != -1:
-            if right_bracket == -1:
-                raise TypeError("Mismatched bracket: {}.".format(name))
-            vals = name[left_bracket+1:right_bracket].split(',')
-            phases = [self.parse_phase_arg(val) for val in vals]
-            name = name[:left_bracket]
         return name, phases, args
 
     def parse_command(self, c: str, registers: Dict[str,Tuple[int,int]]) -> List[Gate]:
@@ -375,33 +378,27 @@ class QASMParser(object):
         return gates
 
     def parse_phase_arg(self, val):
+        val = val.strip()
         if self._param_subst is not None:
             bound = self._bind_phase_parameters(val)
             if bound is not None:
                 return bound
         try:
-            phase = float(val)/math.pi
-        except ValueError:
-            if val.find('pi') == -1: raise TypeError("Invalid specification {}".format(val))
-            try:
-                val = val.replace('pi', '')
-                val = val.replace('*','')
-                if val.find('/') != -1:
-                    n, d = val.split('/',1)
-                    n = n.strip()
-                    if not n: n = 1
-                    elif n == '-': n = -1
-                    else: n = int(n)
-                    d = int(d.strip())
-                    phase = Fraction(n,d)
-                else:
-                    val = val.strip()
-                    if not val: phase = 1
-                    elif val == '-': phase = -1
-                    else: phase = float(val)
-            except: raise TypeError("Invalid specification {}".format(val))
-        phase = Fraction(phase).limit_denominator(settings.float_to_fraction_max_denominator)
-        return phase
+            poly = parse_symbolic_expr(val, lambda n: new_var(n, False))
+        except Exception as exc:
+            raise TypeError("Invalid specification {}: {}".format(val, exc))
+        if poly.free_vars():
+            raise TypeError(
+                "Phase expression {!r} contains unbound variables".format(val))
+        const: Union[int, float, complex, Fraction] = \
+            poly.terms[0][0] if poly.terms else 0
+        if isinstance(const, complex):
+            raise TypeError("Phase expression {!r} is not real".format(val))
+        if 'pi' not in val:
+            # Value without ``pi`` is in radians; normalise by pi.
+            const = float(const) / math.pi
+        return Fraction(const).limit_denominator(
+            settings.float_to_fraction_max_denominator)
 
     def _bind_phase_parameters(self, val: str) -> Optional[Fraction]:
         """Resolve a gate-body phase expression that uses bound parameters.

--- a/pyzx/symbolic.py
+++ b/pyzx/symbolic.py
@@ -22,8 +22,8 @@ Lark is used to define a parser that can translate a string into a Poly.
 """
 
 from typing import Any, Callable, Mapping, Union, Optional, Dict, List, Tuple, Set
-from lark import Lark, Transformer
-from lark.exceptions import VisitError
+from lark import Lark, Transformer, Tree
+from lark.exceptions import UnexpectedToken, VisitError
 from fractions import Fraction
 
 
@@ -417,14 +417,18 @@ def new_const(coeff: Union[int, Fraction]) -> Poly:
 
 poly_grammar = Lark("""
     start      : expr
+    phase_list : "(" expr ("," expr)* ")"
     ?expr      : expr "+" term   -> add
                | expr "-" term   -> sub
                | term
     term       : neg_term | pos_term
     neg_term   : "-" pos_term
     pos_term   : factor (mul_factor | div_factor)*
-    mul_factor : ("*" | "⋅")? factor
-    div_factor : "/" factor
+    mul_factor : ("*" | "⋅") signed_factor
+               | factor
+    div_factor : "/" signed_factor
+    ?signed_factor : "-" factor -> neg_factor
+                   | factor
     ?factor    : base ("^" exponent)?
     base       : intf | decimal | pi | var | "(" expr ")"
     exponent   : intf
@@ -440,7 +444,9 @@ poly_grammar = Lark("""
     %ignore WS
     """,
     parser='lalr',
-    maybe_placeholders=True)
+    start=['start', 'phase_list'],
+    maybe_placeholders=True,
+    propagate_positions=True)
 
 class PolyTransformer(Transformer):
     """Lark transformer that builds :class:`Poly` instances from parse trees.
@@ -486,6 +492,9 @@ class PolyTransformer(Transformer):
         exponent = items[1]
         return base ** exponent
 
+    def neg_factor(self, items: List[Any]) -> Poly:
+        return -items[0]
+
     def base(self, items: List[Any]) -> Poly:
         return items[0]
 
@@ -512,7 +521,7 @@ def parse(expr: str, new_var: Callable[[str], Poly]) -> Poly:
     It converts the string expression into a polynomial.
     Example: parse("x^2 + 3*y + 1/2", new_var) returns Poly([(1, Term([(x,2)])), (3, Term([(y,1)])), (1/2, Term([]))])
     """
-    tree = poly_grammar.parse(expr)
+    tree = poly_grammar.parse(expr, start='start')
     for subtree in tree.iter_subtrees_topdown():
         if subtree.data != "div_factor":
             continue
@@ -529,3 +538,22 @@ def parse(expr: str, new_var: Callable[[str], Poly]) -> Poly:
         return PolyTransformer(new_var).transform(tree)
     except VisitError as e:
         raise e.orig_exc from None
+
+
+def parse_phase_list(text: str) -> Tuple[List[str], int]:
+    """Parse a parenthesised, comma-separated list of expressions.
+
+    ``text`` must start with ``(``; trailing content past the matching ``)``
+    is allowed. Returns the source of each argument and the offset just past
+    the closing ``)``.
+    """
+    try:
+        tree = poly_grammar.parse(text, start='phase_list')
+    except UnexpectedToken as exc:
+        # ``pos_in_stream`` marks the first token past the phase list; re-parse the prefix.
+        if exc.pos_in_stream is None:
+            raise
+        tree = poly_grammar.parse(text[:exc.pos_in_stream], start='phase_list')
+    args = [text[c.meta.start_pos:c.meta.end_pos].strip()
+            for c in tree.children if isinstance(c, Tree)]
+    return args, tree.meta.end_pos

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -326,6 +326,85 @@ class TestQASM(unittest.TestCase):
         c2 = p.parse(s2)
         self.assertListEqual(c1.gates, c2.gates)
 
+    def test_parenthesised_phase_arguments(self):
+        """Phase arguments may contain parenthesised subexpressions.
+
+        The phase-argument tokeniser respects balanced parentheses so that
+        subexpressions like `(pi/2 + pi/4)` or `pi/(2*3)` do not truncate at
+        the first ``)``, and comma splitting inside a multi-argument gate call
+        happens only at the outermost nesting level.
+        """
+        from pyzx.circuit.qasmparser import QASMParser
+        s1 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rz((pi/2)) q[0];
+        rz((pi/2 + pi/4)) q[0];
+        rz((pi/4)/2) q[0];
+        rz(-(pi/4)) q[0];
+        rz((1.5)) q[0];
+        """
+        s2 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rz(pi/2) q[0];
+        rz(3*pi/4) q[0];
+        rz(pi/8) q[0];
+        rz(-pi/4) q[0];
+        rz(1.5) q[0];
+        """
+        p = QASMParser()
+        c1 = p.parse(s1)
+        c2 = p.parse(s2)
+        self.assertListEqual(c1.gates, c2.gates)
+
+    def test_parenthesised_phase_in_multi_argument_gate(self):
+        """A parenthesised phase in the middle of a comma-separated list is
+        not split by the inner comma-free tokeniser split."""
+        from pyzx.circuit.qasmparser import QASMParser
+        s1 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u3(pi, (pi/2 + pi/4), pi/4) q[0];
+        """
+        s2 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        u3(pi, 3*pi/4, pi/4) q[0];
+        """
+        p = QASMParser()
+        c1 = p.parse(s1)
+        c2 = p.parse(s2)
+        self.assertListEqual(c1.gates, c2.gates)
+
+    def test_custom_gate_with_parenthesised_body_expression(self):
+        """A parametrised custom gate body may use parenthesised
+        subexpressions in its phase arguments."""
+        from pyzx.circuit.qasmparser import QASMParser
+        s1 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        gate g(theta) q {
+            rz((theta+pi/2)/2) q;
+        }
+        qreg q[1];
+        g(pi/4) q[0];
+        """
+        s2 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[1];
+        rz(3*pi/8) q[0];
+        """
+        p = QASMParser()
+        c1 = p.parse(s1)
+        c2 = p.parse(s2)
+        self.assertListEqual(c1.gates, c2.gates)
+
     def test_custom_gate_parameter_count_mismatch(self):
         """Calling a parametrised custom gate with the wrong arity errors."""
         from pyzx.circuit.qasmparser import QASMParser


### PR DESCRIPTION
## Description

Route the QASM parser gate phase arguments through the symbolic parser so it fully supports bracketed subexpressions, instead of using the ad hoc bracket-matching code (which was written before the symbolic parsing was available).

Follow-up to #479 and #480.

## Related issue

#220

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.