### PR TITLE
fix handling of custom gate identifiers ending in `gate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 
 ### Fixed
 - `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
+* Correctly handling custom gate identifiers ending in `gate` (by @dlyongemallo).
 
 ### Added
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -74,10 +74,12 @@ class QASMParser(object):
             raise TypeError("File is not importing standard library")
 
         data = "\n".join(r)
-        # Strip the custom command definitions from the normal commands
+        # Strip the custom command definitions from the normal commands.
+        gate_decl = re.compile(r"\bgate ")
         while True:
-            i = data.find("gate ")
-            if i == -1: break
+            m = gate_decl.search(data)
+            if m is None: break
+            i = m.start()
             j = data.find("}", i)
             self.parse_custom_gate(data[i:j+1])
             data = data[:i] + data[j+1:]

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -243,6 +243,36 @@ class TestQASM(unittest.TestCase):
         self.assertEqual(c1.qubits, c2.qubits)
         self.assertListEqual(c1.gates, c2.gates)
 
+    def test_custom_gate_name_ending_in_gate(self):
+        """A custom gate whose name ends in ``gate`` must not confuse the
+        parser.
+        """
+        from pyzx.circuit.qasmparser import QASMParser
+        s1 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        gate flip_gate a, b, c {
+            h a;
+            cx a, b;
+            cx b, c;
+        }
+        qreg q[3];
+        flip_gate q[0], q[1], q[2];
+        """
+        s2 = """
+        OPENQASM 2.0;
+        include "qelib1.inc";
+        qreg q[3];
+        h q[0];
+        cx q[0], q[1];
+        cx q[1], q[2];
+        """
+        p = QASMParser()
+        c1 = p.parse(s1)
+        c2 = p.parse(s2)
+        self.assertEqual(c1.qubits, c2.qubits)
+        self.assertListEqual(c1.gates, c2.gates)
+
     def test_custom_gates_with_parameters(self):
         """A parametrised custom gate is instantiated by binding its argument.
 


### PR DESCRIPTION
## Description

The custom-gate definition stripping loop used `data.find("gate ")` which matched custom gate identifiers ending in `gate`, e.g., `flip_gate`. This raised a `ValueError` from `parse_custom_gate` even though the identifier name is valid.

## Related issue

#482

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.