### PR TITLE
Improve type safety in `pyzx.routing`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ module = "pyzx.optimize"
 ignore_errors = true
 
 [[tool.mypy.overrides]]
+module = "pyzx.routing.*"
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
 module = [
     "numpy.*",
     "igraph.*",

--- a/pyzx/generate.py
+++ b/pyzx/generate.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -37,6 +37,7 @@ import numpy as np
 from pyzx.circuit.gates import CNOT, ZPhase
 from pyzx.linalg import Mat2, MatLike
 
+from pyzx.routing.cnot_mapper import ElimMode
 from pyzx.routing.parity_maps import CNOT_tracker, Parity
 from pyzx.routing.phase_poly import PhasePoly, mat22partition
 
@@ -76,7 +77,7 @@ def spider(
     outputs: int,
     phase:Optional[Union[FractionLike, complex]]=None,
     ) -> BaseGraph:
-    """Returns a Graph containing a single spider of the specified type 
+    """Returns a Graph containing a single spider of the specified type
     and with the specified number of inputs and outputs."""
     if typ == "Z": typ = VertexType.Z
     elif typ == "X": typ = VertexType.X
@@ -264,13 +265,13 @@ def random_phase(add_t: bool, rand:Union[random.Random,types.ModuleType]=random)
     return Fraction(rand.randint(1,4),2)
 
 def cliffordTmeas(
-        qubits: int, 
-        depth: int, 
-        p_t:Optional[float]=None, 
-        p_s:Optional[float]=None, 
-        p_hsh:Optional[float]=None, 
-        p_cnot:Optional[float]=None, 
-        p_meas:Optional[float]=None, 
+        qubits: int,
+        depth: int,
+        p_t:Optional[float]=None,
+        p_s:Optional[float]=None,
+        p_hsh:Optional[float]=None,
+        p_cnot:Optional[float]=None,
+        p_meas:Optional[float]=None,
         backend:Optional[str]=None,
         seed:Optional[int]=None,
         sigma:Optional[float]=None
@@ -430,8 +431,8 @@ def cliffordT(
     return cliffordTmeas(qubits, depth, p_t, p_s, p_hsh, p_cnot, 0, backend, seed, sigma)
 
 def cliffords(
-        qubits: int, 
-        depth: int, 
+        qubits: int,
+        depth: int,
         no_hadamard:bool=False,
         t_gates:bool=False,
         backend:Optional[str]=None,
@@ -488,10 +489,10 @@ def cliffords(
         c = rand.randint(0, qubits-1)
         t = gaussian_random_qubit_target(rand,c,qubits,sigma)
         if accept(p_two_qubit,rand):
-            if no_hadamard or accept(p_cnot,rand): 
+            if no_hadamard or accept(p_cnot,rand):
                 es1.append((v, v+1))
                 ty += [VertexType.Z, VertexType.X]
-            else: 
+            else:
                 es2.append((v,v+1))
                 typ: VertexType = rand.choice([VertexType.Z, VertexType.X])
                 ty += [typ, typ]
@@ -575,7 +576,7 @@ def circuit_identity_commuting_controls(alpha:Fraction,beta:Fraction) -> Circuit
     """Returns the circuit UVU*V* where U=NCZ(2beta) and V=CX(2alpha).
     Since these operations commute this circuit is equal to the identity.
     See page 13 of https://arxiv.org/pdf/1705.11151.pdf for more details."""
-    cb = Circuit(2) 
+    cb = Circuit(2)
     cb.add_gate("NOT",0)
     cb.add_gate("ZPhase",0,beta)
     cb.add_gate("ZPhase",1,beta)
@@ -717,7 +718,7 @@ def phase_poly_from_gadgets(n_qubits: int, n_gadgets: int) -> Circuit:
     zphase_dict = {p: Fraction(1, 4) for p in parities}
     out_parities = mat22partition(Mat2.id(n_qubits))
     phase_poly = PhasePoly(zphase_dict, out_parities)
-    return phase_poly.rec_gray_synth("gauss", architecture=None)[0]
+    return phase_poly.rec_gray_synth(ElimMode.GAUSS_MODE, architecture=None)[0]
 
 
 def build_random_parity_map(qubits: int, n_cnots: int, circuit=None) -> MatLike:

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -18,7 +18,7 @@
 import math
 import itertools
 import sys
-from typing import Any, Iterator, Literal
+from typing import Any, Iterator, Literal, NoReturn, Sequence
 
 from pyzx.graph.base import BaseGraph
 if __name__ == '__main__':
@@ -63,7 +63,7 @@ class Architecture():
     Class that represents the architecture of the qubits to be taken into account when routing.
     """
 
-    def __init__(self, name: str, coupling_graph: BaseGraph | None = None, coupling_matrix=None, backend: str | None = None, qubit_map: list[int] | None = None, reduce_order: list[int] | None = None, **kwargs):
+    def __init__(self, name: str, coupling_graph: BaseGraph[int, tuple[int, int]] | None = None, coupling_matrix: np.ndarray | None = None, backend: str | None = None, qubit_map: list[int] | None = None, reduce_order: list[int] | None = None, **kwargs: Any):
         """
         Class that represents the architecture of the qubits to be taken into account when routing.
 
@@ -150,7 +150,7 @@ class Architecture():
 
         return reduce_order
 
-    def _place_qubits(self, start_vertex=None) -> list[int]:
+    def _place_qubits(self, start_vertex: int | None = None) -> list[int]:
         """
         Label the graph using depth-first traversal (DFT) with post-order labeling, starting at the start_vertex or the highest index node if none given.
         
@@ -161,11 +161,11 @@ class Architecture():
         if start_vertex is None:
             start_vertex = max(self.vertices)
 
-        visited = []
+        visited: list[int] = []
         # If logical qubit q is stored in physical qubit n, then qubit_map[q]=n
-        qubit_map = []
+        qubit_map: list[int] = []
         # DFT relabelling
-        def dft(current):
+        def dft(current: int) -> None:
             visited.append(current) # Mark node as visited
             # Find the neighbors of current.
             neighbors = self.get_neighboring_vertices(current)
@@ -178,7 +178,7 @@ class Architecture():
         dft(start_vertex)
         return qubit_map
         
-    def _non_cutting_vertices_hash(self, subgraph: list[int]) -> tuple[int, ...]:
+    def _non_cutting_vertices_hash(self, subgraph: Sequence[int]) -> tuple[int, ...]:
         """
         Converts a list of vertices, representing a subgraph, to a sorted tuple.
         
@@ -187,7 +187,7 @@ class Architecture():
         """
         return tuple(sorted(subgraph))
 
-    def pre_calc_non_cutting_vertices(self):
+    def pre_calc_non_cutting_vertices(self) -> NoReturn:
         """
         Adds to a dictionary all non-cutting vertices for every possible subset of qubits.
         
@@ -214,7 +214,7 @@ class Architecture():
             hash = self._non_cutting_vertices_hash(subgraph)
             self._non_cutting_vertices[hash] = non_cutting
     
-    def non_cutting_vertices(self, subgraph_vertices: list[int], pre_calc: bool = False) -> list[int]:
+    def non_cutting_vertices(self, subgraph_vertices: Sequence[int], pre_calc: bool = False) -> list[int]:
         """
         Find the non-cutting vertices for this subgraph.
 
@@ -236,7 +236,7 @@ class Architecture():
         return self._non_cutting_vertices[hash]
 
 
-    def _is_cutting(self, vertices: list[int] | None = None) -> list[bool]:
+    def _is_cutting(self, vertices: Sequence[int] | None = None) -> list[bool]:
         """
         Find the articulation points in a subgraph, these are the cutting vertices which if removed would cut the graph.
 
@@ -255,7 +255,7 @@ class Architecture():
         edges += [(v2, v1) for v1, v2 in edges]
         cutting = [False] * number_of_nodes
         parent = [-1] * number_of_nodes
-        def dfs(vertex):
+        def dfs(vertex: int) -> None:
             v = index_lookup[vertex]
             self.dfs_counter += 1
             discovery_times[v] = self.dfs_counter
@@ -301,7 +301,7 @@ class Architecture():
         """
         return set(self.graph.neighbors(vertex))
 
-    def to_quil_device(self):
+    def to_quil_device(self): # TODO: this legacy function doesn't work -- remove?
         """
         Convert the graph to a PyQuil NxDevive object.
 
@@ -315,7 +315,7 @@ class Architecture():
         device = NxDevice(topology)
         return device
 
-    def visualize(self, filename=None):
+    def visualize(self, filename: str | None = None) -> None:
         """
         Visualise the graph and save it as a png image file.
 
@@ -332,7 +332,7 @@ class Architecture():
             filename = self.name + ".png"
         plt.savefig(filename)
 
-    def floyd_warshall(self, subgraph_vertices: list[int], upper: bool = True, rec_vertices: list[int] = []) -> dict[tuple[int, int], tuple[int, list[tuple[int, int]]]]:
+    def floyd_warshall(self, subgraph_vertices: Sequence[int], upper: bool = True, rec_vertices: Sequence[int] = []) -> dict[tuple[int, int], tuple[int, list[tuple[int, int]]]]:
         """
         Implementation of the Floyd-Warshall algorithm to calculate the all-pair distances in a given graph.
 
@@ -342,8 +342,8 @@ class Architecture():
         :return: A dict with for each pair of qubits in the graph, a tuple with their distance and the corresponding shortest path
         """
         # https://en.wikipedia.org/wiki/Floyd%E2%80%93Warshall_algorithm
-        distances = {}
-        vertices = subgraph_vertices if subgraph_vertices is not None else self.vertices
+        distances: dict[tuple[int, int], tuple[int, list[tuple[int, int]]]] = {}
+        vertices = list(subgraph_vertices) if subgraph_vertices is not None else self.vertices
         for edge in self.graph.edges():
             src, tgt = self.graph.edge_st(edge)
             if src in vertices and tgt in vertices:
@@ -356,7 +356,7 @@ class Architecture():
                     distances[(tgt, src)] = (1, [(tgt, src)])
         for v in vertices:
             distances[(v, v)] = (0, [])
-        for v0 in vertices+vertices:
+        for v0 in vertices + vertices:
             for v1 in vertices:
                 for v2 in vertices:
                     # Consider the path v0 -> v1 -> v2 as a shortest path candidate for v0 -> v2
@@ -370,7 +370,7 @@ class Architecture():
                                                 distances[(v2, v1)][1] + distances[(v1, v0)][1])
         return distances
 
-    def shortest_path(self, start_qubit: int, end_qubit: int, qubits_to_use: list[int] | None = None) -> list[int] | None:
+    def shortest_path(self, start_qubit: int, end_qubit: int, qubits_to_use: Sequence[int] | None = None) -> list[int] | None:
         """
         Find the shortest path between two qubits in the graph using breadth-first search (BFS)
         
@@ -402,7 +402,7 @@ class Architecture():
                     visited.append(new_node)
         return None
 
-    def steiner_tree(self, start_qubit: int, qubits_to_use: list[int], upper: bool = True) -> Iterator[tuple[int, int] | None]:
+    def steiner_tree(self, start_qubit: int, qubits_to_use: Sequence[int], upper: bool = True) -> Iterator[tuple[int, int] | None]:
         """
         Approximates the steiner tree given the architecture, a root qubit and the other qubits that should be present.
         This is done using the pre-calculated all-pairs shortest distance and Prim's algorithm for creating a minimum spanning tree.
@@ -487,7 +487,7 @@ class Architecture():
             yield edge
         yield None
 
-    def rec_steiner_tree(self, start_qubit, terminal_qubits, usable_qubits, rec_qubits, upper=True):
+    def rec_steiner_tree(self, start_qubit: int, terminal_qubits: Sequence[int], usable_qubits: Sequence[int], rec_qubits: Sequence[int], upper: bool = True) -> Iterator[tuple[int, int] | None]:
         """
         Build a Steiner tree with recursive constraints for given qubits, connecting all terminal qubits using the min number of edges.
         
@@ -509,8 +509,8 @@ class Architecture():
         distances = self.floyd_warshall(usable_nodes, upper=upper, rec_vertices=rec_nodes)
         # Build the spanning tree of shortest paths with root start, containing at least nodes
         vertices = [start]
-        edges = []
-        steiner_pnts = []
+        edges: list[tuple[int, int]] = []
+        steiner_pnts: list[int] = []
         while nodes != []:
             options = [(node, v, *distances[(v, node)]) for node in nodes for v in (vertices + steiner_pnts) if
                         (v, node) in distances.keys()]
@@ -526,7 +526,7 @@ class Architecture():
 
         vs = {start} # Start with the root
         n_edges = len(edges)
-        yielded_edges = set()
+        yielded_edges: set[tuple[int, int]] = set()
         while len(yielded_edges) < n_edges:
             es = [e for e in edges for v in vs if e[0] == v] # Find all vertices connected to previously yielded vertices
             old_vs = [v for v in vs]
@@ -534,7 +534,8 @@ class Architecture():
                 yield (self.vertex2qubit(edge[0]), self.vertex2qubit(edge[1]))
                 vs.add(edge[1])
                 yielded_edges.add(edge)
-            [vs.remove(v) for v in old_vs]
+            for v in old_vs:
+                vs.remove(v)
         yield None # Signal next phase
         # Walk the tree bottom up to remove all ones.
         while len(edges) > 0:
@@ -548,7 +549,7 @@ class Architecture():
                     edges.remove(edge) # Remove it from the steiner tree
         yield None # Signal done
 
-    def transpose(self):
+    def transpose(self) -> 'Architecture':
         """
         Returns a transposed copy of the architecture with reversed qubit mapping.
         """
@@ -576,7 +577,7 @@ def dynamic_size_architecture_name(base_name: str, n_qubits: int) -> str:
     """
     return str(n_qubits) + "q-" + base_name
 
-def connect_vertices_in_line(vertices: list[int]) -> list[tuple[int, int]]:
+def connect_vertices_in_line(vertices: Sequence[int]) -> list[tuple[int, int]]:
     """
     Connects a list of vertices in a straight line.
     
@@ -585,7 +586,7 @@ def connect_vertices_in_line(vertices: list[int]) -> list[tuple[int, int]]:
     """
     return [(vertices[i], vertices[i+1]) for i in range(len(vertices)-1)]
 
-def connect_vertices_as_grid(width: int, height: int, vertices: list[int]) -> list[tuple[int, int]]:
+def connect_vertices_as_grid(width: int, height: int, vertices: Sequence[int]) -> list[tuple[int, int]]:
     """
     Connects vertices into a grid, with layout specified by width and height, vertices length much be equal to width * height.
     
@@ -603,7 +604,7 @@ def connect_vertices_as_grid(width: int, height: int, vertices: list[int]) -> li
         edges.extend(new_edges)
     return edges
 
-def create_line_architecture(n_qubits, backend=None, **kwargs):
+def create_line_architecture(n_qubits: int, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a linear architecture of connected qubits.
     
@@ -619,7 +620,7 @@ def create_line_architecture(n_qubits, backend=None, **kwargs):
     name = dynamic_size_architecture_name(LINE, n_qubits)
     return Architecture(name=name, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_circle_architecture(n_qubits, backend=None, **kwargs):
+def create_circle_architecture(n_qubits: int, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a circular architecture where qubits form a closed loop.
     
@@ -636,7 +637,7 @@ def create_circle_architecture(n_qubits, backend=None, **kwargs):
     name = dynamic_size_architecture_name(CIRCLE, n_qubits)
     return Architecture(name=name, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_square_architecture(n_qubits, backend=None, **kwargs):
+def create_square_architecture(n_qubits: int, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a square (2D) architecture of qubits, number of qubits must be a perfect square.
     
@@ -681,7 +682,7 @@ def create_5q_line_architecture(**kwargs):
     ])
     return Architecture(name=LINE_5Q, coupling_matrix=m, **kwargs)
 """
-def create_ibm_qx2_architecture(**kwargs):
+def create_ibm_qx2_architecture(**kwargs: Any) -> Architecture:
     """
     Creates the IBM QX2 architecture based on its standard 5-qubit coupling map.
     
@@ -697,7 +698,7 @@ def create_ibm_qx2_architecture(**kwargs):
     ])
     return Architecture(IBM_QX2, coupling_matrix=m, **kwargs)
 
-def create_ibm_qx4_architecture(**kwargs):
+def create_ibm_qx4_architecture(**kwargs: Any) -> Architecture:
     """
     Creates the IBM QX2 architecture based on its standard 5-qubit coupling map.
     
@@ -713,7 +714,7 @@ def create_ibm_qx4_architecture(**kwargs):
     ])
     return Architecture(IBM_QX4, coupling_matrix=m, **kwargs)
 
-def create_ibm_qx3_architecture(**kwargs):
+def create_ibm_qx3_architecture(**kwargs: Any) -> Architecture:
     """
     Creates the IBM QX3 architecture based on its standard 16-qubit coupling map.
     
@@ -741,7 +742,7 @@ def create_ibm_qx3_architecture(**kwargs):
     ])
     return Architecture(IBM_QX3, coupling_matrix=m, **kwargs)
 
