### PR TITLE
tighten `qreg`/`creg` identifier validation and make errors more informative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Hence, occasionally changes will be backwards incompatible (although they will a
 - `string_to_phase` no longer returns a constant `Poly` for a numeric expression that misses its fast parsing path (e.g. the `(1)*1/4` form the TikZ importer produces for `\frac{\pi}{4}`): a parse result without free variables is now collapsed to a `Fraction`. Such a `Poly` compared and printed like its numeric value but broke code that branches on the phase type, e.g. `to_tensor`/`to_matrix` raised `Can't convert diagram with parameters to tensor` after a `to_tikz`/`tikz_to_graph` round trip (by @gauthamkanagaraj).
 - Correctly handling custom gate identifiers ending in `gate` (by @dlyongemallo).
 - `Circuit.from_qasm` routes through the symbolic grammar and accepts parenthesised subexpressions in gate phase arguments, e.g., `rz((pi/2 + pi/4)) q[0];` or `u3(pi, (a+b)/2, c) q[0];` (by @dlyongemallo).
+- Register identifier validation more closely matches OpenQASM 2 and 3 specs (by @dlyongemallo).
 
 ### Added
 - `Circuit.from_qasm` supports parametrised custom gate definitions, e.g., `gate phase_kick(theta) q { rz(theta) q; ... }` (by @dlyongemallo).

--- a/pyzx/circuit/qasmparser.py
+++ b/pyzx/circuit/qasmparser.py
@@ -213,6 +213,47 @@ class QASMParser(object):
         args = [s.strip() for s in rest.split(",") if s.strip()]
         return name, phases, args
 
+    _QASM2_NAME_RE = re.compile(r"[a-z][A-Za-z0-9_]*")
+
+    def _parse_register_declaration(self, spec: str) -> tuple[str, int]:
+        """Split a ``<name>[<size>]`` register declaration into ``(name, size)``.
+
+        Raises ``TypeError`` with a message describing the specific
+        problem (missing brackets, bad identifier, non-integer size).
+        """
+        if "[" not in spec:
+            raise TypeError(
+                "Invalid register declaration {!r}: expected "
+                "'<name>[<size>]'".format(spec))
+        regname, sizep = spec.split("[", 1)
+        if not sizep.endswith("]"):
+            raise TypeError(
+                "Invalid register declaration {!r}: missing closing "
+                "']'".format(spec))
+        if self.qasm_version == 2:
+            name_ok = bool(self._QASM2_NAME_RE.fullmatch(regname))
+            grammar_desc = "OpenQASM 2 rules, i.e., [a-z][A-Za-z0-9_]*"
+        else:
+            # Note: Python's ``str.isidentifier`` uses UAX #31, which is a
+            # superset of the OpenQASM 3 identifier grammar, but close enough.
+            name_ok = regname.isidentifier()
+            grammar_desc = "OpenQASM 3 rules"
+        if "[" in sizep[:-1] or not name_ok:
+            raise TypeError(
+                "Invalid register declaration {!r}: register names must "
+                "match {}".format(spec, grammar_desc))
+        try:
+            size = int(sizep[:-1])
+        except ValueError as exc:
+            raise TypeError(
+                "Invalid register declaration {!r}: size {!r} is not an "
+                "integer".format(spec, sizep[:-1])) from exc
+        if size <= 0:
+            raise TypeError(
+                "Invalid register declaration {!r}: size must be a positive "
+                "integer, got {}".format(spec, size))
+        return regname, size
+
     def parse_command(self, c: str, registers: dict[str, tuple[int, int]]) -> list[Gate]:
         gates: list[Gate] = []
         # Handle `if (creg == val) gate args;` before extract_command_parts,
@@ -232,8 +273,7 @@ class QASMParser(object):
         name, phases, args = self.extract_command_parts(c)
         if name in ("barrier", "id"): return gates
         if name == "creg":
-            regname, sizep = args[0].split("[", 1)
-            size = int(sizep[:-1])
+            regname, size = self._parse_register_declaration(args[0])
             self.cregisters[regname] = size
             return gates
         if name == "measure":
@@ -298,8 +338,7 @@ class QASMParser(object):
         if name in ("opaque",):
             raise TypeError("Unsupported operation {}".format(c))
         if name == "qreg":
-            regname, sizep = args[0].split("[",1)
-            size = int(sizep[:-1])
+            regname, size = self._parse_register_declaration(args[0])
             registers[regname] = (self.qubit_count, size)
             self.qubit_count += size
             return gates

--- a/tests/test_qasm.py
+++ b/tests/test_qasm.py
@@ -273,6 +273,64 @@ class TestQASM(unittest.TestCase):
         self.assertEqual(c1.qubits, c2.qubits)
         self.assertListEqual(c1.gates, c2.gates)
 
+    def test_qasm2_register_declaration(self):
+        """A malformed ``qreg``/``creg`` declaration in an OpenQASM 2 file
+        surfaces a ``TypeError`` specifying the specific problem.
+        """
+        from pyzx.circuit.qasmparser import QASMParser
+        header = 'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
+        cases = [
+            ('reset[0].0[1]',
+             r"register names must match OpenQASM 2 rules, i.e., \[a-z\]\[A-Za-z0-9_\]\*"),
+            ('reset.0[1]',
+             r"register names must match OpenQASM 2 rules, i.e., \[a-z\]\[A-Za-z0-9_\]\*"),
+            ('q-x[1]',
+             r"register names must match OpenQASM 2 rules, i.e., \[a-z\]\[A-Za-z0-9_\]\*"),
+            ('__q32_anc[3]',
+             r"register names must match OpenQASM 2 rules, i.e., \[a-z\]\[A-Za-z0-9_\]\*"),
+            ('Q[3]',
+             r"register names must match OpenQASM 2 rules, i.e., \[a-z\]\[A-Za-z0-9_\]\*"),
+            ('q6',
+             r"expected '<name>\[<size>\]'"),
+            ('q[6',
+             r"missing closing '\]'"),
+            ('q[abc]',
+             r"size 'abc' is not an integer"),
+            ('q[-1]',
+             r"size must be a positive integer, got -1"),
+            ('q[0]',
+             r"size must be a positive integer, got 0"),
+        ]
+        p = QASMParser()
+        for spec, expected in cases:
+            for kind in ('qreg', 'creg'):
+                with self.subTest(spec=spec, kind=kind):
+                    with self.assertRaisesRegex(TypeError, expected):
+                        p.parse(header + '{} {};\n'.format(kind, spec))
+        c = p.parse(header + 'qreg q_reg0[3];\n')
+        self.assertEqual(c.qubits, 3)
+
+    def test_qasm3_register_declaration(self):
+        """OpenQASM 3 relaxes the identifier grammar to allow leading
+        underscore, leading uppercase, and Unicode letter categories
+        (Lu/Ll/Lt/Lm/Lo/Nl).
+        """
+        from pyzx.circuit.qasmparser import QASMParser
+        header = 'OPENQASM 3.0;\ninclude "stdgates.inc";\n'
+        p = QASMParser()
+        # Accepted under QASM 3 but not QASM 2.
+        for name in ('__q32_anc', 'Q', 'γ', 'ñ', 'Ω', 'Ⅷ', '一'):
+            with self.subTest(name=name):
+                c = p.parse(header + 'qreg {}[3];\n'.format(name))
+                self.assertEqual(c.qubits, 3)
+        # Still rejected under QASM 3.
+        rejected = ['q.x', 'q-x', '1q', '🙂']
+        for name in rejected:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(
+                        TypeError, r"OpenQASM 3 rules"):
+                    p.parse(header + 'qreg {}[3];\n'.format(name))
+
     def test_custom_gates_with_parameters(self):
         """A parametrised custom gate is instantiated by binding its argument.
 


### PR DESCRIPTION
## Description

Validate register identifiers per OpenQASM 2 and 3 specs, and display a clearer error message on malformed identifiers. 

(Note: Python's `str.isidentifier` is used to validate OpenQASM 3 identifiers, but strictly speaking it allows a few Unicode classes not allowed by the OpenQASM 3 spec. It's close enough for this library's purposes without having to implement our own custom matcher.)

## Related issue

Fixes #482. (Clearer error messages for malformed identifiers motivated by #220.)

## Checklist
- [x] I have added/updated tests (for bugfixes, please include a regression test, for new features, include new tests either to an existing test file or a new file).
- [x] For new features: I have updated the documentation.
- [x] All the functions I added have a docstring parsable by sphinx (for a good example see `pyzx.extract.extract_circuit`).
- [x] I have added an entry to CHANGELOG.md describing my change.