-def create_ibm_qx5_architecture(**kwargs):
+def create_ibm_qx5_architecture(**kwargs: Any) -> Architecture:
     """
     Creates the IBM QX5 architecture based on its standard 16-qubit coupling map.
     
@@ -769,7 +770,7 @@ def create_ibm_qx5_architecture(**kwargs):
     ])
     return Architecture(IBM_QX5, coupling_matrix=m, **kwargs)
 
-def create_ibm_q20_tokyo_architecture(backend=None, **kwargs):
+def create_ibm_q20_tokyo_architecture(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the IBM Q20 Tokyo architecture with a 5*4 grid plus cross connections.
     
@@ -792,7 +793,7 @@ def create_ibm_q20_tokyo_architecture(backend=None, **kwargs):
     graph.add_edges(edges)
     return Architecture(name=IBM_Q20_TOKYO, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_ibmq_poughkeepsie(backend=None, **kwargs):
+def create_ibmq_poughkeepsie(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the IBM Q Poughkeepsie architecture, consisting of 20 qubits connected in a linear chain with a few additional cross-connections.
     
@@ -810,7 +811,7 @@ def create_ibmq_poughkeepsie(backend=None, **kwargs):
     graph.add_edges(edges)
     return Architecture(name=IBMQ_POUGHKEEPSIE, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_ibmq_singapore(backend=None, name=None, **kwargs):
+def create_ibmq_singapore(backend: str | None = None, name: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the IBM Q Singapore architecture with a modified linear structure and cross-links.
     
@@ -829,7 +830,7 @@ def create_ibmq_singapore(backend=None, name=None, **kwargs):
         return Architecture(name=IBMQ_BOEBLINGEN, coupling_graph=graph, backend=backend, **kwargs)
     return Architecture(name=IBMQ_SINGAPORE, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_rigetti_19q_acorn_architecture(backend=None, **kwargs):
+def create_rigetti_19q_acorn_architecture(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the Rigetti 19Q Acorn architecture, a 20-node graph.
     
@@ -846,7 +847,7 @@ def create_rigetti_19q_acorn_architecture(backend=None, **kwargs):
     return Architecture(RIGETTI_19Q_ACORN, coupling_graph=graph, backend=backend, **kwargs)
 
 
-def create_rigetti_16q_aspen_architecture(backend=None, **kwargs):
+def create_rigetti_16q_aspen_architecture(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the Rigetti 16Q Aspen architecture, a 16-node graph.
     
@@ -862,7 +863,8 @@ def create_rigetti_16q_aspen_architecture(backend=None, **kwargs):
     graph.add_edges(edges)
     return Architecture(RIGETTI_16Q_ASPEN, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_sycamore_like(backend=None, **kwargs):
+
+def create_sycamore_like(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a Sycamore-like architecture inspired by Google's Sycamore topology, a 20-qubit architecture.
     
@@ -879,10 +881,11 @@ def create_sycamore_like(backend=None, **kwargs):
     graph.add_edges(edges)
     return Architecture(SYCAMORE_LIKE, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_rigetti_8q_agave_architecture(**kwargs):
+def create_rigetti_8q_agave_architecture(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
-    Creates the Rigetti 8Q Agave architecture, an 8-qubit architecture using tghe standard Rigetti Agave coupling map.
-    
+    Creates the Rigetti 8Q Agave architecture, an 8-qubit architecture using the standard Rigetti Agave coupling map.
+
+    :param backend: Backend associated with the architecture, default None
     :param **kwargs: Additional arguments passed
     :return: A Rigetti 8Q Agave 8-qubit architecture
     """
@@ -899,7 +902,7 @@ def create_rigetti_8q_agave_architecture(**kwargs):
     ])
     return Architecture(RIGETTI_8Q_AGAVE, coupling_matrix=m, **kwargs)
 
-def create_recursive_architecture(**kwargs):
+def create_recursive_architecture(**kwargs : Any) -> Architecture:
     """
     Creates a 9-qubit recursive architecture.
     
@@ -920,7 +923,7 @@ def create_recursive_architecture(**kwargs):
     ])
     return Architecture(name=REC_ARCH, coupling_matrix=m, **kwargs)
 
-def create_fully_connected_architecture(n_qubits=None, **kwargs):
+def create_fully_connected_architecture(n_qubits: int | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a fully connected architecture where each where each qubit is connected to every other qubit.
     
@@ -937,7 +940,7 @@ def create_fully_connected_architecture(n_qubits=None, **kwargs):
     name = dynamic_size_architecture_name(FULLY_CONNECTED, n_qubits)
     return Architecture(name, coupling_matrix=m, **kwargs)
 
-def create_dynamic_density_hamiltonian_architecture(n_qubits, density_prob=0.1, backend=None, **kwargs):
+def create_dynamic_density_hamiltonian_architecture(n_qubits: int, density_prob: float = 0.1, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a randomly connected architecture with user-defined edge density.
     
@@ -947,19 +950,19 @@ def create_dynamic_density_hamiltonian_architecture(n_qubits, density_prob=0.1, 
     :param **kwargs: Additional arguments passed
     :return: A graph-based architecture with specified qubit count and edge density
     """
-    graph = Graph(backend=backend)
+    graph: BaseGraph[int, Any] = Graph(backend=backend)
     vertices = graph.add_vertices(n_qubits)
     edges = connect_vertices_in_line(vertices)
     n_edges = int(density_prob*n_qubits*(n_qubits-1)/2) - n_qubits+1 # Number of edges still to add.
     if n_edges > 0:
         possible_edges = [(v1, v2) for i, v1 in enumerate(vertices) for v2 in vertices[i+2:]]
-        indices = np.random.choice(len(possible_edges), n_edges, replace=False)
-        edges.extend([possible_edges[i] for i in indices])
+        new_edges = np.random.choice(len(possible_edges), n_edges, replace=False)
+        edges.extend([possible_edges[i] for i in new_edges])
     graph.add_edges(edges)
     name = dynamic_size_architecture_name(DENSITY+str(density_prob), n_qubits)
     return Architecture(name=name, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_dynamic_density_tree_architecture(n_qubits, density_prob=0.1, backend=None, **kwargs):
+def create_dynamic_density_tree_architecture(n_qubits: int, density_prob: float = 0.1, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a random tree-based architecture with additional edges to control density.
     
@@ -995,20 +998,21 @@ def create_dynamic_density_tree_architecture(n_qubits, density_prob=0.1, backend
             child_indices = np.random.choice(indices, n_children, replace=False)
             children = [vertices[child] for child in child_indices]
             edges += [(parent, child) for child in children]
-            [indices.remove(i) for i in child_indices]
+            for i in child_indices:
+                indices.remove(i)
             stack += children
     n_edges = int(density_prob*n_qubits*(n_qubits-1)/2) - len(edges) # Number of edges still to add.
     if n_edges > 0:
         possible_edges = [(v1, v2) for i, v1 in enumerate(vertices) for v2 in vertices[i+1:] if (v1,v2) not in edges and v1!=v2 and (v2,v1) not in edges]
-        indices = np.random.choice(len(possible_edges), n_edges, replace=False)
-        edges.extend([possible_edges[i] for i in indices])
+        new_edges = np.random.choice(len(possible_edges), n_edges, replace=False)
+        edges.extend([possible_edges[i] for i in new_edges])
     graph.add_edges(edges)
     # Make the coupling graph and adjust the numbering
     name = dynamic_size_architecture_name(DENSITY+str(density_prob), n_qubits)
     arch = Architecture(name=name, coupling_graph=graph, **kwargs)
     return arch
 
-def create_dynamic_density_architecture(n_qubits, density_prob=0.1, backend=None, **kwargs):
+def create_dynamic_density_architecture(n_qubits: int, density_prob: float = 0.1, backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates a randomly connected architecture with specified edge density, ensuring full connectivity.
     
@@ -1026,7 +1030,7 @@ def create_dynamic_density_architecture(n_qubits, density_prob=0.1, backend=None
             graph.add_edge(v,u)
     # Make sure it is connected
     to_explore = set(vertices)
-    explored = set()
+    explored: set[int] = set()
     while to_explore:
         # Pick a random root
         root = np.random.choice(tuple(to_explore))
@@ -1049,7 +1053,7 @@ def create_dynamic_density_architecture(n_qubits, density_prob=0.1, backend=None
     arch = Architecture(name=name, coupling_graph=graph, **kwargs)
     return arch
 
-def create_ibm_rochester(backend=None, **kwargs):
+def create_ibm_rochester(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the IBM Rochester architecture, a 53-qubit architecture.
     
@@ -1065,7 +1069,7 @@ def create_ibm_rochester(backend=None, **kwargs):
     graph.add_edges(edges)
     return Architecture(IBM_ROCHESTER, coupling_graph=graph, backend=backend, **kwargs)
 
-def create_google_sycamore(backend=None, **kwargs):
+def create_google_sycamore(backend: str | None = None, **kwargs: Any) -> Architecture:
     """
     Creates the Google Sycamore architecture, a 53-qubit architecture.
     
@@ -1090,7 +1094,7 @@ def create_google_sycamore(backend=None, **kwargs):
     arch = Architecture(GOOGLE_SYCAMORE, coupling_graph=graph, backend=backend, **kwargs)
     return arch
 
-def create_architecture(name: str | Architecture, **kwargs) -> Architecture:
+def create_architecture(name: str | Architecture, **kwargs: Any) -> Architecture:
     """
     Creates an architecture from a name.
 
@@ -1131,7 +1135,7 @@ def create_architecture(name: str | Architecture, **kwargs) -> Architecture:
     else:
         raise KeyError("name" + str(name) + "not recognized as architecture name. Please use one of", *architectures)
 
-def colored_print_9X9(np_array):
+def colored_print_9X9(np_array: np.ndarray) -> None:
     """
     Prints a 9x9 numpy array with colors representing their distance in a 9x9 square architecture
     :param np_array:  the array

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -15,18 +15,19 @@
 # limitations under the License.
 
 
-from collections.abc import Iterator, Sequence
-import math
 import itertools
+import math
 import sys
-from typing import Any, Literal, NoReturn
+from collections.abc import Iterator, Sequence
+from typing import Any, Literal
 
 from pyzx.graph.base import BaseGraph
+
 if __name__ == '__main__':
     sys.path.append('..')
-from ..graph.graph import Graph
-
 import numpy as np
+
+from ..graph.graph import Graph
 
 SQUARE = "square"
 LINE = "line"
@@ -187,7 +188,7 @@ class Architecture:
         """
         return tuple(sorted(subgraph))
 
-    def pre_calc_non_cutting_vertices(self) -> NoReturn:
+    def pre_calc_non_cutting_vertices(self) -> None:
         """
         Adds to a dictionary all non-cutting vertices for every possible subset of qubits.
         
@@ -321,8 +322,8 @@ class Architecture:
 
         :param filename: The filename of the image to be saved, default None
         """
-        import networkx as nx
         import matplotlib.pyplot as plt
+        import networkx as nx
         plt.switch_backend('agg')
         g = nx.Graph()
         g.add_nodes_from(self.vertices)
@@ -900,7 +901,7 @@ def create_rigetti_8q_agave_architecture(backend: str | None = None, **kwargs: A
         [0, 0, 0, 0, 0, 1, 0, 1],
         [1, 0, 0, 0, 0, 0, 1, 0]
     ])
-    return Architecture(RIGETTI_8Q_AGAVE, coupling_matrix=m, **kwargs)
+    return Architecture(RIGETTI_8Q_AGAVE, backend=backend, coupling_matrix=m, **kwargs)
 
 def create_recursive_architecture(**kwargs : Any) -> Architecture:
     """

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -301,7 +301,7 @@ class Architecture():
         """
         return set(self.graph.neighbors(vertex))
 
-    def to_quil_device(self): # TODO: this legacy function doesn't work -- remove?
+    def to_quil_device(self): # type: ignore # TODO: this legacy function doesn't work -- remove?
         """
         Convert the graph to a PyQuil NxDevive object.
 

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -18,8 +18,7 @@
 import math
 import itertools
 import sys
-from typing import Any, Dict, Iterator, List, Set, Tuple, Optional, Union
-from typing_extensions import Literal
+from typing import Any, Iterator, Literal
 
 from pyzx.graph.base import BaseGraph
 if __name__ == '__main__':
@@ -64,7 +63,7 @@ class Architecture():
     Class that represents the architecture of the qubits to be taken into account when routing.
     """
 
-    def __init__(self, name: str, coupling_graph: Optional[BaseGraph]=None, coupling_matrix=None, backend: Optional[str]=None, qubit_map: Optional[List[int]] = None, reduce_order: Optional[List[int]]=None, **kwargs):
+    def __init__(self, name: str, coupling_graph: BaseGraph | None = None, coupling_matrix=None, backend: str | None = None, qubit_map: list[int] | None = None, reduce_order: list[int] | None = None, **kwargs):
         """
         Class that represents the architecture of the qubits to be taken into account when routing.
 
@@ -106,11 +105,11 @@ class Architecture():
 
         # Pre-calculated distances between all pairs of qubits in the architecture
         # See :func:`pre_calc_distances` for more details
-        self.distances: Optional[Dict[Literal["upper", "full"], List[Dict[Tuple[int,int], Tuple[int,List[Tuple[int,int]]]]]]] = None
+        self.distances: dict[Literal["upper", "full"], list[dict[tuple[int, int], tuple[int, list[tuple[int, int]]]]]] | None = None
 
         self.n_qubits = len(self.vertices)
         self.reduce_order = self._get_reduce_order() if reduce_order is None else reduce_order
-        self._non_cutting_vertices: Dict[Tuple[int, ...], List[int]] = {}
+        self._non_cutting_vertices: dict[tuple[int, ...], list[int]] = {}
 
     def qubit2vertex(self, qubit: int) -> int:
         """Get the internal graph vertex index for a logical architecture qubit."""
@@ -120,7 +119,7 @@ class Architecture():
         """Get the logical architecture qubit for an internal graph vertex index."""
         return int(self.graph.qubit(vertex))
 
-    def pre_calc_distances(self) -> Dict[Literal["upper", "full"], List[Dict[Tuple[int,int], Tuple[int,List[Tuple[int,int]]]]]]:
+    def pre_calc_distances(self) -> dict[Literal["upper", "full"], list[dict[tuple[int, int], tuple[int, list[tuple[int, int]]]]]]:
         """
         Pre-calculates the distances between all pairs of qubits in the architecture.
 
@@ -132,7 +131,7 @@ class Architecture():
         return {"upper": [self.floyd_warshall(self.vertices[until:], upper=True) for until, v in enumerate(self.vertices)],
                 "full": [self.floyd_warshall(self.vertices[:until+1], upper=False) for until, v in enumerate(self.vertices)]}
 
-    def _get_reduce_order(self) -> List[int]:
+    def _get_reduce_order(self) -> list[int]:
         """
         Determines reduction order by iteratively removing the largest labelled leaf node.
 
@@ -151,7 +150,7 @@ class Architecture():
 
         return reduce_order
 
-    def _place_qubits(self, start_vertex=None) -> List[int]:
+    def _place_qubits(self, start_vertex=None) -> list[int]:
         """
         Label the graph using depth-first traversal (DFT) with post-order labeling, starting at the start_vertex or the highest index node if none given.
         
@@ -179,7 +178,7 @@ class Architecture():
         dft(start_vertex)
         return qubit_map
         
-    def _non_cutting_vertices_hash(self, subgraph: List[int]) -> Tuple[int, ...]:
+    def _non_cutting_vertices_hash(self, subgraph: list[int]) -> tuple[int, ...]:
         """
         Converts a list of vertices, representing a subgraph, to a sorted tuple.
         
@@ -199,7 +198,7 @@ class Architecture():
         raise NotImplementedError("pre calculation non cutting vertices")
 
         qubits = [i for i in range(self.n_qubits)]
-        def collect_non_cutting(qubits: List[int]) -> List[Tuple[List[int], List[int]]]:
+        def collect_non_cutting(qubits: list[int]) -> list[tuple[list[int], list[int]]]:
             if qubits == []:
                 return []
             vertices = [self.vertices[q] for q in qubits]
@@ -215,7 +214,7 @@ class Architecture():
             hash = self._non_cutting_vertices_hash(subgraph)
             self._non_cutting_vertices[hash] = non_cutting
     
-    def non_cutting_vertices(self, subgraph_vertices: List[int], pre_calc: bool=False) -> List[int]:
+    def non_cutting_vertices(self, subgraph_vertices: list[int], pre_calc: bool = False) -> list[int]:
         """
         Find the non-cutting vertices for this subgraph.
 
@@ -237,7 +236,7 @@ class Architecture():
         return self._non_cutting_vertices[hash]
 
 
-    def _is_cutting(self, vertices: Optional[List[int]]=None) -> List[bool]:
+    def _is_cutting(self, vertices: list[int] | None = None) -> list[bool]:
         """
         Find the articulation points in a subgraph, these are the cutting vertices which if removed would cut the graph.
 
@@ -249,7 +248,7 @@ class Architecture():
             vertices = self.vertices
         number_of_nodes = len(vertices)
         discovery_times = [-1]*number_of_nodes
-        lows: List[int] = [len(vertices)*2]*number_of_nodes
+        lows: list[int] = [len(vertices)*2]*number_of_nodes
         index_lookup = {self.vertices[v]:i for i, v in enumerate(vertices)}
         self.dfs_counter = 0
         edges = [e for e in self.graph.edges() if e[0] in vertices and e[1] in vertices]
@@ -283,7 +282,7 @@ class Architecture():
         del self.dfs_counter
         return cutting
                     
-    def get_neighboring_qubits(self, qubit: int) -> Set[int]:
+    def get_neighboring_qubits(self, qubit: int) -> set[int]:
         """
         Given a qubit, finds all neighboring qubits in the graph.
 
@@ -293,7 +292,7 @@ class Architecture():
         vertex = self.qubit2vertex(qubit)
         return set(self.vertex2qubit(q) for q in self.get_neighboring_vertices(vertex))
 
-    def get_neighboring_vertices(self, vertex: int) -> Set[int]:
+    def get_neighboring_vertices(self, vertex: int) -> set[int]:
         """
         From a given vertex location, finds all neighboring vertices in the graph.
 
@@ -333,7 +332,7 @@ class Architecture():
             filename = self.name + ".png"
         plt.savefig(filename)
 
-    def floyd_warshall(self, subgraph_vertices: List[int], upper: bool=True, rec_vertices: List[int]=[]) -> Dict[Tuple[int,int], Tuple[int,List[Tuple[int,int]]]]:
+    def floyd_warshall(self, subgraph_vertices: list[int], upper: bool = True, rec_vertices: list[int] = []) -> dict[tuple[int, int], tuple[int, list[tuple[int, int]]]]:
         """
         Implementation of the Floyd-Warshall algorithm to calculate the all-pair distances in a given graph.
 
@@ -371,7 +370,7 @@ class Architecture():
                                                 distances[(v2, v1)][1] + distances[(v1, v0)][1])
         return distances
 
-    def shortest_path(self, start_qubit: int, end_qubit: int, qubits_to_use: Optional[List[int]]=None) -> Optional[List[int]]:
+    def shortest_path(self, start_qubit: int, end_qubit: int, qubits_to_use: list[int] | None = None) -> list[int] | None:
         """
         Find the shortest path between two qubits in the graph using breadth-first search (BFS)
         
@@ -403,7 +402,7 @@ class Architecture():
                     visited.append(new_node)
         return None
 
-    def steiner_tree(self, start_qubit: int, qubits_to_use: List[int], upper: bool=True) -> Iterator[Optional[Tuple[int,int]]]:
+    def steiner_tree(self, start_qubit: int, qubits_to_use: list[int], upper: bool = True) -> Iterator[tuple[int, int] | None]:
         """
         Approximates the steiner tree given the architecture, a root qubit and the other qubits that should be present.
         This is done using the pre-calculated all-pairs shortest distance and Prim's algorithm for creating a minimum spanning tree.
@@ -431,14 +430,14 @@ class Architecture():
         assert len(qubits_to_use) == len(set(qubits_to_use))
         
         # The vertices and edges of the generated tree
-        tree_vertices: Set[int] = {root}
-        edges: Set[Tuple[int,int]] = set()
+        tree_vertices: set[int] = {root}
+        edges: set[tuple[int, int]] = set()
         # Map with all distances between nodes with index <= root (if not upper) or index >= root (if upper), and the corresponding shortest paths
-        distances: Dict[Tuple[int,int], Tuple[int,List[Tuple[int,int]]]] = self.distances["upper"][root] if upper else self.distances["full"][root]
+        distances: dict[tuple[int, int], tuple[int, list[tuple[int, int]]]] = self.distances["upper"][root] if upper else self.distances["full"][root]
         # Nodes that are not yet in the tree
         remaining_nodes = set(n for n in target_nodes if n != root)
         # Non-target nodes added to the tree
-        steiner_pnts: Set[int] = set()
+        steiner_pnts: set[int] = set()
 
         while remaining_nodes:
             # Each candidate is a tuple of (tree node, candidate, distance, path)
@@ -469,7 +468,7 @@ class Architecture():
         # Compute all the edges of the steiner tree in BFS order, starting from the root
         visited = {root}
         queue = [root]
-        generated_edges: List[Tuple[int,int]] = []
+        generated_edges: list[tuple[int, int]] = []
         
         while queue != []:
             node = queue.pop(0)
@@ -558,7 +557,7 @@ class Architecture():
         arch = Architecture(self.name + "_transpose", coupling_graph=self.graph, qubit_map=qubit_map)
         return arch
         
-    def arities(self) -> List[Tuple[int, int]]:
+    def arities(self) -> list[tuple[int, int]]:
         """
         Returns a list of tuples (i, arity) where i is the index of each node and arity is the number of neighbors,
         sorted by decreasing arity.
@@ -577,7 +576,7 @@ def dynamic_size_architecture_name(base_name: str, n_qubits: int) -> str:
     """
     return str(n_qubits) + "q-" + base_name
 
-def connect_vertices_in_line(vertices: List[int]) -> List[Tuple[int, int]]:
+def connect_vertices_in_line(vertices: list[int]) -> list[tuple[int, int]]:
     """
     Connects a list of vertices in a straight line.
     
@@ -586,7 +585,7 @@ def connect_vertices_in_line(vertices: List[int]) -> List[Tuple[int, int]]:
     """
     return [(vertices[i], vertices[i+1]) for i in range(len(vertices)-1)]
 
-def connect_vertices_as_grid(width: int, height: int, vertices: List[int]) -> List[Tuple[int,int]]:
+def connect_vertices_as_grid(width: int, height: int, vertices: list[int]) -> list[tuple[int, int]]:
     """
     Connects vertices into a grid, with layout specified by width and height, vertices length much be equal to width * height.
     
@@ -1091,7 +1090,7 @@ def create_google_sycamore(backend=None, **kwargs):
     arch = Architecture(GOOGLE_SYCAMORE, coupling_graph=graph, backend=backend, **kwargs)
     return arch
 
-def create_architecture(name: Union[str, Architecture], **kwargs) -> Architecture:
+def create_architecture(name: str | Architecture, **kwargs) -> Architecture:
     """
     Creates an architecture from a name.
 
@@ -1105,7 +1104,7 @@ def create_architecture(name: Union[str, Architecture], **kwargs) -> Architectur
     # IBM architectures are currently ignoring CNOT direction.
     if isinstance(name, Architecture):
         return name
-    arch_dict: Dict[str, Any] = {}
+    arch_dict: dict[str, Any] = {}
     arch_dict[SQUARE] = create_square_architecture
     arch_dict[LINE] = create_line_architecture
     arch_dict[FULLY_CONNECTED] = create_fully_connected_architecture

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -58,7 +58,7 @@ hamiltonian_path_architectures = [FULLY_CONNECTED, LINE, CIRCLE, SQUARE, IBM_QX4
                 IBM_QX5, IBM_Q20_TOKYO, RIGETTI_8Q_AGAVE, RIGETTI_16Q_ASPEN,
                 IBMQ_POUGHKEEPSIE]
 
-class Architecture():
+class Architecture:
     """
     Class that represents the architecture of the qubits to be taken into account when routing.
     """

--- a/pyzx/routing/architecture.py
+++ b/pyzx/routing/architecture.py
@@ -15,16 +15,16 @@
 # limitations under the License.
 
 
+from collections.abc import Iterator, Sequence
 import math
 import itertools
 import sys
-from typing import Any, Iterator, Literal, NoReturn, Sequence
+from typing import Any, Literal, NoReturn
 
 from pyzx.graph.base import BaseGraph
 if __name__ == '__main__':
     sys.path.append('..')
 from ..graph.graph import Graph
-#from pyzx.graph.base import BaseGraph # TODO fix the right graph import - one of many - right backend etc
 
 import numpy as np
 

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -4,18 +4,11 @@ import numpy as np
 
 from enum import Enum
 
-from numpy.typing import NDArray
-
 from pyzx.circuit import Circuit
-
-from ..linalg import Mat2
-from .architecture import (
-    Architecture,
-    create_fully_connected_architecture,
-)
-from .parity_maps import CNOT_tracker
+from pyzx.linalg import Mat2
+from .architecture import Architecture, create_fully_connected_architecture
 from .machine_learning import GeneticAlgorithm, ParticleSwarmOptimization
-
+from .parity_maps import CNOT_tracker
 from .steiner import rec_steiner_gauss as steiner_gauss
 
 

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -242,7 +242,7 @@ def permuted_gauss(
     x: CNOT_tracker | None = None,
     y: CNOT_tracker | None = None,
     **kwargs: Any,
-) -> tuple[list[int], Circuit, int]:
+) -> tuple[list[int], CNOT_tracker, int]:
     """
     Applies gaussian elimination to the given matrix, finding an optimal
     permutation of the matrix to reduce the number of CNOT gates.
@@ -381,7 +381,7 @@ def sequential_gauss(
             )
             # if not col and not row:
             #    perm = current_perm
-            circuits.append(circuit)  # type: ignore # Store the extracted circuit
+            circuits.append(circuit)  # Store the extracted circuit
             # Update the new permutation
             current_perm = list(perm)
             if col:

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -83,7 +83,7 @@ class FitnessFunction:
         """
         Creates and returns a fitness function using the given metric.
 
-        :param metric_func: The metric to use for the fitness function
+        :param metric: The metric to use for the fitness function
         :param mode: The type of Gaussian elimination to be used
         :param matrix: A Mat2 parity map to route.
         :param architecture: The architecture to take into account when routing

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -276,11 +276,11 @@ def permuted_gauss(
             fitness_func,
         )
         permsize = len(matrix.data) if row else len(matrix.data[0])
-        best_permutation = optimizer.find_optimum(
+        best_permutation = np.array(optimizer.find_optimum(
             permsize, n_iterations, continued=True
-        )
+        ))
     else:
-        best_permutation = np.arange(len(matrix.data))
+        best_permutation = np.arange(len(matrix.data)).tolist()
 
     n_qubits = len(matrix.data)
     row_perm = best_permutation if row else np.arange(len(matrix.data))

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from enum import Enum
-from typing import List, Optional, Tuple
 
 from pyzx.circuit import Circuit
 
@@ -77,8 +76,8 @@ class FitnessFunction(object):
         self,
         metric: CostMetric,
         matrix: Mat2,
-        mode: Optional[ElimMode],
-        architecture: Optional[Architecture],
+        mode: ElimMode | None,
+        architecture: Architecture | None,
         row: bool = True,
         col: bool = True,
         full_reduce: bool = True,
@@ -136,10 +135,10 @@ class FitnessFunction(object):
 
 
 def gauss(
-    mode: Optional[ElimMode],
+    mode: ElimMode | None,
     matrix: Mat2,
-    architecture: Optional[Architecture] = None,
-    permutation: Optional[List[int]] = None,
+    architecture: Architecture | None = None,
+    permutation: list[int] | None = None,
     try_transpose: bool = False,
     **kwargs,
 ) -> int:
@@ -234,8 +233,8 @@ def gauss(
 
 def permuted_gauss(
     matrix: Mat2,
-    mode: Optional[ElimMode] = None,
-    architecture: Optional[Architecture] = None,
+    mode: ElimMode | None = None,
+    architecture: Architecture | None = None,
     population_size: int = 30,
     crossover_prob: float = 0.8,
     mutate_prob: float = 0.2,
@@ -243,11 +242,11 @@ def permuted_gauss(
     row: bool = True,
     col: bool = True,
     full_reduce: bool = True,
-    fitness_func: Optional[FitnessFunction] = None,
+    fitness_func: FitnessFunction | None = None,
     x=None,
     y=None,
     **kwargs,
-) -> Tuple[List[int], Circuit, int]:
+) -> tuple[list[int], Circuit, int]:
     """
     Applies gaussian elimination to the given matrix, finding an optimal
     permutation of the matrix to reduce the number of CNOT gates.
@@ -311,10 +310,10 @@ def permuted_gauss(
 
 
 def sequential_gauss(
-    matrices: List[Mat2],
-    mode: Optional[ElimMode] = None,
-    architecture: Optional[Architecture] = None,
-    fitness_func: Optional[FitnessFunction] = None,
+    matrices: list[Mat2],
+    mode: ElimMode | None = None,
+    architecture: Architecture | None = None,
+    fitness_func: FitnessFunction | None = None,
     input_perm: bool = True,
     output_perm: bool = True,
     swarm_size: int = 15,
@@ -324,7 +323,7 @@ def sequential_gauss(
     pso_mutation: float = 0.2,
     full_reduce: bool = True,
     **kwargs,
-) -> Tuple[List[CNOT_tracker], List[List[int]], int]:
+) -> tuple[list[CNOT_tracker], list[list[int]], int]:
     """
     Applies architecture-aware Gaussian elimination to multiple matrices,
     sharing the optimization passes when using ParticleSwarmOptimization modes.
@@ -348,8 +347,8 @@ def sequential_gauss(
     """
     n_qubits = len(matrices[0].data)
     kwargs["full_reduce"] = full_reduce
-    circuits: List[CNOT_tracker]
-    permutations: List[List[int]] = []
+    circuits: list[CNOT_tracker]
+    permutations: list[list[int]] = []
     # print(mode)
     # print(*matrices, sep="\n\n")
     if mode in basic_elim_modes or mode is None:

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -1,10 +1,10 @@
-from typing import Any, Callable
+from enum import Enum
+from typing import Any
 
 import numpy as np
 
-from enum import Enum
-
 from pyzx.linalg import Mat2
+
 from .architecture import Architecture, create_fully_connected_architecture
 from .machine_learning import GeneticAlgorithm, ParticleSwarmOptimization
 from .parity_maps import CNOT_tracker
@@ -100,33 +100,28 @@ class FitnessFunction:
         self.n_qubits = architecture.n_qubits if architecture else matrix.cols()
         self.kwargs = kwargs
 
-    def _make_function(self) -> Callable[[list[int]], int]:
-        def fitness_func(permutation: list[int]) -> int:
-            row_perm = permutation if self.row else np.arange(len(self.matrix.data))
-            col_perm = permutation if self.col else np.arange(len(self.matrix.data[0]))
-            circuit = CNOT_tracker(self.n_qubits)
-            mat = Mat2([[self.matrix.data[r][c] for c in col_perm] for r in row_perm])
-            gauss(
-                self.mode,
-                mat,
-                architecture=self.architecture,
-                y=circuit,
-                full_reduce=self.full_reduce,
-                **self.kwargs,
-            )
-            match self.metric:
-                case CostMetric.COMBINED:
-                    return circuit.cnot_depth() * 10000 + circuit.count_cnots()
-                case CostMetric.COUNT:
-                    return circuit.count_cnots()
-                case CostMetric.DEPTH:
-                    return circuit.cnot_depth()
-        
-        return fitness_func
-
     def __call__(self, permutation: list[int]) -> int:
-        f = self._make_function()
-        return f(permutation)
+        row_perm = permutation if self.row else np.arange(len(self.matrix.data))
+        col_perm = permutation if self.col else np.arange(len(self.matrix.data[0]))
+        circuit = CNOT_tracker(self.n_qubits)
+        mat = Mat2([[self.matrix.data[r][c] for c in col_perm] for r in row_perm])
+        gauss(
+            self.mode,
+            mat,
+            architecture=self.architecture,
+            y=circuit,
+            full_reduce=self.full_reduce,
+            **self.kwargs,
+        )
+        match self.metric:
+            case CostMetric.COMBINED:
+                return circuit.cnot_depth() * 10000 + circuit.count_cnots()
+            case CostMetric.COUNT:
+                return circuit.count_cnots()
+            case CostMetric.DEPTH:
+                return circuit.cnot_depth()
+            case _:
+                raise ValueError(f"Invalid cost metric '{self.metric}'")
 
 
 def gauss(

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from enum import Enum
 
-from pyzx.circuit import Circuit
 from pyzx.linalg import Mat2
 from .architecture import Architecture, create_fully_connected_architecture
 from .machine_learning import GeneticAlgorithm, ParticleSwarmOptimization

--- a/pyzx/routing/cnot_mapper.py
+++ b/pyzx/routing/cnot_mapper.py
@@ -1,6 +1,10 @@
+from typing import Any, Callable
+
 import numpy as np
 
 from enum import Enum
+
+from numpy.typing import NDArray
 
 from pyzx.circuit import Circuit
 
@@ -40,7 +44,7 @@ class ElimMode(Enum):
     PSO_STEINER_MODE = "pso_steiner"
     """Steiner Gauss elimination using Particle Swarm Optimization to find the best row permutation."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.value}"
 
 
@@ -63,11 +67,11 @@ class CostMetric(Enum):
     COUNT = "count"
     """Count the depth of the circuit"""
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.value}"
 
 
-class FitnessFunction(object):
+class FitnessFunction:
     """
     A fitness function that calculates the cost of the gates needed for a given permutation.
     """
@@ -81,7 +85,7 @@ class FitnessFunction(object):
         row: bool = True,
         col: bool = True,
         full_reduce: bool = True,
-        **kwargs,
+        **kwargs: Any,
     ):
         """
         Creates and returns a fitness function using the given metric.
@@ -104,15 +108,8 @@ class FitnessFunction(object):
         self.n_qubits = architecture.n_qubits if architecture else matrix.cols()
         self.kwargs = kwargs
 
-    def _make_function(self):
-        if self.metric == CostMetric.COMBINED:
-            f = lambda c: c.cnot_depth() * 10000 + c.count_cnots()
-        elif self.metric == CostMetric.COUNT:
-            f = lambda c: c.count_cnots()
-        elif self.metric == CostMetric.DEPTH:
-            f = lambda c: c.cnot_depth()
-
-        def fitness_func(permutation):
+    def _make_function(self) -> Callable[[list[int]], int]:
+        def fitness_func(permutation: list[int]) -> int:
             row_perm = permutation if self.row else np.arange(len(self.matrix.data))
             col_perm = permutation if self.col else np.arange(len(self.matrix.data[0]))
             circuit = CNOT_tracker(self.n_qubits)
@@ -125,11 +122,17 @@ class FitnessFunction(object):
                 full_reduce=self.full_reduce,
                 **self.kwargs,
             )
-            return f(circuit)
-
+            match self.metric:
+                case CostMetric.COMBINED:
+                    return circuit.cnot_depth() * 10000 + circuit.count_cnots()
+                case CostMetric.COUNT:
+                    return circuit.count_cnots()
+                case CostMetric.DEPTH:
+                    return circuit.cnot_depth()
+        
         return fitness_func
 
-    def __call__(self, permutation):
+    def __call__(self, permutation: list[int]) -> int:
         f = self._make_function()
         return f(permutation)
 
@@ -140,7 +143,7 @@ def gauss(
     architecture: Architecture | None = None,
     permutation: list[int] | None = None,
     try_transpose: bool = False,
-    **kwargs,
+    **kwargs: Any,
 ) -> int:
     """
     Performs architecture-aware Gaussian Elimination on a matrix.
@@ -243,9 +246,9 @@ def permuted_gauss(
     col: bool = True,
     full_reduce: bool = True,
     fitness_func: FitnessFunction | None = None,
-    x=None,
-    y=None,
-    **kwargs,
+    x: CNOT_tracker | None = None,
+    y: CNOT_tracker | None = None,
+    **kwargs: Any,
 ) -> tuple[list[int], Circuit, int]:
     """
     Applies gaussian elimination to the given matrix, finding an optimal
@@ -305,8 +308,7 @@ def permuted_gauss(
     rank = gauss(
         mode, mat, architecture, x=x, y=circuit, full_reduce=full_reduce, **kwargs
     )
-    best_permutation = list(best_permutation)
-    return best_permutation, circuit, rank
+    return list(best_permutation), circuit, rank
 
 
 def sequential_gauss(
@@ -322,7 +324,7 @@ def sequential_gauss(
     p_crossover: float = 0.3,
     pso_mutation: float = 0.2,
     full_reduce: bool = True,
-    **kwargs,
+    **kwargs: Any,
 ) -> tuple[list[CNOT_tracker], list[list[int]], int]:
     """
     Applies architecture-aware Gaussian elimination to multiple matrices,
@@ -440,7 +442,7 @@ class StepFunction:
     A step function for the PSO algorithm.
     """
 
-    def __init__(self, matrices, mode, architecture, fitness_func, **kwargs):
+    def __init__(self, matrices: list[Mat2], mode: ElimMode, architecture: Architecture | None, fitness_func: FitnessFunction | None, **kwargs: Any):
         """
         Creates and returns a step function.
 
@@ -459,7 +461,7 @@ class StepFunction:
             Mat2(np.asarray(m.data).T.tolist()) for m in reversed(matrices)
         ]  # Reverse and transpose the parity matrices to create the reversed equivalent sequence
 
-    def __call__(self, initial_perm):
+    def __call__(self, initial_perm: list[int]) -> tuple[list[int], tuple[list[CNOT_tracker], list[list[int]]], int]:
         """
         Evaluates a candidate qubit permutation by running a forward and reverse sequence of architecture-aware Gaussian eliminations.
 

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -302,8 +302,7 @@ class ParticleSwarmOptimization:
         :return: The optimum solution for swarm
         """
         self._create_swarm(n_qubits)
-        best = self.swarm[0] # we use this variable instead of self.best_particle so mypy can tell it's not None
-        self.best_particle = best
+        self.best_particle = self.swarm[0]
         for i in range(n_steps):
             self._update_swarm()
             if not quiet:
@@ -311,13 +310,13 @@ class ParticleSwarmOptimization:
                     "PSO - Iteration",
                     i,
                     "best fitness:",
-                    best.best,
-                    best.best_point,
+                    self.best_particle.best,
+                    self.best_particle.best_point,
                 )
         if close_pool and self.pool:
             self.pool.close()
             self.pool.join()
-        return best.best_solution or ([], [])
+        return self.best_particle.best_solution or ([], [])
 
     @staticmethod
     def particle_update_func(args: tuple['Particle', 'Particle']) -> 'Particle':

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -15,15 +15,17 @@
 # limitations under the License.
 
 
+from collections.abc import Callable
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 import numpy as np
 from numpy.typing import ArrayLike, ArrayLike, NDArray
 
-from pyzx.routing.parity_maps import CNOT_tracker
+from .parity_maps import CNOT_tracker
 
-from .cnot_mapper import StepFunction
+if TYPE_CHECKING:
+    from .cnot_mapper import StepFunction
 
 
 class GeneticAlgorithm:
@@ -211,7 +213,7 @@ class ParticleSwarmOptimization:
     def __init__(
         self,
         swarm_size: int,
-        step_func: StepFunction,
+        step_func: "StepFunction",
         s_best_crossover: float,
         p_best_crossover: float,
         mutation: float,
@@ -222,7 +224,7 @@ class ParticleSwarmOptimization:
         Setup the optimizer
 
         :param swarm_size: Swarm size for the swarm optimization.
-        :param step_function: The step function to progress the swarm.
+        :param step_func: The step function to progress the swarm.
         :param s_best_crossover: The crossover percentage with the best particle in the swarm. Must be between 0.0 and 1.0.
         :param p_best_crossover: The crossover percentage with the personal best of a particle. Must be between 0.0 and 1.0.
         :param mutation: The mutation percentage of a particle. Must be between 0.0 and 1.0.
@@ -361,7 +363,7 @@ class Particle:
     def __init__(
         self,
         size: int,
-        step_func: StepFunction,
+        step_func: "StepFunction",
         s_best_crossover: float,
         p_best_crossover: float,
         mutation: float,

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -24,7 +24,7 @@ from numpy.typing import ArrayLike, ArrayLike, NDArray
 from pyzx.routing.parity_maps import CNOT_tracker
 
 from .cnot_mapper import StepFunction
-    
+
 
 class GeneticAlgorithm:
     """

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -15,17 +15,17 @@
 # limitations under the License.
 
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
 from typing import TYPE_CHECKING, Any
-import numpy as np
-from numpy.typing import ArrayLike, ArrayLike, NDArray
 
-from .parity_maps import CNOT_tracker
+import numpy as np
+from numpy.typing import NDArray
 
 if TYPE_CHECKING:
     from .cnot_mapper import StepFunction
+    from .parity_maps import CNOT_tracker
 
 
 class GeneticAlgorithm:
@@ -78,7 +78,7 @@ class GeneticAlgorithm:
             self.population_size, size=2, replace=False, p=selection_chance
         )
 
-    def _create_population(self, n: ArrayLike) -> None:
+    def _create_population(self, n: int | Sequence[int]) -> None:
         """
         Initialises the population with random permutations with size n and evaluates their fitness.
         Also creates a list of the weakest individuals - negative population.
@@ -95,7 +95,7 @@ class GeneticAlgorithm:
 
     def find_optimum(
         self, n_qubits: int, n_generations: int, initial_order: list[int] | None = None, n_child: int | None = None, continued: bool = False
-    ) -> np.ndarray:
+    ) -> list[int]:
         """
         Runs the genetic algorithm to find the best permutation over a number of generations.
 
@@ -170,7 +170,7 @@ class GeneticAlgorithm:
                 children.append(child)
         self._add_children(children)
 
-    def _crossover(self, parent1: NDArray, parent2: NDArray) -> list[int]:
+    def _crossover(self, parent1: Sequence[int], parent2: Sequence[int]) -> list[int]:
         """
         Performs ordered crossover between two parents.
 
@@ -291,7 +291,7 @@ class ParticleSwarmOptimization:
         # Start with 1 particle with initial permutation
         self.swarm[0].current = np.arange(n).tolist()
 
-    def find_optimum(self, n_qubits: int, n_steps: int, quiet: bool = True, close_pool: bool = True) -> tuple[list[CNOT_tracker], list[list[int]]]:
+    def find_optimum(self, n_qubits: int, n_steps: int, quiet: bool = True, close_pool: bool = True) -> tuple[list["CNOT_tracker"], list[list[int]]]:
         """
         Creates a swarm of n-qubits and determines the optimum fitness solution for a given number of steps
 
@@ -316,7 +316,11 @@ class ParticleSwarmOptimization:
         if close_pool and self.pool:
             self.pool.close()
             self.pool.join()
-        return self.best_particle.best_solution or ([], [])
+        
+        if not self.best_particle.best_solution:
+            raise ValueError("No valid solution found.")
+        
+        return self.best_particle.best_solution
 
     @staticmethod
     def particle_update_func(args: tuple['Particle', 'Particle']) -> 'Particle':
@@ -385,7 +389,7 @@ class Particle:
         self.current: list[int] = np.random.permutation(size).tolist()
         self.best_point = self.current
         self.best: int | None = None
-        self.best_solution: tuple[list[CNOT_tracker], list[list[int]]] | None = None
+        self.best_solution: tuple[list["CNOT_tracker"], list[list[int]]] | None = None
         self.s_crossover = int(s_best_crossover * size)
         self.p_crossover = int(p_best_crossover * size)
         self.mutation = int(mutation * size)
@@ -411,7 +415,7 @@ class Particle:
 
     def step(self, swarm_best: 'Particle') -> bool:
         """
-        Preform one optimisation step for the particle.
+        Perform one optimisation step for the particle.
 
         :param swarm_best: The best particle in the swarm
         :return: True, a better solution was found, False, no better solution was found
@@ -451,7 +455,7 @@ class Particle:
 
     def _crossover(self, particle: list[int], best_particle: list[int], n: int) -> list[int]:
         """
-        Preform a crossover between this particle and the best current particle.
+        Perform a crossover between this particle and the best current particle.
 
         :param particle: The current particle permutation
         :param best_particle: The highest scoring particle permutation
@@ -460,7 +464,8 @@ class Particle:
         """
         cross_idxs = np.random.choice(self.size, size=n, replace=False)
         new_particle = [-1] * len(particle)
-        new_particle[cross_idxs] = best_particle[cross_idxs]
+        for i in cross_idxs:
+            new_particle[i] = best_particle[i]
         idx = 0
         for i, gen in enumerate(new_particle):
             if gen == -1:  # skip over the parent1 part in child

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -17,7 +17,7 @@
 
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
-from typing import Any, List, Optional, Tuple
+from typing import Any
 import numpy as np
 
 
@@ -40,7 +40,7 @@ class GeneticAlgorithm:
         :param crossover_prob: Probability of crossover between individuals
         :param mutation_prob: Probability of mutation for an offspring
         :param fitness_func: Function to evaluate fitness of permutations
-        :param maximize: True, Maximise the fitness, False, Minimise the Fitness, default False 
+        :param maximize: True, Maximise the fitness, False, Minimise the Fitness, default False
         """
         self.population_size = population_size
         self.negative_population_size = int(np.sqrt(population_size))
@@ -50,7 +50,7 @@ class GeneticAlgorithm:
         self._sort = lambda l: l.sort(key=lambda x: x[1], reverse=maximize)
         self.maximize = maximize
         self.n_qubits = 0
-        self.population: List[Tuple[List[int], Any]] = []
+        self.population: list[tuple[list[int], Any]] = []
 
     def _select(self):
         """
@@ -211,7 +211,7 @@ class ParticleSwarmOptimization:
         p_best_crossover: float,
         mutation: float,
         maximize: bool = False,
-        n_threads: Optional[int] = None,
+        n_threads: int | None = None,
     ):
         """
         Setup the optimizer
@@ -231,8 +231,8 @@ class ParticleSwarmOptimization:
         self.mutation = mutation
         self.best_particle = None
         self.maximize = maximize
-        self.swarm: List[Particle] = []
-        self.pool: Optional[Pool] = None
+        self.swarm: list[Particle] = []
+        self.pool: Pool | None = None
         n_threads = (
             min(n_threads, cpu_count()) if n_threads is not None else cpu_count()
         )
@@ -369,7 +369,7 @@ class Particle:
         :param s_best_crossover: Proportion of genes inherited from the swarms best particle
         :param p_best_crossover: Proportion of genes inherited from the particles own best known position
         :param mutation: Mutation rate as a proportion of the permatation length
-        :param maximize: True, Maximise the fitness, False, Minimise the fitness, default False 
+        :param maximize: True, Maximise the fitness, False, Minimise the fitness, default False
         :param id: Id for the particle, default None
         """
         self.step_func = step_func

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -123,8 +123,8 @@ class GeneticAlgorithm:
         for _ in range(n_generations):
             self._update_population(n_child)
         if partial_solution and initial_order is not None:
-            return np.array(self.population[0][0] + initial_order[n_qubits:])
-        return np.array(self.population[0][0])
+            return np.array(self.population[0][0] + initial_order[n_qubits:]).tolist()
+        return np.array(self.population[0][0]).tolist()
 
     def _add_children(self, children: list[list[int]]) -> None:
         """

--- a/pyzx/routing/machine_learning.py
+++ b/pyzx/routing/machine_learning.py
@@ -17,9 +17,14 @@
 
 from multiprocessing import cpu_count
 from multiprocessing.pool import Pool
-from typing import Any
+from typing import Any, Callable
 import numpy as np
+from numpy.typing import ArrayLike, ArrayLike, NDArray
 
+from pyzx.routing.parity_maps import CNOT_tracker
+
+from .cnot_mapper import StepFunction
+    
 
 class GeneticAlgorithm:
     """
@@ -30,7 +35,7 @@ class GeneticAlgorithm:
         population_size: int,
         crossover_prob: float,
         mutation_prob: float,
-        fitness_func,
+        fitness_func: Callable[[list[int]], float],
         maximize: bool = False,
     ):
         """
@@ -52,7 +57,7 @@ class GeneticAlgorithm:
         self.n_qubits = 0
         self.population: list[tuple[list[int], Any]] = []
 
-    def _select(self):
+    def _select(self) -> NDArray:
         """
         Selects two parent indices from the population based on fitness-proportional selection.
         
@@ -71,14 +76,14 @@ class GeneticAlgorithm:
             self.population_size, size=2, replace=False, p=selection_chance
         )
 
-    def _create_population(self, n):
+    def _create_population(self, n: ArrayLike) -> None:
         """
         Initialises the population with random permutations with size n and evaluates their fitness.
         Also creates a list of the weakest individuals - negative population.
 
         :param n: The size of the random permutation
         """
-        population = [np.random.permutation(n) for _ in range(self.population_size)]
+        population = [[int(x) for x in np.random.permutation(n)] for _ in range(self.population_size)]
         self.population = [
             (list(chromosome), self.fitness_func(chromosome))
             for chromosome in population
@@ -87,8 +92,8 @@ class GeneticAlgorithm:
         self.negative_population = self.population[-self.negative_population_size :]
 
     def find_optimum(
-        self, n_qubits, n_generations, initial_order=None, n_child=None, continued=False
-    ):
+        self, n_qubits: int, n_generations: int, initial_order: list[int] | None = None, n_child: int | None = None, continued: bool = False
+    ) -> np.ndarray:
         """
         Runs the genetic algorithm to find the best permutation over a number of generations.
 
@@ -116,10 +121,10 @@ class GeneticAlgorithm:
         for _ in range(n_generations):
             self._update_population(n_child)
         if partial_solution and initial_order is not None:
-            return self.population[0] + initial_order[n_qubits:]
-        return self.population[0][0]
+            return np.array(self.population[0][0] + initial_order[n_qubits:])
+        return np.array(self.population[0][0])
 
-    def _add_children(self, children):
+    def _add_children(self, children: list[list[int]]) -> None:
         """
         Adds new children to the population and updates fitness scores.
 
@@ -141,13 +146,13 @@ class GeneticAlgorithm:
         ]
         self.population = self.population[: self.population_size]
 
-    def _update_population(self, n_child: int):
+    def _update_population(self, n_child: int) -> None:
         """
         Generates a new generation of children and integrates them into the population.
 
         :param n_child: The number of children
         """
-        children = []
+        children: list[list[int]] = []
         # Create a child from weak parents to avoid local optima
         p1, p2 = np.random.choice(self.negative_population_size, size=2, replace=False)
         child = self._crossover(
@@ -163,7 +168,7 @@ class GeneticAlgorithm:
                 children.append(child)
         self._add_children(children)
 
-    def _crossover(self, parent1, parent2):
+    def _crossover(self, parent1: NDArray, parent2: NDArray) -> list[int]:
         """
         Performs ordered crossover between two parents.
 
@@ -183,9 +188,9 @@ class GeneticAlgorithm:
             if parent_gen not in child:  # only add new genes
                 child[child_idx] = parent_gen
                 child_idx += 1
-        return child
+        return child.tolist()
 
-    def _mutate(self, parent):
+    def _mutate(self, parent: list[int]) -> list[int]:
         """
         Applies mutation by swapping two random elements in the permutation.
 
@@ -206,7 +211,7 @@ class ParticleSwarmOptimization:
     def __init__(
         self,
         swarm_size: int,
-        step_func, # type 'StepFunction'
+        step_func: StepFunction,
         s_best_crossover: float,
         p_best_crossover: float,
         mutation: float,
@@ -217,7 +222,7 @@ class ParticleSwarmOptimization:
         Setup the optimizer
 
         :param swarm_size: Swarm size for the swarm optimization.
-        :param step_function: The to progress the swarm.
+        :param step_function: The step function to progress the swarm.
         :param s_best_crossover: The crossover percentage with the best particle in the swarm. Must be between 0.0 and 1.0.
         :param p_best_crossover: The crossover percentage with the personal best of a particle. Must be between 0.0 and 1.0.
         :param mutation: The mutation percentage of a particle. Must be between 0.0 and 1.0.
@@ -229,7 +234,7 @@ class ParticleSwarmOptimization:
         self.s_crossover = s_best_crossover
         self.p_crossover = p_best_crossover
         self.mutation = mutation
-        self.best_particle = None
+        self.best_particle: Particle | None = None
         self.maximize = maximize
         self.swarm: list[Particle] = []
         self.pool: Pool | None = None
@@ -239,7 +244,7 @@ class ParticleSwarmOptimization:
         if n_threads > 1:
             self.pool = Pool(n_threads)
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         """
         Prepares the object state for pickling by removing non-serialisable fields.
 
@@ -251,7 +256,7 @@ class ParticleSwarmOptimization:
         del state["pool"]
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
         """
         Restores the object state after unpickling
 
@@ -262,7 +267,7 @@ class ParticleSwarmOptimization:
         # self.fitness_func = None
         self.pool = None
 
-    def _create_swarm(self, n):
+    def _create_swarm(self, n: int) -> None:
         """
         Initializes the swarm with random permutations.
 
@@ -282,9 +287,9 @@ class ParticleSwarmOptimization:
             for i in range(self.size)
         ]
         # Start with 1 particle with initial permutation
-        self.swarm[0].current = np.arange(n)
+        self.swarm[0].current = np.arange(n).tolist()
 
-    def find_optimum(self, n_qubits, n_steps, quiet=True, close_pool=True):
+    def find_optimum(self, n_qubits: int, n_steps: int, quiet: bool = True, close_pool: bool = True) -> tuple[list[CNOT_tracker], list[list[int]]]:
         """
         Creates a swarm of n-qubits and determines the optimum fitness solution for a given number of steps
 
@@ -295,7 +300,8 @@ class ParticleSwarmOptimization:
         :return: The optimum solution for swarm
         """
         self._create_swarm(n_qubits)
-        self.best_particle = self.swarm[0]
+        best = self.swarm[0] # we use this variable instead of self.best_particle so mypy can tell it's not None
+        self.best_particle = best
         for i in range(n_steps):
             self._update_swarm()
             if not quiet:
@@ -303,16 +309,16 @@ class ParticleSwarmOptimization:
                     "PSO - Iteration",
                     i,
                     "best fitness:",
-                    self.best_particle.best,
-                    self.best_particle.best_point,
+                    best.best,
+                    best.best_point,
                 )
         if close_pool and self.pool:
             self.pool.close()
             self.pool.join()
-        return self.best_particle.best_solution
+        return best.best_solution or ([], [])
 
     @staticmethod
-    def particle_update_func(args):
+    def particle_update_func(args: tuple['Particle', 'Particle']) -> 'Particle':
         """
         Update a single particle in the swarm using the current global best particle.
 
@@ -323,18 +329,19 @@ class ParticleSwarmOptimization:
         p.step(swarm_best)
         return p
 
-    def _update_swarm(self):
+    def _update_swarm(self) -> None:
         """
         Update the state of all particles in the swarm, after updating the method finds the best particle in the swarm.
         """
-        if self.pool is not None:
-            self.swarm = self.pool.map(
-                self.particle_update_func, [(self.best_particle, p) for p in self.swarm]
-            )
-        else:
-            self.swarm = [
-                self.particle_update_func((self.best_particle, p)) for p in self.swarm
-            ]
+        if self.best_particle is not None:
+            if self.pool is not None:
+                self.swarm = self.pool.map(
+                    self.particle_update_func, [(self.best_particle, p) for p in self.swarm]
+                )
+            else:
+                self.swarm = [
+                    self.particle_update_func((self.best_particle, p)) for p in self.swarm
+                ]
         if self.maximize:
             top = max(
                 self.swarm, key=lambda p: p.best if p.best is not None else -np.inf
@@ -353,13 +360,13 @@ class Particle:
     """
     def __init__(
         self,
-        size,
-        step_func,
-        s_best_crossover,
-        p_best_crossover,
-        mutation,
-        maximize=False,
-        id=None,
+        size: int,
+        step_func: StepFunction,
+        s_best_crossover: float,
+        p_best_crossover: float,
+        mutation: float,
+        maximize: bool = False,
+        id: int | None = None,
     ):
         """
         Creates and returns a single particle.
@@ -374,31 +381,34 @@ class Particle:
         """
         self.step_func = step_func
         self.size = size
-        self.current = np.random.permutation(size)
+        self.current: list[int] = np.random.permutation(size).tolist()
         self.best_point = self.current
-        self.best = None
-        self.best_solution = None
+        self.best: int | None = None
+        self.best_solution: tuple[list[CNOT_tracker], list[list[int]]] | None = None
         self.s_crossover = int(s_best_crossover * size)
         self.p_crossover = int(p_best_crossover * size)
         self.mutation = int(mutation * size)
         self.maximize = maximize
         self.id = id
 
-    def compare(self, x):
+    def compare(self, x: float | None) -> bool:
         """
         Compare a new fitness score to the current best.
 
         :param x: New score to compare
         :return: True, if it is the better than the best score
         """
+        if self.best is None:
+            return False
         if x is None:
             return True
+
         if self.maximize:
             return x < self.best
         else:
             return x > self.best
 
-    def step(self, swarm_best):
+    def step(self, swarm_best: 'Particle') -> bool:
         """
         Preform one optimisation step for the particle.
 
@@ -424,7 +434,7 @@ class Particle:
         self.current = new
         return is_better
 
-    def _mutate(self, particle):
+    def _mutate(self, particle: list[int]) -> list[int]:
         """
         Randomly mutate the particle by permuting a subset of its genes.
 
@@ -438,7 +448,7 @@ class Particle:
             new_particle[m_idxs[old_i]] = particle[m_idxs[new_i]]
         return new_particle
 
-    def _crossover(self, particle, best_particle, n):
+    def _crossover(self, particle: list[int], best_particle: list[int], n: int) -> list[int]:
         """
         Preform a crossover between this particle and the best current particle.
 
@@ -448,7 +458,7 @@ class Particle:
         :return: A new mutated particle permutation resulting from the crossover
         """
         cross_idxs = np.random.choice(self.size, size=n, replace=False)
-        new_particle = -1 * np.ones_like(particle)
+        new_particle = [-1] * len(particle)
         new_particle[cross_idxs] = best_particle[cross_idxs]
         idx = 0
         for i, gen in enumerate(new_particle):
@@ -463,7 +473,7 @@ class Particle:
 
 if __name__ == "__main__":
 
-    def fitness_func(chromosome):
+    def fitness_func(chromosome: list[int]) -> float:
         """
         Sample fitness function.
 

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -17,7 +17,7 @@
 
 from collections.abc import Iterable, Iterator
 from typing import Any
-from pyzx.circuit import Circuit, Gate, gate_types, CNOT
+from pyzx.circuit import Circuit, Gate, gate_types, CNOT, CZ
 from pyzx.linalg import Z2, Mat2
 
 import numpy as np
@@ -54,7 +54,7 @@ class CNOT_tracker(Circuit):
     def count_cnots(self) -> int:
         """Returns the number of CNOT gates in the tracker."""
         return len(
-            [g for g in self.gates if hasattr(g, "name") and g.name in ["CNOT", "CZ"]]
+            [g for g in self.gates if isinstance(g, (CNOT, CZ))]
         )
 
     def cnot_depth(self) -> int:
@@ -62,13 +62,13 @@ class CNOT_tracker(Circuit):
         depth = 1
         previous_gates: list[int] = []
         for g in self.gates:
-            if hasattr(g, "name") and g.name in ["CNOT", "CZ"]:
-                if g.control in previous_gates or g.target in previous_gates:  # type: ignore # Overlapping gate
+            if isinstance(g, (CNOT, CZ)):
+                if g.control in previous_gates or g.target in previous_gates: # Overlapping gate
                     # Start a new CNOT layer
                     previous_gates = []
                     depth += 1
                 else:
-                    previous_gates += [g.control, g.target]  # type: ignore
+                    previous_gates += [g.control, g.target]
         return depth
 
     def row_add(self, q0: int, q1: int) -> None:

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -15,9 +15,9 @@
 # limitations under the License.
 
 
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Iterable
 from pyzx.circuit import Circuit, Gate, gate_types, CNOT
-from pyzx.linalg import Z2, Mat2, MatLike
+from pyzx.linalg import Z2, Mat2
 
 import numpy as np
 
@@ -59,7 +59,7 @@ class CNOT_tracker(Circuit):
     def cnot_depth(self) -> int:
         """Returns the CNOT/CZ depth of the tracked circuit."""
         depth = 1
-        previous_gates: List[int] = []
+        previous_gates: list[int] = []
         for g in self.gates:
             if hasattr(g, "name") and g.name in ["CNOT", "CZ"]:
                 if g.control in previous_gates or g.target in previous_gates:  # type: ignore # Overlapping gate
@@ -75,7 +75,7 @@ class CNOT_tracker(Circuit):
         self.add_gate("CNOT", q0, q1)
         self.matrix.row_add(q0, q1)
 
-    def add_gate(self, gate: Union[Gate,str], *args, **kwargs):
+    def add_gate(self, gate: Gate | str, *args, **kwargs):
         """ Adds a gate to the circuit, if it is a CNOT gate it will track a row addition operation on the matrix. """
         if isinstance(gate, CNOT):
             self.row_add(gate.control, gate.target)
@@ -88,18 +88,18 @@ class CNOT_tracker(Circuit):
         self.matrix.col_add(q0, q1)
 
     @staticmethod
-    def get_metric_names() -> List[str]:
+    def get_metric_names() -> list[str]:
         """Metric names for the CNOT tracker."""
         return ["n_cnots", "depth"]
 
-    def gather_metrics(self) -> Dict[str, int]:
+    def gather_metrics(self) -> dict[str, int]:
         """Gather metrics for the CNOT tracker."""
         metrics = {}
         metrics["n_cnots"] = self.count_cnots()
         metrics["depth"] = self.cnot_depth()
         return metrics
 
-    def prepend_gate(self, gate: Union[Gate, str], *args, **kwargs):
+    def prepend_gate(self, gate: Gate | str, *args, **kwargs):
         """Adds a gate to the circuit. ``gate`` can either be
         an instance of a :class:`Gate`, or it can be the name of a gate,
         in which case additional arguments should be given.
@@ -165,9 +165,9 @@ class Parity:
     """
     A set of qubits XORed together.
     """
-    parity: List[bool]
+    parity: list[bool]
 
-    def __init__(self, par: Union[str, int, Iterable[Any]], n_qubits: Optional[int] = None):
+    def __init__(self, par: str | int | Iterable[Any], n_qubits: int | None = None):
         """
         Creates and returns a set of qubits XORed together.
 
@@ -191,7 +191,7 @@ class Parity:
         """Returns the total number of qubits."""
         return len(self.parity)
     
-    def to_mat2_row(self) -> List[Z2]:
+    def to_mat2_row(self) -> list[Z2]:
         """Returns an array of 1s and 0s based off the internal parity array."""
         return [1 if b else 0 for b in self.parity]
 

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -54,7 +54,7 @@ class CNOT_tracker(Circuit):
     def count_cnots(self) -> int:
         """Returns the number of CNOT gates in the tracker."""
         return len(
-            [g for g in self.gates if isinstance(g, (CNOT, CZ))]
+            [g for g in self.gates if type(g) in (CNOT, CZ)] # don't use isinstance here -- CZ is subclassed
         )
 
     def cnot_depth(self) -> int:

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-from typing import Any, Iterable
+from typing import Any, Iterable, Iterator
 from pyzx.circuit import Circuit, Gate, gate_types, CNOT
 from pyzx.linalg import Z2, Mat2
 
@@ -36,7 +36,7 @@ class CNOT_tracker(Circuit):
     col_perm: np.ndarray
     """The column permutation of the qubit parity matrix."""
 
-    def __init__(self, n_qubits: int, **kwargs):
+    def __init__(self, n_qubits: int, **kwargs: Any) -> None:
         """
         Creates and returns a circuit-like object.
 
@@ -70,19 +70,19 @@ class CNOT_tracker(Circuit):
                     previous_gates += [g.control, g.target]  # type: ignore
         return depth
 
-    def row_add(self, q0: int, q1: int):
+    def row_add(self, q0: int, q1: int) -> None:
         """Track a row addition operation on the matrix."""
         self.add_gate("CNOT", q0, q1)
         self.matrix.row_add(q0, q1)
 
-    def add_gate(self, gate: Gate | str, *args, **kwargs):
+    def add_gate(self, gate: Gate | str, *args: Any, **kwargs: Any) -> None:
         """ Adds a gate to the circuit, if it is a CNOT gate it will track a row addition operation on the matrix. """
         if isinstance(gate, CNOT):
             self.row_add(gate.control, gate.target)
         else:
             super().add_gate(gate, *args, **kwargs)
 
-    def col_add(self, q0: int, q1: int):
+    def col_add(self, q0: int, q1: int) -> None:
         """Track a column addition operation on the matrix."""
         self.prepend_gate("CNOT", q1, q0)
         self.matrix.col_add(q0, q1)
@@ -99,7 +99,7 @@ class CNOT_tracker(Circuit):
         metrics["depth"] = self.cnot_depth()
         return metrics
 
-    def prepend_gate(self, gate: Gate | str, *args, **kwargs):
+    def prepend_gate(self, gate: Gate | str, *args: Any, **kwargs: Any) -> None:
         """Adds a gate to the circuit. ``gate`` can either be
         an instance of a :class:`Gate`, or it can be the name of a gate,
         in which case additional arguments should be given.
@@ -139,11 +139,11 @@ class CNOT_tracker(Circuit):
         new_circuit.update_matrix()
         return new_circuit
 
-    def update_matrix(self):
+    def update_matrix(self) -> None:
         """Rebuilds the parity matrix from the gates in the circuit."""
         self.matrix = Mat2.id(self.n_qubits)
         for gate in self.gates:
-            if hasattr(gate, "name") and gate.name == "CNOT":
+            if isinstance(gate, CNOT):
                 self.matrix.row_add(gate.control, gate.target)
             else:
                 print(
@@ -195,31 +195,31 @@ class Parity:
         """Returns an array of 1s and 0s based off the internal parity array."""
         return [1 if b else 0 for b in self.parity]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns a string of 1s and 0s based off the internal parity array."""
         return "".join(["1" if p else "0" for p in self.parity])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Returns a string representation of the parity."""
         return "Parity(" + str(self) + ")"
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Returns the length of the parity."""
         return len(self.parity)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[bool]:
         """Makes the parity iterable."""
         return iter(self.parity)
 
-    def __getitem__(self, i):
+    def __getitem__(self, i: int) -> bool:
         """Returns the item at index i in the parity."""
         return self.parity[i]
 
-    def __set_item__(self, i, v):
+    def __setitem__(self, i: int, v: bool) -> None:
         """Sets the item at index i to the value given by v in the parity."""
         self.parity[i] = v
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         """Returns true if other is equal to the parity."""
         if isinstance(other, Parity):
             return self.parity == other.parity
@@ -227,6 +227,6 @@ class Parity:
             return str(self) == other
         return False
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Returns a hash of the parity."""
         return hash(str(self))

--- a/pyzx/routing/parity_maps.py
+++ b/pyzx/routing/parity_maps.py
@@ -15,7 +15,8 @@
 # limitations under the License.
 
 
-from typing import Any, Iterable, Iterator
+from collections.abc import Iterable, Iterator
+from typing import Any
 from pyzx.circuit import Circuit, Gate, gate_types, CNOT
 from pyzx.linalg import Z2, Mat2
 

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -21,14 +21,14 @@ from typing import Any, Protocol, Union
 from enum import Enum
 
 
-from pyzx.circuit import Circuit, ZPhase, XPhase, CNOT
+from pyzx.circuit import Circuit, ZPhase, XPhase, CNOT, CZ
 from pyzx.graph.graph_s import GraphS
 from pyzx.linalg import Mat2, MatLike
-from pyzx.routing.parity_maps import CNOT_tracker, Parity
-from pyzx.routing.cnot_mapper import sequential_gauss, ElimMode, gauss
-from pyzx.routing.steiner import steiner_reduce_column
-from pyzx.routing.architecture import create_architecture, FULLY_CONNECTED, Architecture
 from pyzx.utils import EdgeType, FractionLike, maxelements
+from .architecture import create_architecture, FULLY_CONNECTED, Architecture
+from .cnot_mapper import sequential_gauss, ElimMode, gauss
+from .parity_maps import CNOT_tracker, Parity
+from .steiner import steiner_reduce_column
 
 
 class RoutingMethod(Enum):
@@ -817,10 +817,8 @@ class PhasePoly:
             for gate in c.gates:
                 # CNOTs have been mapped already, do not need to be adjusted!
                 circuit.add_gate(gate)
-                try:
-                    current_parities.row_add(gate.control, gate.target)  # type: ignore
-                except AttributeError:
-                    pass
+                if isinstance(gate, (CNOT, CZ)):
+                    current_parities.row_add(gate.control, gate.target)
             # Place the rotations at each parity
             for target, p in enumerate(current_parities.data):
                 parity = Parity(p)

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -21,14 +21,14 @@ from typing import Any, Protocol, Union
 from enum import Enum
 
 
-from ..circuit import Circuit, ZPhase, XPhase, CNOT
-from ..graph.graph_s import GraphS
-from ..linalg import Mat2, MatLike
-from ..routing.parity_maps import CNOT_tracker, Parity
-from ..routing.cnot_mapper import sequential_gauss, ElimMode, gauss
-from ..routing.steiner import steiner_reduce_column
-from ..routing.architecture import create_architecture, FULLY_CONNECTED, Architecture
-from ..utils import EdgeType, FractionLike, maxelements
+from pyzx.circuit import Circuit, ZPhase, XPhase, CNOT
+from pyzx.graph.graph_s import GraphS
+from pyzx.linalg import Mat2, MatLike
+from pyzx.routing.parity_maps import CNOT_tracker, Parity
+from pyzx.routing.cnot_mapper import sequential_gauss, ElimMode, gauss
+from pyzx.routing.steiner import steiner_reduce_column
+from pyzx.routing.architecture import create_architecture, FULLY_CONNECTED, Architecture
+from pyzx.utils import EdgeType, FractionLike, maxelements
 
 
 class RoutingMethod(Enum):

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -1,4 +1,4 @@
-# PyZX - Python library for quantum circuit rewriting 
+# PyZX - Python library for quantum circuit rewriting
 #        and optimization using the ZX-calculus
 # Copyright (C) 2018 - Aleks Kissinger and John van de Wetering
 
@@ -16,17 +16,17 @@
 
 import numpy as np
 from fractions import Fraction
-from typing import Callable, Dict, List, Set, Tuple, Union, Optional, Any
+from typing import Any, Callable, Union
 from enum import Enum
 
-from ..circuit import Circuit, ZPhase, HAD, XPhase, CNOT
+from ..circuit import Circuit, ZPhase, XPhase, CNOT
 from ..graph.graph import Graph
 from ..linalg import Mat2, MatLike
 from ..routing.parity_maps import CNOT_tracker, Parity
 from ..routing.cnot_mapper import sequential_gauss, ElimMode, gauss
 from ..routing.steiner import steiner_reduce_column
 from ..routing.architecture import create_architecture, FULLY_CONNECTED, Architecture
-from ..utils import make_into_list, maxelements
+from ..utils import maxelements
 
 
 class RoutingMethod(Enum):
@@ -82,7 +82,7 @@ class RootHeuristic(Enum):
 
     def to_function(
         self,
-    ) -> Callable[[Architecture, Mat2, List[int], List[int], int, int, Any], List[int]]:
+    ) -> Callable[[Architecture, Mat2, list[int], list[int], int, int, Any], list[int]]:
         """
         Looks at the RootHeuristic type and returns the relevant root heuristic
         """
@@ -121,7 +121,7 @@ class SplitHeuristic(Enum):
 
     def to_function(
         self,
-    ) -> Callable[[Architecture, Mat2, List[int], List[int], Any], List[int]]:
+    ) -> Callable[[Architecture, Mat2, list[int], list[int], Any], list[int]]:
         """
         Looks at the SplitHeuristic type and returns the relevant split heuristic
         """
@@ -223,7 +223,7 @@ def exhaustive_root_heuristic(
     architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
 ):
     """
-    Exhastively applies the Steiner reduction with all the given qubits as roots for a specific column in the matrix and returns the shortest 
+    Exhastively applies the Steiner reduction with all the given qubits as roots for a specific column in the matrix and returns the shortest
     reduction sequence.
 
     :param architecture: The quantum architecture to be used
@@ -259,7 +259,7 @@ def arity_root_heuristic(
     architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
 ):
     """
-    Filters qubits by highest arity and randomly selects one as a root for a specific column in the matrix and returns the 
+    Filters qubits by highest arity and randomly selects one as a root for a specific column in the matrix and returns the
     reduction sequence.
 
     :param architecture: The quantum architecture to be used
@@ -360,8 +360,8 @@ def calculate_reward(architecture, matrix, cols_to_use, root):
 def random_split_heuristic(
     architecture: Architecture,
     matrix: Mat2,
-    cols_to_use: List[int],
-    qubits: List[int],
+    cols_to_use: list[int],
+    qubits: list[int],
     **kwargs,
 ):
     """
@@ -424,8 +424,8 @@ class PhasePoly:
 
     def __init__(
         self,
-        zphase_dict: Dict[Parity, Fraction],
-        out_parities: List[Parity],
+        zphase_dict: dict[Parity, Fraction],
+        out_parities: list[Parity],
     ):
         """
         Creates and returns a phase polynomial object.
@@ -445,7 +445,7 @@ class PhasePoly:
         final_qubit_placement=None,
     ):
         """
-        Takes a circuit and tracks how qubit parities evolve as gates are applied, 
+        Takes a circuit and tracks how qubit parities evolve as gates are applied,
         accumulates Z-phase rotations then builds a compact PhasePoly representing the circuit's phase structure
 
         :param circuit: The circuit to be used
@@ -631,7 +631,7 @@ class PhasePoly:
             current = choice
         return new_partitions
 
-    def _place_parities(self, parities: Union[Mat2, MatLike]) -> List[int]:
+    def _place_parities(self, parities: Union[Mat2, MatLike]) -> list[int]:
         """
         Assigns parities to qubits
 
@@ -709,12 +709,12 @@ class PhasePoly:
         return self._dfs(new_nodes, graph, inv_vs_dict, partitions)
 
     @staticmethod
-    def _independent(partition: List[Parity]) -> bool:
+    def _independent(partition: list[Parity]) -> bool:
         """
         Checks if a partition is independent
 
         :param partition: The list of parities to check
-        :return: True if partition is independent 
+        :return: True if partition is independent
         """
         return inverse_hack(partition2mat2(partition)) is not None
 
@@ -808,7 +808,7 @@ class PhasePoly:
         return circuit, perms[0], perms[-1]
 
     def gray_synth(
-        self, mode: ElimMode, architecture: Optional[Architecture], **kwargs
+        self, mode: ElimMode, architecture: Architecture | None, **kwargs
     ):
         """
         Using gray synthesis method, builds a quantum circuit by reducing a parity matrix
@@ -1071,9 +1071,9 @@ class PhasePoly:
         neighbour_path=False,
         tie_break=False,
         **kwargs,
-    ) -> Tuple[Circuit, Any, Any]:
+    ) -> tuple[Circuit, Any, Any]:
         """
-        Builds CNOT circuit  to implement a set of parity transformations using recursive 
+        Builds CNOT circuit  to implement a set of parity transformations using recursive
         Gaussian elimination
 
         :param mode: Elimination mode, controls Gaussian elimination strategy
@@ -1107,14 +1107,14 @@ class PhasePoly:
             list(range(len(parities_to_reach))),
             parities_to_reach,
         )
-        self.prev_rows: List[int] = []
+        self.prev_rows: list[int] = []
 
         def place_cnot(control, target):
             """
             Add CNOT gate from control qubit to target qubit and updates the parity matrix
 
             :param control: The control qubit
-            :param target: The target qubit 
+            :param target: The target qubit
             """
             # Place the CNOT on the circuit
             circuit.add_gate(CNOT(control, target))
@@ -1260,8 +1260,8 @@ class PhasePoly:
         self,
         parity_matrix: Mat2,
         circuit: Circuit,
-        columns: List[int],
-        parities_to_reach: List[Parity],
+        columns: list[int],
+        parities_to_reach: list[Parity],
     ):
         """
         Check if any of the columns are finished (are phase gadgets over a single qubit)
@@ -1342,7 +1342,7 @@ class PhasePoly:
             circuit.add_gate(cnot)
 
 
-def inverse_hack(matrix: Mat2) -> Optional[Tuple[Mat2, Mat2]]:
+def inverse_hack(matrix: Mat2) -> tuple[Mat2, Mat2] | None:
     """
     Compute the inverse of a binary matrix (over GF(2)), if matrix is not square it is extened
 
@@ -1374,7 +1374,7 @@ def inverse_hack(matrix: Mat2) -> Optional[Tuple[Mat2, Mat2]]:
         return matrix, inv
 
 
-def partition2mat2(partition: List[Parity]) -> Mat2:
+def partition2mat2(partition: list[Parity]) -> Mat2:
     """
     Convert a list of Parity objects into a Mat2 binary matrix.
 
@@ -1384,7 +1384,7 @@ def partition2mat2(partition: List[Parity]) -> Mat2:
     return Mat2([parity.to_mat2_row() for parity in partition])
 
 
-def mat22partition(m: Mat2) -> List[Parity]:
+def mat22partition(m: Mat2) -> list[Parity]:
     """
     Convert a Mat2 binary matrix into a list of Parity objects.
 

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -14,19 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Mapping
+
 import numpy as np
-from fractions import Fraction
-from typing import Any, Callable, Union
+from typing import Any, Protocol, Union
 from enum import Enum
 
+
 from ..circuit import Circuit, ZPhase, XPhase, CNOT
-from ..graph.graph import Graph
+from ..graph.graph_s import GraphS
 from ..linalg import Mat2, MatLike
 from ..routing.parity_maps import CNOT_tracker, Parity
 from ..routing.cnot_mapper import sequential_gauss, ElimMode, gauss
 from ..routing.steiner import steiner_reduce_column
 from ..routing.architecture import create_architecture, FULLY_CONNECTED, Architecture
-from ..utils import maxelements
+from ..utils import EdgeType, FractionLike, maxelements
 
 
 class RoutingMethod(Enum):
@@ -53,7 +55,7 @@ class RoutingMethod(Enum):
     Combination of :attr:`.RoutingMethod.GRAY` and :attr:`.RoutingMethod.MEIJER`, keeps the best result of both.
     """
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{self.value}"
 
 
@@ -74,27 +76,39 @@ class RootHeuristic(Enum):
     RECURSIVE = "recursive"
     """Use an already-chosen root in a recursive call."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Converts RootHeuristic into a string
         """
         return f"{self.value}"
+    
+    
+    class RootHeuristicProtocol(Protocol):
+        def __call__(
+            self,
+            architecture: Architecture,
+            matrix: Mat2,
+            cols_to_use: list[int],
+            qubits: list[int],
+            column: int,
+            phase_qubit: int,
+            **kwargs: Any
+        ) -> list[tuple[int, int]]:
+            ...
 
-    def to_function(
-        self,
-    ) -> Callable[[Architecture, Mat2, list[int], list[int], int, int, Any], list[int]]:
+    def to_function(self) -> RootHeuristicProtocol:
         """
         Looks at the RootHeuristic type and returns the relevant root heuristic
         """
-        # ignore types due to https://github.com/python/mypy/issues/5876
+        
         if self == RootHeuristic.RANDOM:
-            return random_root_heuristic  # type: ignore
+            return random_root_heuristic
         elif self == RootHeuristic.EXHAUSTIVE:
-            return exhaustive_root_heuristic  # type: ignore
+            return exhaustive_root_heuristic
         elif self == RootHeuristic.ARITY:
-            return arity_root_heuristic  # type: ignore
+            return arity_root_heuristic
         elif self == RootHeuristic.RECURSIVE:
-            return rec_root_heuristic  # type: ignore
+            return rec_root_heuristic
         else:
             raise KeyError(f"The root heuristic '{self}' is not implemented")
 
@@ -113,24 +127,35 @@ class SplitHeuristic(Enum):
     COUNT = "count"
     """Split the circuit on all the candidate nodes."""
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Converts SplitHeuristic into a string
         """
         return f"{self.value}"
+    
+    class SplitHeuristicProtocol(Protocol):
+        def __call__(
+            self,
+            architecture: Architecture,
+            matrix: Mat2,
+            cols_to_use: list[int],
+            qubits: list[int],
+            **kwargs: Any
+        ) -> list[int]:
+            ...
 
     def to_function(
         self,
-    ) -> Callable[[Architecture, Mat2, list[int], list[int], Any], list[int]]:
+    ) -> SplitHeuristicProtocol:
         """
         Looks at the SplitHeuristic type and returns the relevant split heuristic
         """
         if self == SplitHeuristic.RANDOM:
-            return random_split_heuristic  # type: ignore
+            return random_split_heuristic
         elif self == SplitHeuristic.ARITY:
-            return arity_split_heuristic  # type: ignore
+            return arity_split_heuristic
         elif self == SplitHeuristic.COUNT:
-            return count_split_heuristic  # type: ignore
+            return count_split_heuristic
         else:
             raise KeyError(f"The split heuristic '{self}' is not implemented")
 
@@ -142,7 +167,7 @@ def route_phase_poly(
     mode: ElimMode = ElimMode.STEINER_MODE,
     root_heuristic: RootHeuristic = RootHeuristic.RECURSIVE,
     split_heuristic: SplitHeuristic = SplitHeuristic.COUNT,
-    **kwargs,
+    **kwargs: Any,
 ) -> Circuit:
     """
     Compile a circuit to an architecture with restricted connectivity.
@@ -191,8 +216,8 @@ def route_phase_poly(
 
 
 def random_root_heuristic(
-    architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
-):
+    architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], column: int, phase_qubit: int, **kwargs: Any
+) -> list[tuple[int, int]]:
     """
     Randomly chooses a root from the given qubits and creates a steiner reduction for a specific column in the matrix
 
@@ -220,8 +245,8 @@ def random_root_heuristic(
 
 
 def exhaustive_root_heuristic(
-    architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
-):
+    architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], column: int, phase_qubit: int | None, **kwargs: Any
+) -> list[tuple[int, int]]:
     """
     Exhastively applies the Steiner reduction with all the given qubits as roots for a specific column in the matrix and returns the shortest
     reduction sequence.
@@ -252,12 +277,12 @@ def exhaustive_root_heuristic(
         )
         if cnots is None or len(possible_cnots) < len(cnots):
             cnots = possible_cnots
-    return cnots
+    return cnots or []
 
 
 def arity_root_heuristic(
-    architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
-):
+    architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], column: int, phase_qubit: int | None, **kwargs: Any
+) -> list[tuple[int, int]]:
     """
     Filters qubits by highest arity and randomly selects one as a root for a specific column in the matrix and returns the
     reduction sequence.
@@ -271,15 +296,15 @@ def arity_root_heuristic(
     :param **kwargs: Additional arguments passed
     :return: The sequence of row operations applied
     """
-    iterator = (
-        (qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits
-    )
-    q, a = next(iterator)
+
     best_qubits = []
-    best_arity = a
-    while a == best_arity:
+    best_arity = None
+    for q, a in [(qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits]:
         best_qubits.append(q)
-        q, a = next(iterator, (None, best_arity - 1))
+        if best_arity is None:
+            best_arity = a
+        elif a != best_arity:
+            break
     root = np.random.choice(best_qubits)
     return list(
         steiner_reduce_column(
@@ -295,8 +320,8 @@ def arity_root_heuristic(
 
 
 def rec_root_heuristic(
-    architecture, matrix, cols_to_use, qubits, column, phase_qubit, **kwargs
-):
+    architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], column: int, phase_qubit: int, **kwargs: Any
+) -> list[tuple[int, int]]:
     """
     Uses the phase_qubit as a root for a specific column in the matrix and returns the reduction sequence.
 
@@ -323,7 +348,7 @@ def rec_root_heuristic(
     )
 
 
-def calculate_reward(architecture, matrix, cols_to_use, root):
+def calculate_reward(architecture: Architecture, matrix: Mat2, cols_to_use: list[int], root: int) -> float:
     """
     Runs Steiner reduction over multiple columns and sums up the total number of CNOT operations, outputting a reward score
 
@@ -362,8 +387,8 @@ def random_split_heuristic(
     matrix: Mat2,
     cols_to_use: list[int],
     qubits: list[int],
-    **kwargs,
-):
+    **kwargs: Any,
+) -> list[int]:
     """
     Returns a random split of qubits
 
@@ -378,7 +403,7 @@ def random_split_heuristic(
     return [np.random.choice(qubits)]
 
 
-def arity_split_heuristic(architecture, matrix, cols_to_use, qubits, **kwargs):
+def arity_split_heuristic(architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], **kwargs: Any) -> list[int]:
     """
     Returns a split of qubits with the highest arity score
 
@@ -390,19 +415,19 @@ def arity_split_heuristic(architecture, matrix, cols_to_use, qubits, **kwargs):
 
     :return: A split from the given qubits with the highest arity score
     """
-    iterator = (
-        (qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits
-    )
-    q, a = next(iterator)
-    best_qubits = []
-    best_arity = a
-    while a == best_arity:
+
+    best_qubits: list[int] = []
+    best_arity = None
+    for q, a in [(qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits]:
         best_qubits.append(q)
-        q, a = next(iterator, (None, best_arity - 1))
+        if best_arity is None:
+            best_arity = a
+        elif a != best_arity:
+            break
     return best_qubits
 
 
-def count_split_heuristic(architecture, matrix, cols_to_use, qubits, **kwargs):
+def count_split_heuristic(architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], **kwargs: Any) -> list[int]:
     """
     Returns a split of qubits with the highest arity score
 
@@ -424,7 +449,7 @@ class PhasePoly:
 
     def __init__(
         self,
-        zphase_dict: dict[Parity, Fraction],
+        zphase_dict: Mapping[Parity, FractionLike],
         out_parities: list[Parity],
     ):
         """
@@ -433,17 +458,17 @@ class PhasePoly:
         :param zphase_dict: A dictionary of parity objects and phase factors
         :param out_parities: A list of final parity objects
         """
-        self.zphases = zphase_dict
+        self.zphases = dict(zphase_dict)
         self.out_par = out_parities
         self.n_qubits = out_parities[0].n_qubits()
         self.all_parities = list(zphase_dict.keys())
 
     @staticmethod
     def fromCircuit(
-        circuit,
-        initial_qubit_placement=None,
-        final_qubit_placement=None,
-    ):
+        circuit: Circuit,
+        initial_qubit_placement: list[int] | None = None,
+        final_qubit_placement: list[int] | None = None,
+    ) -> 'PhasePoly':
         """
         Takes a circuit and tracks how qubit parities evolve as gates are applied,
         accumulates Z-phase rotations then builds a compact PhasePoly representing the circuit's phase structure
@@ -453,7 +478,7 @@ class PhasePoly:
         :param final_qubit_placement: Optional list specifying final qubit mapping, default None
         :return: A PhasePoly object representing the circuit's accumulated Z-phase structure
         """
-        zphases = {}
+        zphases: dict[Parity, FractionLike] = {}
         current_parities = mat22partition(Mat2.id(circuit.qubits))
         if initial_qubit_placement is not None:
             current_parities = [
@@ -461,15 +486,16 @@ class PhasePoly:
                 for row in current_parities
             ]
         for gate in circuit.gates:
-            parity = current_parities[gate.target]
-            if gate.name in ["CNOT", "CX"]:
+            if isinstance(gate, CNOT):
                 # Update current_parities
                 control = current_parities[gate.control]
+                parity = current_parities[gate.target]
                 current_parities[gate.target] = Parity(
                     (int(i) + int(j)) % 2 for i, j in zip(control, parity)
                 )
             elif isinstance(gate, ZPhase):
                 # Add the T rotation to the phases
+                parity = current_parities[gate.target]
                 if parity in zphases:
                     zphases[parity] += gate.phase
                 else:
@@ -479,7 +505,7 @@ class PhasePoly:
             else:
                 raise Exception("Gate not supported!", gate.name)
 
-        def clamp(phase):
+        def clamp(phase: FractionLike) -> FractionLike:
             """
             Normalize phase into range [-1, 1]
 
@@ -497,7 +523,7 @@ class PhasePoly:
 
         return PhasePoly(zphases, current_parities)
 
-    def partition(self, skip_output_parities=True, optimize_parity_order=False):
+    def partition(self, skip_output_parities: bool = True, optimize_parity_order: bool = False) -> list[list[Parity]]:
         """
         Uses matroid partitioning algorithm to split the parities into independent partiotions
 
@@ -506,20 +532,20 @@ class PhasePoly:
         :return: List of ordered parity partitions
         """
         # Matroid partitioning based on wikipedia: https://en.wikipedia.org/wiki/Matroid_partitioning
-        def add_edge(graph, vs_dict, node1, node2):
+        def add_edge(graph: GraphS, vs_dict: dict[int, Parity | list[Parity]], node1: Parity | list[Parity], node2: Parity | list[Parity]) -> None:
             v1 = [k for k, v in vs_dict.items() if v == node1][0]
             v2 = [k for k, v in vs_dict.items() if v == node2][0]
             graph.nedges += 1
-            graph.graph[v1][v2] = 1
+            graph.graph[v1][v2] = EdgeType.SIMPLE
 
-        partitions = []
+        partitions: list[list[Parity]] = []
         parities_to_partition = (
             self.all_parities
             if not skip_output_parities
             else [p for p in self.all_parities if p not in self.out_par]
         )
         for parity in parities_to_partition:
-            graph = Graph()
+            graph = GraphS()
             # Add current parity to the graph
             # Add each partition to the graph
             # Add each parity in the partition to the graph
@@ -547,24 +573,22 @@ class PhasePoly:
                                 if self._independent(new_partition):
                                     add_edge(graph, vs_dict, p2, p)
             # Find a path from the parity to a partition
-            path = self._dfs([(parity, [parity])], graph, vs_dict, partitions)
-            if path != []:
+            found_partition, path = self._dfs([(parity, [parity])], graph, vs_dict, partitions)
+            if found_partition != []:
                 # Apply those changes if such a path exists
                 # Remember which partition to add the final element to
-                p_idx = partitions.index(
-                    path[-1]
-                )  # Last element in the path is always a partition
+                p_idx = partitions.index(found_partition)
                 for p1, p2 in zip(path[:-1], path[1:]):
                     # Replace p2 with p1 in p1's partition
                     for partition in partitions:
                         if p1 in partition:
-                            partition.pop(p1)
+                            partition.remove(p1)
                             partition.append(p2)
-                partitions[p_idx].append(path[-2])
+                partitions[p_idx].append(path[-1])
             else:
                 # Make a new partition if no such path exists.
                 partitions.append([parity])
-        ordered_partitions = []
+        ordered_partitions: list[list[Parity]] = []
         for partition in partitions:
             # Add identity parities to the partition if the set is not full yet.
             matrix = partition2mat2(partition)
@@ -575,13 +599,13 @@ class PhasePoly:
                 # Find a more optimal ordering of the parities
                 parity_placement = self._place_parities(matrix)
             else:
-                parity_placement = np.arange(self.n_qubits)
+                parity_placement = np.arange(self.n_qubits).tolist()
             partition = mat22partition(matrix)
             new_partition = [partition[i] for i in parity_placement]
             ordered_partitions.append(new_partition)
         return ordered_partitions
 
-    def _order_partitions(self, partitions):
+    def _order_partitions(self, partitions: list[list[Parity]]) -> list[list[Parity]]:
         """
         Reorders partitions based on a cost metric
 
@@ -593,7 +617,7 @@ class PhasePoly:
             i: partition2mat2(partition) for i, partition in enumerate(partitions)
         }
 
-        def cost_func(p1, p2):
+        def cost_func(p1: Mat2, p2: Mat2) -> int:
             """
             Calculates the cost to go from one partition to another
 
@@ -601,9 +625,9 @@ class PhasePoly:
             :param p2: Second partition
             :return: Cost to go from p1 to p2
             """
-            inv = inverse_hack(p1)
-            if inv is not None:
-                _, inv = inv
+            mats = inverse_hack(p1)
+            if mats is not None:
+                _, inv = mats
             else:
                 inv = Mat2.id(p2.rows())
             c = CNOT_tracker(len(partitions[0]))
@@ -618,7 +642,7 @@ class PhasePoly:
         }
         # start at the back
         new_partitions = [partitions[-1]]
-        visited = []
+        visited: list[int] = []
         current = n - 1
         while len(visited) < n - 1:
             # Pick the partition that was not yet visited whose
@@ -631,7 +655,7 @@ class PhasePoly:
             current = choice
         return new_partitions
 
-    def _place_parities(self, parities: Union[Mat2, MatLike]) -> list[int]:
+    def _place_parities(self, parities: Mat2 | MatLike) -> list[int]:
         """
         Assigns parities to qubits
 
@@ -680,20 +704,20 @@ class PhasePoly:
             permutation[i] = skipped_parities.pop()[0]
         return permutation
 
-    def _dfs(self, nodes, graph, inv_vs_dict, partitions):
+    def _dfs(self, nodes: list[tuple[Parity | list[Parity], list[Parity]]], graph: GraphS, inv_vs_dict: dict[int, Parity | list[Parity]], partitions: list[list[Parity]]) -> tuple[list[Parity], list[Parity]]:
         """
-        A depth first search to find the path
+        A depth first search to find the path to a partition
 
         :param nodes: A list of (current_node, current_path) tuples
         :param graph: The graph showcasing the adjacency connections
         :param inv_vs_dict: A reverse lookup
         :param partitions: List of node objects considered as target nodes
-        :return: The path
+        :return: A tuple containing the found partition and the path to it
         """
         # recursive dfs to find the shortest path
         if nodes == []:
-            return []
-        new_nodes = []
+            return [], []
+        new_nodes: list[tuple[Parity | list[Parity], list[Parity]]] = []
         for (node, path) in nodes:
             # For each node2 connected to node
             v = [k for k, v in inv_vs_dict.items() if v == node][0]
@@ -701,10 +725,12 @@ class PhasePoly:
                 # If it's a partition, we found a path
                 next_node = inv_vs_dict[node2]
                 if next_node not in path:  # Avoid loops!
-                    new_path = path + [next_node]
                     if next_node in partitions:
-                        return new_path
+                        assert isinstance(next_node, list) # safe because partitions is a list of lists
+                        return next_node, path
                     else:
+                        assert isinstance(next_node, Parity)
+                        new_path = path + [next_node]
                         new_nodes.append((next_node, new_path))
         return self._dfs(new_nodes, graph, inv_vs_dict, partitions)
 
@@ -727,8 +753,8 @@ class PhasePoly:
         iterative_placement: bool = False,
         parity_permutation: bool = True,
         iterative_initial_placement: bool = False,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> tuple[Circuit, list[int], list[int]]:
         """
         Using Matroid synthesis method, partitions parities, builds transformation matrices, runs sequential Gaussian elimination,
         builds a final circuit, tracks and updates the current parity states.
@@ -808,8 +834,8 @@ class PhasePoly:
         return circuit, perms[0], perms[-1]
 
     def gray_synth(
-        self, mode: ElimMode, architecture: Architecture | None, **kwargs
-    ):
+        self, mode: ElimMode, architecture: Architecture | None, **kwargs: Any
+    ) -> tuple[CNOT_tracker, list[int], list[int]]:
         """
         Using gray synthesis method, builds a quantum circuit by reducing a parity matrix
 
@@ -901,14 +927,14 @@ class PhasePoly:
 
     def rec_gray_synth(
         self,
-        mode,
-        architecture,
+        mode: ElimMode,
+        architecture: Architecture | None,
         root_heuristic: RootHeuristic = RootHeuristic.RECURSIVE,
         split_heuristic: SplitHeuristic = SplitHeuristic.COUNT,
-        full=True,
-        phase_qubit=None,
-        **kwargs,
-    ):
+        full: bool = True,
+        phase_qubit: int | None = None,
+        **kwargs: Any,
+    ) -> tuple[CNOT_tracker, list[int], list[int]]:
         """
         Builds quantum circuit by applying a recursive Gray synthesis strategy
 
@@ -946,8 +972,8 @@ class PhasePoly:
         circuit = CNOT_tracker(architecture.n_qubits)
         # Make a stack - aka use the python stack >^.^<
         def recurse(
-            cols_to_use, qubits_to_use, phase_qubit
-        ):  # Arguments from the original paper, steiner version might only use the first
+            cols_to_use: list[int], qubits_to_use: list[int], phase_qubit: int | None
+        ) -> None:  # Arguments from the original paper, steiner version might only use the first
             # Check for finished columns
             cols_to_use = self._check_columns(
                 matrix, circuit, cols_to_use, parities_to_reach
@@ -1064,13 +1090,13 @@ class PhasePoly:
 
     def Ariannes_synth(
         self,
-        mode,
-        architecture,
-        full=True,
-        zeroes_rec=False,
-        neighbour_path=False,
-        tie_break=False,
-        **kwargs,
+        mode: ElimMode,
+        architecture: Architecture | None,
+        full: bool = True,
+        zeroes_rec: bool = False,
+        neighbour_path: bool = False,
+        tie_break: bool = False,
+        **kwargs: Any,
     ) -> tuple[Circuit, Any, Any]:
         """
         Builds CNOT circuit  to implement a set of parity transformations using recursive
@@ -1109,7 +1135,7 @@ class PhasePoly:
         )
         self.prev_rows: list[int] = []
 
-        def place_cnot(control, target):
+        def place_cnot(control: int, target: int) -> None:
             """
             Add CNOT gate from control qubit to target qubit and updates the parity matrix
 
@@ -1121,7 +1147,7 @@ class PhasePoly:
             # Adjust the matrix accordingly - reversed elementary row operations
             parity_matrix.row_add(target, control)
 
-        def base_recurse(cols_to_use, qubits_to_use):
+        def base_recurse(cols_to_use: list[int], qubits_to_use: list[int]) -> None:
             """
             Recursively synthesize parity columns by choosing a pivot qubit and splitting columns.
 
@@ -1175,7 +1201,7 @@ class PhasePoly:
                     cols1, [q for q in qubits_to_use if q != chosen_row], chosen_row
                 )
 
-        def one_recurse(cols_to_use, qubits_to_use, qubit):
+        def one_recurse(cols_to_use: list[int], qubits_to_use: list[int], qubit: int) -> None:
             """
             Recursively synthesize parity columns where the pivot qubit row has 1s.
 
@@ -1262,7 +1288,7 @@ class PhasePoly:
         circuit: Circuit,
         columns: list[int],
         parities_to_reach: list[Parity],
-    ):
+    ) -> list[int]:
         """
         Check if any of the columns are finished (are phase gadgets over a single qubit)
         and add the corresponding phase gates to the circuit.
@@ -1278,7 +1304,7 @@ class PhasePoly:
                 columns.remove(col)
         return columns
 
-    def _tie_break(self, qubits, indices):
+    def _tie_break(self, qubits: list[int], indices: list[int]) -> int:
         """
         Tie-breaking strategy to select a qubit index among multiple candidates.
 
@@ -1291,7 +1317,7 @@ class PhasePoly:
                 return qubits[i] if not qubits[i] else qubits[i]
         return qubits[indices[0]] if not qubits[indices[0]] else qubits[indices[0]]
 
-    def _update_prev_rows(self, qubits):
+    def _update_prev_rows(self, qubits: list[int]) -> None:
         """
         Update the internal record of previously used qubits.
 
@@ -1314,7 +1340,7 @@ class PhasePoly:
             if index != len(self.prev_rows):
                 self.prev_rows = self.prev_rows[index:] + qubits
             else:
-                self.prev_rows = [qubits]
+                self.prev_rows = qubits
         # print(self.prev_rows)
 
     def _obtain_final_parities(
@@ -1322,8 +1348,8 @@ class PhasePoly:
         circuit: CNOT_tracker,
         architecture: Architecture,
         mode: ElimMode,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         """
         Calculate the final parity that needs to be added from the circuit and self.out_par
         """

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -15,18 +15,18 @@
 # limitations under the License.
 
 from collections.abc import Mapping
+from enum import Enum
+from typing import Any, Protocol
 
 import numpy as np
-from typing import Any, Protocol, Union
-from enum import Enum
 
-
-from pyzx.circuit import Circuit, ZPhase, XPhase, CNOT, CZ
+from pyzx.circuit import CNOT, CZ, Circuit, XPhase, ZPhase
 from pyzx.graph.graph_s import GraphS
 from pyzx.linalg import Mat2, MatLike
 from pyzx.utils import EdgeType, FractionLike, maxelements
-from .architecture import create_architecture, FULLY_CONNECTED, Architecture
-from .cnot_mapper import sequential_gauss, ElimMode, gauss
+
+from .architecture import FULLY_CONNECTED, Architecture, create_architecture
+from .cnot_mapper import ElimMode, gauss, sequential_gauss
 from .parity_maps import CNOT_tracker, Parity
 from .steiner import steiner_reduce_column
 
@@ -161,7 +161,7 @@ class SplitHeuristic(Enum):
 
 
 def route_phase_poly(
-    circuit: Union[Circuit, "PhasePoly"],
+    circuit: 'Circuit | PhasePoly',
     architecture: Architecture,
     method: RoutingMethod = RoutingMethod.GRAY_MEIJER,
     mode: ElimMode = ElimMode.STEINER_MODE,
@@ -300,12 +300,13 @@ def arity_root_heuristic(
     best_qubits = []
     best_arity = None
     for q, a in [(qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits]:
-        best_qubits.append(q)
         if best_arity is None:
             best_arity = a
         elif a != best_arity:
             break
-    root = np.random.choice(best_qubits)
+        best_qubits.append(q)
+    
+    root = int(np.random.choice(best_qubits))
     return list(
         steiner_reduce_column(
             architecture,
@@ -400,7 +401,7 @@ def random_split_heuristic(
 
     :return: A random split from the given qubits
     """
-    return [np.random.choice(qubits)]
+    return [int(np.random.choice(qubits))]
 
 
 def arity_split_heuristic(architecture: Architecture, matrix: Mat2, cols_to_use: list[int], qubits: list[int], **kwargs: Any) -> list[int]:
@@ -419,11 +420,11 @@ def arity_split_heuristic(architecture: Architecture, matrix: Mat2, cols_to_use:
     best_qubits: list[int] = []
     best_arity = None
     for q, a in [(qubit, arity) for qubit, arity in architecture.arities() if qubit in qubits]:
-        best_qubits.append(q)
         if best_arity is None:
             best_arity = a
         elif a != best_arity:
             break
+        best_qubits.append(q)
     return best_qubits
 
 
@@ -574,7 +575,7 @@ class PhasePoly:
                                     add_edge(graph, vs_dict, p2, p)
             # Find a path from the parity to a partition
             found_partition, path = self._dfs([(parity, [parity])], graph, vs_dict, partitions)
-            if found_partition != []:
+            if found_partition:
                 # Apply those changes if such a path exists
                 # Remember which partition to add the final element to
                 p_idx = partitions.index(found_partition)
@@ -675,7 +676,7 @@ class PhasePoly:
         skipped_idxs = []
         deliberating = []
         for i in range(self.n_qubits):
-            if permutation[i] is None:
+            if permutation[i] is None: # TODO: this may be a mistake -- always evaluates to false
                 # Find the best parity in skipped_parities to place there
                 pivoted_parities = [(j, p) for j, p in skipped_parities if p[i] == 1]
                 if pivoted_parities:
@@ -1338,7 +1339,7 @@ class PhasePoly:
             if index != len(self.prev_rows):
                 self.prev_rows = self.prev_rows[index:] + qubits
             else:
-                self.prev_rows = qubits
+                self.prev_rows = list(qubits)
         # print(self.prev_rows)
 
     def _obtain_final_parities(

--- a/pyzx/routing/phase_poly.py
+++ b/pyzx/routing/phase_poly.py
@@ -525,7 +525,7 @@ class PhasePoly:
 
     def partition(self, skip_output_parities: bool = True, optimize_parity_order: bool = False) -> list[list[Parity]]:
         """
-        Uses matroid partitioning algorithm to split the parities into independent partiotions
+        Uses matroid partitioning algorithm to split the parities into independent partitions
 
         :param skip_output_parities: If True, ignore the out_par parities, default True
         :param optimize_parity_order: If True, reorder parities for more optimal placement, default False

--- a/pyzx/routing/steiner.py
+++ b/pyzx/routing/steiner.py
@@ -18,6 +18,7 @@ from collections.abc import Iterator
 from typing import Any
 
 from pyzx.linalg import Mat2
+
 from .architecture import Architecture
 from .parity_maps import CNOT_tracker
 
@@ -52,9 +53,9 @@ def steiner_gauss(
         matrix.row_add(c0, c1)
         if debug:
             print("Reducing", c0, c1)
-        if x != None:
+        if x is not None:
             x.row_add(c0, c1)
-        if y != None:
+        if y is not None:
             y.col_add(c1, c0)
 
     def steiner_reduce(col: int, root: int, nodes: list[int], upper: bool) -> None:

--- a/pyzx/routing/steiner.py
+++ b/pyzx/routing/steiner.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple, Optional
-
 from pyzx.routing.parity_maps import CNOT_tracker
 
 from .architecture import Architecture
@@ -28,8 +26,8 @@ def steiner_gauss(
     matrix: Mat2,
     architecture: Architecture,
     full_reduce: bool = False,
-    x: Optional[CNOT_tracker] = None,
-    y: Optional[CNOT_tracker] = None,
+    x: CNOT_tracker | None = None,
+    y: CNOT_tracker | None = None,
 ):
     """
     Performs Gaussian elimination that is constrained by the given architecture
@@ -57,7 +55,7 @@ def steiner_gauss(
         if y != None:
             y.col_add(c1, c0)
 
-    def steiner_reduce(col: int, root: int, nodes: List[int], upper: bool):
+    def steiner_reduce(col: int, root: int, nodes: list[int], upper: bool):
         """
         Uses Steiner tree to reduce matrix columns
 
@@ -167,9 +165,9 @@ def rec_steiner_gauss(
     matrix: Mat2,
     architecture: Architecture,
     full_reduce: bool = False,
-    x: Optional[CNOT_tracker] = None,
-    y: Optional[CNOT_tracker] = None,
-    permutation: Optional[List[int]] = None,
+    x: CNOT_tracker | None = None,
+    y: CNOT_tracker | None = None,
+    permutation: list[int] | None = None,
     **kwargs,
 ):
     """
@@ -308,10 +306,10 @@ def rec_steiner_gauss(
 
 def steiner_reduce_column(
     architecture: Architecture,
-    col: List[int],
+    col: list[int],
     root: int,
-    nodes: List[int],
-    usable_nodes: List[int],
+    nodes: list[int],
+    usable_nodes: list[int],
     rec_nodes,
     upper: bool,
 ):

--- a/pyzx/routing/steiner.py
+++ b/pyzx/routing/steiner.py
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Iterator
+from collections.abc import Iterator
+from typing import Any
 
-from pyzx.routing.parity_maps import CNOT_tracker
-
+from pyzx.linalg import Mat2
 from .architecture import Architecture
-from ..linalg import Mat2
+from .parity_maps import CNOT_tracker
 
 debug = False
 

--- a/pyzx/routing/steiner.py
+++ b/pyzx/routing/steiner.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any, Iterator
+
 from pyzx.routing.parity_maps import CNOT_tracker
 
 from .architecture import Architecture
@@ -28,7 +30,7 @@ def steiner_gauss(
     full_reduce: bool = False,
     x: CNOT_tracker | None = None,
     y: CNOT_tracker | None = None,
-):
+) -> int:
     """
     Performs Gaussian elimination that is constrained by the given architecture
 
@@ -40,7 +42,7 @@ def steiner_gauss(
     :return: Rank of the given matrix
     """
 
-    def row_add(c0, c1):
+    def row_add(c0: int, c1: int) -> None:
         """
         Adds row c0 to c1 in the main matrix. If debug flag is set it prints what happening.
 
@@ -55,7 +57,7 @@ def steiner_gauss(
         if y != None:
             y.col_add(c1, c0)
 
-    def steiner_reduce(col: int, root: int, nodes: list[int], upper: bool):
+    def steiner_reduce(col: int, root: int, nodes: list[int], upper: bool) -> None:
         """
         Uses Steiner tree to reduce matrix columns
 
@@ -168,8 +170,8 @@ def rec_steiner_gauss(
     x: CNOT_tracker | None = None,
     y: CNOT_tracker | None = None,
     permutation: list[int] | None = None,
-    **kwargs,
-):
+    **kwargs: Any,
+) -> None:
     """
     Performs Gaussian elimination that is constrained bij the given architecture according to https://arxiv.org/pdf/1904.00633.pdf
     Only works on full rank, square matrices.
@@ -186,7 +188,7 @@ def rec_steiner_gauss(
     else:
         matrix.permute_cols(permutation)
 
-    def row_add(c0, c1):
+    def row_add(c0: int, c1: int) -> None:
         """
         Adds row c0 to c1 in the main matrix. If debug flag is set it prints what happening.
 
@@ -201,7 +203,7 @@ def rec_steiner_gauss(
         if y != None:
             y.col_add(c1, c0)
 
-    def steiner_reduce(col, root, nodes, usable_nodes, rec_nodes, upper):
+    def steiner_reduce(col: int, root: int, nodes: list[int], usable_nodes: list[int], rec_nodes: list[int], upper: bool) -> list[int]:
         """
         Uses Steiner tree to reduce matrix columns
 
@@ -226,7 +228,7 @@ def rec_steiner_gauss(
             upper,
         )
         cnot = next(generator, None)
-        tree_nodes = []
+        tree_nodes: list[int] = []
         while cnot is not None:
             if (
                 cnot[0] not in usable_nodes + rec_nodes
@@ -238,7 +240,7 @@ def rec_steiner_gauss(
             cnot = next(generator, None)
         return tree_nodes
 
-    def rec_step(qubit_removal_order):
+    def rec_step(qubit_removal_order: list[int]) -> None:
         """
         Recursive step function to reduce matrix
 
@@ -310,9 +312,9 @@ def steiner_reduce_column(
     root: int,
     nodes: list[int],
     usable_nodes: list[int],
-    rec_nodes,
+    rec_nodes: list[int],
     upper: bool,
-):
+) -> Iterator[tuple[int, int]]:
     """
     Performs Steiner tree reduction to a matrix column under the constraints of some quantum architecture
 
@@ -333,7 +335,7 @@ def steiner_reduce_column(
     if debug:
         print("Step 1: remove zeros")
     if upper:
-        zeros = []
+        zeros: list[tuple[int, int]] = []
         while next_check is not None:
             s0, s1 = next_check
             if col[s0] == 0:  # s1 is a new steiner point or root = 0


### PR DESCRIPTION
Adds type annotations to all functions in the `pyzx.routing` submodule and enables the mypy setting to enforce type annotations in the submodule. Additionall, removes all instances of `#type: ignore` by replacing them with properly type-checked code (with one exception, see below), and modernises the typing syntax.

As in the previous typehint PRs, I did my best to avoid modifying function bodies. However, because of the complex nature of this module, there were several locations where types were inconsistent (including some that seemed like logic bugs) and some code needed updating in order to give type annotations without introducing a plethora of errors. Here's a long list of various comments about the decisions made while annotating the module:

- `Architecture.to_quil_device` seems to be completely broken legacy code—the function body imports `NxDeviceA` from `pyquil.device` and then references `NxDevice`, which seems like a typo. The class `NxDevice` and the module `pyquil.device` have not existed since pyquil v2, which is over 5 years out of date (we are now on v4!). For now, I marked it with a `#type: ignore`, but this function should probably be modernised or completely removed.

- A lot of functions in the module use `**kwargs: Any` to absorb arguments, but this often hides errors, so I would recommend redesigning that. I opted not to change any of those in this PR, but there are many places where the type annotations are a lot less helpful than they could be or type safety is lost because of this. At times (e.g. `Architecture.__init__`), the `**kwargs` parameter is completely unused, and at other times (e.g. `CNOT_tracker.__init__`) the extra arguments are passed into another function, removing all the type safety of the arguments.

- I refactored `FitnessFunction._make_function` to make it easier to type. There's technically a tiny edge case where behaviour could change if `self.metric` is changed between calls to the outputted function (before the function would stay locked to old metric), but this doesn't seem like something that should happen anyway.

- There are various spots in `machine_learning.py` and `phase_poly.py` where null checks were introduced or types were coerced to either lists or numpy arrays, as types were haphazardly mix and matched, or `None` was returned but not handled. In general, all the code that interfaces with numpy was difficult to properly type. Generally, I tried to make the outputs of public-facing functions python lists, and I worried a little less about any internal functions as long as the mappings were consistent.

- `PhasePoly.partition` was an extremely difficult function to decipher because of the way it mixes and matches parities and partitions of parities! I had to refactor the logic within it and its helper functions a little bit in order to separate the two in a way that appeased the type checker, and in doing so I also noticed a couple logic errors (e.g. using `pop` instead of `remove` to remove by value from a list). Because of the high complexity, this is probably the most likely spot that I made an error.

- I replaced references to `Graph` with `GraphS` because the code relied on implementation details. In general, using the `Graph` helper function tends to hurt type safety and opens the codebase up to logic errors which can't be caught statically (e.g. typos in the backend input). I would recommend moving away from that design decision, especially since a lot of the code which instantiates graphs is making assumptions about the implementation anyway.

- A couple of the heuristic functions in `phase_poly.py` were minorly refactored to use for loops instead of iterators, since they were written in an unfriendly way for the type checker (and for human readers).

There were definitely a lot more opinionated changes in this PR than in the previous type-safety PRs, so please feel free to scrutinise the decisions and ask me to change things! In particular, I don't know how this module is used in practice, so if any of the changes I made break things then I can try to solve the typing issues in a different way.